### PR TITLE
Make "set_", "init_", and "clear" methods take a "mut self"

### DIFF
--- a/benchmark/carsales.rs
+++ b/benchmark/carsales.rs
@@ -68,7 +68,7 @@ car_value_impl!(Builder)
 const MAKES : [&'static str, .. 5] = ["Toyota", "GM", "Ford", "Honda", "Tesla"];
 const MODELS : [&'static str, .. 6] = ["Camry", "Prius", "Volt", "Accord", "Leaf", "Model S"];
 
-pub fn random_car(rng : &mut FastRand, car : car::Builder) {
+pub fn random_car(rng : &mut FastRand, mut car : car::Builder) {
     use std::mem::transmute;
 
     car.set_make(MAKES[rng.next_less_than(MAKES.len() as u32) as uint]);
@@ -78,7 +78,7 @@ pub fn random_car(rng : &mut FastRand, car : car::Builder) {
     car.set_seats(2 + rng.next_less_than(6) as u8);
     car.set_doors(2 + rng.next_less_than(3) as u8);
 
-    for wheel in car.init_wheels(4).iter() {
+    for mut wheel in car.init_wheels(4).iter() {
         wheel.set_diameter(25 + rng.next_less_than(15) as u16);
         wheel.set_air_pressure((30.0 + rng.next_double(20.0)) as f32);
         wheel.set_snow_tires(rng.next_less_than(16) == 0);
@@ -87,10 +87,11 @@ pub fn random_car(rng : &mut FastRand, car : car::Builder) {
     car.set_length(170 + rng.next_less_than(150) as u16);
     car.set_width(48 + rng.next_less_than(36) as u16);
     car.set_height(54 + rng.next_less_than(48) as u16);
-    car.set_weight(car.get_length() as u32 * car.get_width() as u32 *
-                   car.get_height() as u32 / 200);
+    let weight = car.get_length() as u32 * car.get_width() as u32 *
+                 car.get_height() as u32 / 200;
+    car.set_weight(weight);
 
-    let engine = car.init_engine();
+    let mut engine = car.init_engine();
     engine.set_horsepower(100 * rng.next_less_than(400) as u16);
     engine.set_cylinders(4 + 2 * rng.next_less_than(3) as u8);
     engine.set_cc(800 + rng.next_less_than(10000));
@@ -98,7 +99,8 @@ pub fn random_car(rng : &mut FastRand, car : car::Builder) {
     engine.set_uses_electric(rng.gen());
 
     car.set_fuel_capacity((10.0 + rng.next_double(30.0)) as f32);
-    car.set_fuel_level(rng.next_double(car.get_fuel_capacity() as f64) as f32);
+    let fuel_level = rng.next_double(car.get_fuel_capacity() as f64) as f32;
+    car.set_fuel_level(fuel_level);
     car.set_has_power_windows(rng.gen());
     car.set_has_power_steering(rng.gen());
     car.set_has_cruise_control(rng.gen());
@@ -106,7 +108,7 @@ pub fn random_car(rng : &mut FastRand, car : car::Builder) {
     car.set_has_nav_system(rng.gen());
 }
 
-pub fn setup_request(rng : &mut FastRand, request : parking_lot::Builder) -> u64 {
+pub fn setup_request(rng : &mut FastRand, mut request : parking_lot::Builder) -> u64 {
     let mut result = 0;
     for car in request.init_cars(rng.next_less_than(200)).iter() {
         random_car(rng, car);
@@ -116,7 +118,7 @@ pub fn setup_request(rng : &mut FastRand, request : parking_lot::Builder) -> u64
     result
 }
 
-pub fn handle_request(request : parking_lot::Reader, response : total_value::Builder) {
+pub fn handle_request(request : parking_lot::Reader, mut response : total_value::Builder) {
     let mut result = 0;
     for car in request.get_cars().iter() {
         result += car.car_value();

--- a/benchmark/catrank.rs
+++ b/benchmark/catrank.rs
@@ -20,14 +20,14 @@ pub struct ScoredResult<'a> {
 
 const URL_PREFIX : &'static str = "http://example.com";
 
-pub fn setup_request(rng : &mut FastRand, request : search_result_list::Builder) -> int {
+pub fn setup_request(rng : &mut FastRand, mut request : search_result_list::Builder) -> int {
     let count = rng.next_less_than(1000);
     let mut good_count : int = 0;
 
     let list = request.init_results(count);
 
     for i in range(0, count) {
-        let result = list.get(i);
+        let mut result = list.get(i);
         result.set_score(1000.0 - i as f64);
         let url_size = rng.next_less_than(100);
 
@@ -68,7 +68,7 @@ pub fn setup_request(rng : &mut FastRand, request : search_result_list::Builder)
 }
 
 pub fn handle_request(request : search_result_list::Reader,
-                      response : search_result_list::Builder) {
+                      mut response : search_result_list::Builder) {
     let mut scored_results : Vec<ScoredResult> = Vec::new();
 
     let results = request.get_results();
@@ -89,7 +89,7 @@ pub fn handle_request(request : search_result_list::Reader,
 
     let list = response.init_results(scored_results.len() as u32);
     for i in range(0, list.size()) {
-        let item = list.get(i);
+        let mut item = list.get(i);
         let result = scored_results[i as uint];
         item.set_score(result.score);
         item.set_url(result.result.get_url());

--- a/benchmark/eval.rs
+++ b/benchmark/eval.rs
@@ -14,7 +14,7 @@ pub type Expectation = i32;
 pub type RequestReader<'a> = expression::Reader<'a>;
 pub type ResponseReader<'a> = evaluation_result::Reader<'a>;
 
-fn make_expression(rng : &mut FastRand, exp : expression::Builder, depth : u32) -> i32 {
+fn make_expression(rng : &mut FastRand, mut exp : expression::Builder, depth : u32) -> i32 {
     exp.set_op(unsafe {
             std::mem::transmute(rng.next_less_than( operation::Modulus as u32 + 1) as u16)});
 
@@ -74,7 +74,7 @@ pub fn setup_request(rng : &mut FastRand, request : expression::Builder) -> i32 
 }
 
 #[inline]
-pub fn handle_request(request : expression::Reader, response : evaluation_result::Builder) {
+pub fn handle_request(request : expression::Reader, mut response : evaluation_result::Builder) {
     response.set_value(evaluate_expression(request));
 }
 

--- a/compiler_tests/test.rs
+++ b/compiler_tests/test.rs
@@ -21,22 +21,22 @@ mod tests {
         // Make the first segment small to force allocation of a second segment.
         let mut message = MallocMessageBuilder::new(*BuilderOptions::new().first_segment_words(50));
 
-        let test_prim_list = message.init_root::<test_prim_list::Builder>();
+        let mut test_prim_list = message.init_root::<test_prim_list::Builder>();
 
-        let uint8_list = test_prim_list.init_uint8_list(100);
+        let mut uint8_list = test_prim_list.init_uint8_list(100);
 
         for i in range(0, uint8_list.size()) {
             uint8_list.set(i, i as u8);
         }
 
-        let uint64_list = test_prim_list.init_uint64_list(20);
+        let mut uint64_list = test_prim_list.init_uint64_list(20);
 
         for i in range(0, uint64_list.size()) {
             uint64_list.set(i, i as u64);
         }
 
         assert_eq!(test_prim_list.has_bool_list(), false);
-        let bool_list = test_prim_list.init_bool_list(65);
+        let mut bool_list = test_prim_list.init_bool_list(65);
         assert_eq!(test_prim_list.has_bool_list(), true);
 
         bool_list.set(0, true);
@@ -54,7 +54,7 @@ mod tests {
         assert!(bool_list.get(64));
 
         assert_eq!(test_prim_list.has_void_list(), false);
-        let void_list = test_prim_list.init_void_list(1025);
+        let mut void_list = test_prim_list.init_void_list(1025);
         assert_eq!(test_prim_list.has_void_list(), true);
         void_list.set(257, ());
 
@@ -98,7 +98,7 @@ mod tests {
 
         let mut message = MallocMessageBuilder::new_default();
 
-        let test_struct_list = message.init_root::<test_struct_list::Builder>();
+        let mut test_struct_list = message.init_root::<test_struct_list::Builder>();
 
         test_struct_list.init_struct_list(4);
         let struct_list = test_struct_list.get_struct_list();
@@ -115,7 +115,7 @@ mod tests {
         use test_capnp::test_blob;
 
         let mut message = MallocMessageBuilder::new_default();
-        let test_blob = message.init_root::<test_blob::Builder>();
+        let mut test_blob = message.init_root::<test_blob::Builder>();
 
         assert_eq!(test_blob.has_text_field(), false);
         test_blob.set_text_field("abcdefghi");
@@ -167,7 +167,7 @@ mod tests {
         // Make the first segment small to force allocation of a second segment.
         let mut message = MallocMessageBuilder::new(*BuilderOptions::new().first_segment_words(5));
 
-        let big_struct = message.init_root::<test_big_struct::Builder>();
+        let mut big_struct = message.init_root::<test_big_struct::Builder>();
 
         big_struct.set_bool_field(false);
         big_struct.set_int8_field(-128);
@@ -175,7 +175,7 @@ mod tests {
         big_struct.set_int32_field(1009);
 
         assert_eq!(big_struct.has_struct_field(), false);
-        let inner = big_struct.init_struct_field();
+        let mut inner = big_struct.init_struct_field();
         assert_eq!(big_struct.has_struct_field(), true);
         inner.set_float64_field(0.1234567);
 
@@ -201,9 +201,9 @@ mod tests {
 
         let mut message = MallocMessageBuilder::new_default();
 
-        let test_complex_list = message.init_root::<test_complex_list::Builder>();
+        let mut test_complex_list = message.init_root::<test_complex_list::Builder>();
 
-        let enum_list = test_complex_list.init_enum_list(100);
+        let mut enum_list = test_complex_list.init_enum_list(100);
 
         for i in range::<u32>(0, 10) {
             enum_list.set(i, an_enum::Qux);
@@ -212,50 +212,50 @@ mod tests {
             enum_list.set(i, an_enum::Bar);
         }
 
-        let text_list = test_complex_list.init_text_list(2);
+        let mut text_list = test_complex_list.init_text_list(2);
         text_list.set(0, "garply");
         text_list.set(1, "foo");
 
-        let data_list = test_complex_list.init_data_list(2);
+        let mut data_list = test_complex_list.init_data_list(2);
         data_list.set(0, [0u8, 1u8, 2u8]);
         data_list.set(1, [255u8, 254u8, 253u8]);
 
-        let prim_list_list = test_complex_list.init_prim_list_list(2);
-        let prim_list = prim_list_list.init(0, 3);
+        let mut prim_list_list = test_complex_list.init_prim_list_list(2);
+        let mut prim_list = prim_list_list.init(0, 3);
         prim_list.set(0, 5);
         prim_list.set(1, 6);
         prim_list.set(2, 7);
         assert_eq!(prim_list.size(), 3);
-        let prim_list = prim_list_list.init(1, 1);
+        let mut prim_list = prim_list_list.init(1, 1);
         prim_list.set(0,-1);
 
-        let prim_list_list_list = test_complex_list.init_prim_list_list_list(2);
-        let prim_list_list = prim_list_list_list.init(0, 2);
-        let prim_list = prim_list_list.init(0, 2);
+        let mut prim_list_list_list = test_complex_list.init_prim_list_list_list(2);
+        let mut prim_list_list = prim_list_list_list.init(0, 2);
+        let mut prim_list = prim_list_list.init(0, 2);
         prim_list.set(0, 0);
         prim_list.set(1, 1);
-        let prim_list = prim_list_list.init(1, 1);
+        let mut prim_list = prim_list_list.init(1, 1);
         prim_list.set(0, 255);
-        let prim_list_list = prim_list_list_list.init(1, 1);
-        let prim_list = prim_list_list.init(0, 3);
+        let mut prim_list_list = prim_list_list_list.init(1, 1);
+        let mut prim_list = prim_list_list.init(0, 3);
         prim_list.set(0, 10);
         prim_list.set(1, 9);
         prim_list.set(2, 8);
 
-        let enum_list_list = test_complex_list.init_enum_list_list(2);
-        let enum_list = enum_list_list.init(0, 1);
+        let mut enum_list_list = test_complex_list.init_enum_list_list(2);
+        let mut enum_list = enum_list_list.init(0, 1);
         enum_list.set(0, an_enum::Bar);
-        let enum_list = enum_list_list.init(1, 2);
+        let mut enum_list = enum_list_list.init(1, 2);
         enum_list.set(0, an_enum::Foo);
         enum_list.set(1, an_enum::Qux);
 
-        let text_list_list = test_complex_list.init_text_list_list(1);
+        let mut text_list_list = test_complex_list.init_text_list_list(1);
         text_list_list.init(0,1).set(0, "abc");
 
-        let data_list_list = test_complex_list.init_data_list_list(1);
+        let mut data_list_list = test_complex_list.init_data_list_list(1);
         data_list_list.init(0,1).set(0, [255, 254, 253]);
 
-        let struct_list_list = test_complex_list.init_struct_list_list(1);
+        let mut struct_list_list = test_complex_list.init_struct_list_list(1);
         struct_list_list.init(0,1).get(0).set_int8_field(-1);
 
 
@@ -310,7 +310,7 @@ mod tests {
         use test_capnp::test_defaults;
 
         let mut message = MallocMessageBuilder::new_default();
-        let test_defaults = message.init_root::<test_defaults::Builder>();
+        let mut test_defaults = message.init_root::<test_defaults::Builder>();
 
         assert_eq!(test_defaults.get_void_field(), ());
         assert_eq!(test_defaults.get_bool_field(), true);
@@ -336,9 +336,9 @@ mod tests {
         use test_capnp::{test_any_pointer, test_empty_struct, test_big_struct};
 
         let mut message = MallocMessageBuilder::new_default();
-        let test_any_pointer = message.init_root::<test_any_pointer::Builder>();
+        let mut test_any_pointer = message.init_root::<test_any_pointer::Builder>();
 
-        let any_pointer = test_any_pointer.init_any_pointer_field();
+        let mut any_pointer = test_any_pointer.init_any_pointer_field();
         any_pointer.set_as_text("xyzzy");
 
         {
@@ -356,7 +356,7 @@ mod tests {
 
         {
             let mut message = MallocMessageBuilder::new_default();
-            let test_big_struct = message.init_root::<test_big_struct::Builder>();
+            let mut test_big_struct = message.init_root::<test_big_struct::Builder>();
             test_big_struct.set_int32_field(-12345);
             any_pointer.set_as_struct(&test_big_struct.as_reader());
         }
@@ -373,9 +373,9 @@ mod tests {
         use test_capnp::test_big_struct;
 
         let mut message = MallocMessageBuilder::new_default();
-        let big_struct = message.init_root::<test_big_struct::Builder>();
+        let mut big_struct = message.init_root::<test_big_struct::Builder>();
 
-        let struct_field = big_struct.init_struct_field();
+        let mut struct_field = big_struct.init_struct_field();
         assert_eq!(struct_field.get_uint64_field(), 0);
 
         struct_field.set_uint64_field(-7);
@@ -386,7 +386,7 @@ mod tests {
         assert_eq!(struct_field.get_uint32_field(), 0);
 
         // getting before init is the same as init
-        let other_struct_field = big_struct.get_another_struct_field();
+        let mut other_struct_field = big_struct.get_another_struct_field();
         assert_eq!(other_struct_field.get_uint64_field(), 0);
         other_struct_field.set_uint32_field(-31);
 
@@ -405,7 +405,7 @@ mod tests {
         use test_capnp::test_union;
 
         let mut message = MallocMessageBuilder::new_default();
-        let union_struct = message.init_root::<test_union::Builder>();
+        let mut union_struct = message.init_root::<test_union::Builder>();
 
         union_struct.get_union0().set_u0f0s0(());
         match union_struct.get_union0().which() {
@@ -451,7 +451,7 @@ mod tests {
 
         let mut message1 = MallocMessageBuilder::new_default();
         let mut message2 = MallocMessageBuilder::new_default();
-        let struct1 = message1.init_root::<test_big_struct::Builder>();
+        let mut struct1 = message1.init_root::<test_big_struct::Builder>();
         struct1.set_uint8_field(3);
         message2.set_root(&struct1.as_reader());
         let struct2 = message2.get_root::<test_big_struct::Builder>();
@@ -465,7 +465,7 @@ mod tests {
 
         let mut message = MallocMessageBuilder::new_default();
         {
-            let old_version = message.init_root::<test_old_version::Builder>();
+            let mut old_version = message.init_root::<test_old_version::Builder>();
             old_version.set_old1(123);
         }
         {

--- a/examples/addressbook/addressbook.rs
+++ b/examples/addressbook/addressbook.rs
@@ -18,11 +18,11 @@ pub mod addressbook {
     pub fn write_address_book() -> IoResult<()> {
         let mut message = MallocMessageBuilder::new_default();
         {
-            let address_book = message.init_root::<address_book::Builder>();
+            let mut address_book = message.init_root::<address_book::Builder>();
 
             let people = address_book.init_people(2);
 
-            let alice = people.get(0);
+            let mut alice = people.get(0);
             alice.set_id(123);
             alice.set_name("Alice");
             alice.set_email("alice@example.com");
@@ -32,7 +32,7 @@ pub mod addressbook {
             alice_phones.get(0).set_type(person::phone_number::type_::Mobile);
             alice.get_employment().set_school("MIT");
 
-            let bob = people.get(1);
+            let mut bob = people.get(1);
             bob.set_id(456);
             bob.set_name("Bob");
             bob.set_email("bob@example.com");

--- a/src/capnp/any_pointer.rs
+++ b/src/capnp/any_pointer.rs
@@ -77,31 +77,31 @@ impl <'a> Builder<'a> {
             self.builder.get_struct(HasStructSize::struct_size(None::<T>), ::std::ptr::null()))
     }
 
-    pub fn init_as_struct<T : FromStructBuilder<'a> + HasStructSize>(&self) -> T {
+    pub fn init_as_struct<T : FromStructBuilder<'a> + HasStructSize>(&mut self) -> T {
         FromStructBuilder::new(
             self.builder.init_struct(
                 HasStructSize::struct_size(None::<T>)))
     }
 
-    pub fn set_as_struct<'b, T : ToStructReader<'b>>(&self, value : &T) {
+    pub fn set_as_struct<'b, T : ToStructReader<'b>>(&mut self, value : &T) {
         self.builder.set_struct(&value.struct_reader());
     }
 
     // XXX value should be a user client.
-    pub fn set_as_capability(&self, value : Box<ClientHook+Send>) {
+    pub fn set_as_capability(&mut self, value : Box<ClientHook+Send>) {
         self.builder.set_capability(value);
     }
 
-    pub fn set_as_text(&self, value : &str) {
+    pub fn set_as_text(&mut self, value : &str) {
         self.builder.set_text(value);
     }
 
-    pub fn set_as_data(&self, value : &[u8]) {
+    pub fn set_as_data(&mut self, value : &[u8]) {
         self.builder.set_data(value);
     }
 
     #[inline]
-    pub fn clear(&self) {
+    pub fn clear(&mut self) {
         self.builder.clear()
     }
 

--- a/src/capnp/layout.rs
+++ b/src/capnp/layout.rs
@@ -1957,20 +1957,20 @@ impl <'a> PointerBuilder<'a> {
         }
     }
 
-    pub fn init_struct(&self, size : StructSize) -> StructBuilder<'a> {
+    pub fn init_struct(&mut self, size : StructSize) -> StructBuilder<'a> {
         unsafe {
             wire_helpers::init_struct_pointer(self.pointer, self.segment, size)
         }
     }
 
-    pub fn init_list(&self, element_size : ElementSize, element_count : ElementCount32) -> ListBuilder<'a> {
+    pub fn init_list(&mut self, element_size : ElementSize, element_count : ElementCount32) -> ListBuilder<'a> {
         unsafe {
             wire_helpers::init_list_pointer(
                 self.pointer, self.segment, element_count, element_size)
         }
     }
 
-    pub fn init_struct_list(&self, element_count : ElementCount32, element_size : StructSize)
+    pub fn init_struct_list(&mut self, element_count : ElementCount32, element_size : StructSize)
                             -> ListBuilder<'a> {
         unsafe {
             wire_helpers::init_struct_list_pointer(
@@ -1978,49 +1978,49 @@ impl <'a> PointerBuilder<'a> {
         }
     }
 
-    pub fn init_text(&self, size : ByteCount32) -> text::Builder<'a> {
+    pub fn init_text(&mut self, size : ByteCount32) -> text::Builder<'a> {
         unsafe {
             wire_helpers::init_text_pointer(self.pointer, self.segment, size).value
         }
     }
 
-    pub fn init_data(&self, size : ByteCount32) -> data::Builder<'a> {
+    pub fn init_data(&mut self, size : ByteCount32) -> data::Builder<'a> {
         unsafe {
             wire_helpers::init_data_pointer(self.pointer, self.segment, size).value
         }
     }
 
-    pub fn set_struct(&self, value : &StructReader) {
+    pub fn set_struct(&mut self, value : &StructReader) {
         unsafe {
             wire_helpers::set_struct_pointer(self.segment, self.pointer, *value);
         }
     }
 
-    pub fn set_list(&self, value : &ListReader) {
+    pub fn set_list(&mut self, value : &ListReader) {
         unsafe {
             wire_helpers::set_list_pointer(self.segment, self.pointer, *value);
         }
     }
 
-    pub fn set_text(&self, value : &str) {
+    pub fn set_text(&mut self, value : &str) {
         unsafe {
             wire_helpers::set_text_pointer(self.pointer, self.segment, value);
         }
     }
 
-    pub fn set_data(&self, value : &[u8]) {
+    pub fn set_data(&mut self, value : &[u8]) {
         unsafe {
             wire_helpers::set_data_pointer(self.pointer, self.segment, value);
         }
     }
 
-    pub fn set_capability(&self, cap : Box<ClientHook+Send>) {
+    pub fn set_capability(&mut self, cap : Box<ClientHook+Send>) {
         unsafe {
             wire_helpers::set_capability_pointer(self.segment, self.pointer, cap);
         }
     }
 
-    pub fn clear(&self) {
+    pub fn clear(&mut self) {
         unsafe {
             wire_helpers::zero_object(self.segment, self.pointer);
             ::std::ptr::zero_memory(self.pointer, 1);
@@ -2184,7 +2184,7 @@ impl <'a> StructBuilder<'a> {
     }
 
     #[inline]
-    pub fn set_data_field<T:Endian>(&self, offset : ElementCount, value : T) {
+    pub fn set_data_field<T:Endian>(&mut self, offset : ElementCount, value : T) {
         unsafe {
             let ptr : *mut WireValue<T> = ::std::mem::transmute(self.data);
             (*ptr.offset(offset as int)).set(value)
@@ -2192,7 +2192,7 @@ impl <'a> StructBuilder<'a> {
     }
 
     #[inline]
-    pub fn set_data_field_mask<T:Endian + ::std::num::Zero + Mask>(&self,
+    pub fn set_data_field_mask<T:Endian + ::std::num::Zero + Mask>(&mut self,
                                                                  offset : ElementCount,
                                                                  value : T,
                                                                  mask : T) {
@@ -2216,7 +2216,7 @@ impl <'a> StructBuilder<'a> {
 
 
     #[inline]
-    pub fn set_bool_field(&self, offset : ElementCount, value : bool) {
+    pub fn set_bool_field(&mut self, offset : ElementCount, value : bool) {
         //# This branch should be compiled out whenever this is
         //# inlined with a constant offset.
         let boffset : BitCount0 = offset;
@@ -2226,7 +2226,7 @@ impl <'a> StructBuilder<'a> {
     }
 
     #[inline]
-    pub fn set_bool_field_mask(&self,
+    pub fn set_bool_field_mask(&mut self,
                                offset : ElementCount,
                                value : bool,
                                mask : bool) {

--- a/src/capnp/list.rs
+++ b/src/capnp/list.rs
@@ -81,6 +81,22 @@ pub mod primitive_list {
         }
     }
 
+    /*
+    impl <'a, T : PrimitiveElement> Index<u32, T> for Reader<'a, T> {
+        fn index(&self, index : &u32) -> &T {
+            assert!(*index < self.size());
+            &'static PrimitiveElement::get(&self.reader, *index)
+        }
+    }
+
+    impl <'a, T : PrimitiveElement> IndexMut<u32, T> for Reader<'a, T> {
+        fn index_mut(&mut self, index : &u32) -> &mut T {
+            assert!(*index < self.size());
+            PrimitiveElement::get(&self.reader, *index)
+        }
+    }
+    */
+
     pub struct Builder<'a, T> {
         pub builder : ListBuilder<'a>
     }
@@ -92,13 +108,13 @@ pub mod primitive_list {
 
         pub fn size(&self) -> u32 { self.builder.size() }
 
-        pub fn set(&self, index : u32, value : T) {
+        pub fn set(&mut self, index : u32, value : T) {
             PrimitiveElement::set(&self.builder, index, value);
         }
     }
 
     impl <'a, T : PrimitiveElement> FromPointerBuilder<'a> for Builder<'a, T> {
-        fn init_pointer(builder : PointerBuilder<'a>, size : u32) -> Builder<'a, T> {
+        fn init_pointer(mut builder : PointerBuilder<'a>, size : u32) -> Builder<'a, T> {
             Builder { builder : builder.init_list(element_size_for_type::<T>(), size) }
         }
         fn get_from_pointer(builder : PointerBuilder<'a>, default_value : *const Word) -> Builder<'a, T> {
@@ -163,14 +179,14 @@ pub mod enum_list {
 
         pub fn size(&self) -> u32 { self.builder.size() }
 
-        pub fn set(&self, index : u32, value : T) {
+        pub fn set(&mut self, index : u32, value : T) {
             assert!(index < self.size());
             PrimitiveElement::set(&self.builder, index, value.to_u16());
         }
     }
 
     impl <'a, T : FromPrimitive> FromPointerBuilder<'a> for Builder<'a, T> {
-        fn init_pointer(builder : PointerBuilder<'a>, size : u32) -> Builder<'a, T> {
+        fn init_pointer(mut builder : PointerBuilder<'a>, size : u32) -> Builder<'a, T> {
             Builder { builder : builder.init_list(TwoBytes, size) }
         }
         fn get_from_pointer(builder : PointerBuilder<'a>, default_value : *const Word) -> Builder<'a, T> {
@@ -243,7 +259,7 @@ pub mod struct_list {
 
         pub fn size(&self) -> u32 { self.builder.size() }
 
-//        pub fn set(&self, index : uint, value : T) {
+//        pub fn set(&mut self, index : uint, value : T) {
 //        }
 
         pub fn iter(self) -> super::ListIter<Builder<'a, T>> {
@@ -253,7 +269,7 @@ pub mod struct_list {
     }
 
     impl <'a, T : FromStructBuilder<'a> + HasStructSize> FromPointerBuilder<'a> for Builder<'a, T> {
-        fn init_pointer(builder : PointerBuilder<'a>, size : u32) -> Builder<'a, T> {
+        fn init_pointer(mut builder : PointerBuilder<'a>, size : u32) -> Builder<'a, T> {
             Builder {
                 builder : builder.init_struct_list(size, HasStructSize::struct_size(None::<T>))
             }
@@ -325,7 +341,7 @@ pub mod list_list {
 
         pub fn size(&self) -> u32 { self.builder.size() }
 
-        pub fn init(&self, index : u32, size : u32) -> T {
+        pub fn init(&mut self, index : u32, size : u32) -> T {
             let result : T =
                 FromPointerBuilder::init_pointer(self.builder.get_pointer_element(index), size);
             result
@@ -334,7 +350,7 @@ pub mod list_list {
 
 
     impl <'a, T : FromPointerBuilder<'a>> FromPointerBuilder<'a> for Builder<'a, T> {
-        fn init_pointer(builder : PointerBuilder<'a>, size : u32) -> Builder<'a, T> {
+        fn init_pointer(mut builder : PointerBuilder<'a>, size : u32) -> Builder<'a, T> {
             Builder {
                 builder : builder.init_list(Pointer, size)
             }
@@ -401,7 +417,7 @@ pub mod text_list {
 
         pub fn size(&self) -> u32 { self.builder.size() }
 
-        pub fn set(&self, index : u32, value : text::Reader) {
+        pub fn set(&mut self, index : u32, value : text::Reader) {
             assert!(index < self.size());
             self.builder.get_pointer_element(index).set_text(value);
         }
@@ -409,7 +425,7 @@ pub mod text_list {
 
 
     impl <'a> FromPointerBuilder<'a> for Builder<'a> {
-        fn init_pointer(builder : PointerBuilder<'a>, size : u32) -> Builder<'a> {
+        fn init_pointer(mut builder : PointerBuilder<'a>, size : u32) -> Builder<'a> {
             Builder {
                 builder : builder.init_list(Pointer, size)
             }
@@ -471,7 +487,7 @@ pub mod data_list {
 
         pub fn size(&self) -> u32 { self.builder.size() }
 
-        pub fn set(&self, index : u32, value : data::Reader) {
+        pub fn set(&mut self, index : u32, value : data::Reader) {
             assert!(index < self.size());
             self.builder.get_pointer_element(index).set_data(value);
         }
@@ -479,7 +495,7 @@ pub mod data_list {
 
 
     impl <'a> FromPointerBuilder<'a> for Builder<'a> {
-        fn init_pointer(builder : PointerBuilder<'a>, size : u32) -> Builder<'a> {
+        fn init_pointer(mut builder : PointerBuilder<'a>, size : u32) -> Builder<'a> {
             Builder {
                 builder : builder.init_list(Pointer, size)
             }

--- a/src/capnpc-rust/codegen.rs
+++ b/src/capnpc-rust/codegen.rs
@@ -760,7 +760,7 @@ fn generate_setter(node_map : &collections::hash_map::HashMap<u64, schema_capnp:
                     (Some(format!("{}::Client",the_mod)), None)
                 }
                 Some(type_::AnyPointer(())) => {
-                    initter_interior.push(Line(format!("let result = any_pointer::Builder::new(self.builder.get_pointer_field({}));",
+                    initter_interior.push(Line(format!("let mut result = any_pointer::Builder::new(self.builder.get_pointer_field({}));",
                                                offset)));
                     initter_interior.push(Line("result.clear();".to_string()));
                     initter_interior.push(Line("result".to_string()));
@@ -774,7 +774,7 @@ fn generate_setter(node_map : &collections::hash_map::HashMap<u64, schema_capnp:
     match maybe_reader_type {
         Some(reader_type) => {
             result.push(Line("#[inline]".to_string()));
-            result.push(Line(format!("pub fn set_{}{}(&self, {} : {}) {{",
+            result.push(Line(format!("pub fn set_{}{}(&mut self, {} : {}) {{",
                                      styled_name, setter_lifetime_param, setter_param, reader_type)));
             result.push(Indent(box Branch(setter_interior)));
             result.push(Line("}".to_string()));
@@ -785,7 +785,7 @@ fn generate_setter(node_map : &collections::hash_map::HashMap<u64, schema_capnp:
         Some(builder_type) => {
             result.push(Line("#[inline]".to_string()));
             let args = initter_params.connect(", ");
-            result.push(Line(format!("pub fn init_{}(&self, {}) -> {} {{",
+            result.push(Line(format!("pub fn init_{}(&mut self, {}) -> {} {{",
                                      styled_name, args, builder_type)));
             result.push(Indent(box Branch(initter_interior)));
             result.push(Line("}".to_string()));

--- a/src/capnpc-rust/schema_capnp.rs
+++ b/src/capnpc-rust/schema_capnp.rs
@@ -117,7 +117,7 @@ pub mod node {
       self.builder.get_data_field::<u64>(0)
     }
     #[inline]
-    pub fn set_id(&self, value : u64) {
+    pub fn set_id(&mut self, value : u64) {
       self.builder.set_data_field::<u64>(0, value);
     }
     #[inline]
@@ -125,11 +125,11 @@ pub mod node {
       self.builder.get_pointer_field(0).get_text(::std::ptr::null(), 0)
     }
     #[inline]
-    pub fn set_display_name(&self, value : text::Reader) {
+    pub fn set_display_name(&mut self, value : text::Reader) {
       self.builder.get_pointer_field(0).set_text(value);
     }
     #[inline]
-    pub fn init_display_name(&self, size : u32) -> text::Builder<'a> {
+    pub fn init_display_name(&mut self, size : u32) -> text::Builder<'a> {
       self.builder.get_pointer_field(0).init_text(size)
     }
     pub fn has_display_name(&self) -> bool {
@@ -140,7 +140,7 @@ pub mod node {
       self.builder.get_data_field::<u32>(2)
     }
     #[inline]
-    pub fn set_display_name_prefix_length(&self, value : u32) {
+    pub fn set_display_name_prefix_length(&mut self, value : u32) {
       self.builder.set_data_field::<u32>(2, value);
     }
     #[inline]
@@ -148,7 +148,7 @@ pub mod node {
       self.builder.get_data_field::<u64>(2)
     }
     #[inline]
-    pub fn set_scope_id(&self, value : u64) {
+    pub fn set_scope_id(&mut self, value : u64) {
       self.builder.set_data_field::<u64>(2, value);
     }
     #[inline]
@@ -156,11 +156,11 @@ pub mod node {
       struct_list::Builder::new(self.builder.get_pointer_field(1).get_struct_list(::schema_capnp::node::nested_node::STRUCT_SIZE, ::std::ptr::null()))
     }
     #[inline]
-    pub fn set_nested_nodes(&self, value : struct_list::Reader<'a,::schema_capnp::node::nested_node::Reader<'a>>) {
+    pub fn set_nested_nodes(&mut self, value : struct_list::Reader<'a,::schema_capnp::node::nested_node::Reader<'a>>) {
       self.builder.get_pointer_field(1).set_list(&value.reader)
     }
     #[inline]
-    pub fn init_nested_nodes(&self, size : u32) -> struct_list::Builder<'a,::schema_capnp::node::nested_node::Builder<'a>> {
+    pub fn init_nested_nodes(&mut self, size : u32) -> struct_list::Builder<'a,::schema_capnp::node::nested_node::Builder<'a>> {
       struct_list::Builder::<'a, ::schema_capnp::node::nested_node::Builder<'a>>::new(
         self.builder.get_pointer_field(1).init_struct_list(size, ::schema_capnp::node::nested_node::STRUCT_SIZE))
     }
@@ -172,11 +172,11 @@ pub mod node {
       struct_list::Builder::new(self.builder.get_pointer_field(2).get_struct_list(::schema_capnp::annotation::STRUCT_SIZE, ::std::ptr::null()))
     }
     #[inline]
-    pub fn set_annotations(&self, value : struct_list::Reader<'a,::schema_capnp::annotation::Reader<'a>>) {
+    pub fn set_annotations(&mut self, value : struct_list::Reader<'a,::schema_capnp::annotation::Reader<'a>>) {
       self.builder.get_pointer_field(2).set_list(&value.reader)
     }
     #[inline]
-    pub fn init_annotations(&self, size : u32) -> struct_list::Builder<'a,::schema_capnp::annotation::Builder<'a>> {
+    pub fn init_annotations(&mut self, size : u32) -> struct_list::Builder<'a,::schema_capnp::annotation::Builder<'a>> {
       struct_list::Builder::<'a, ::schema_capnp::annotation::Builder<'a>>::new(
         self.builder.get_pointer_field(2).init_struct_list(size, ::schema_capnp::annotation::STRUCT_SIZE))
     }
@@ -184,11 +184,11 @@ pub mod node {
       !self.builder.get_pointer_field(2).is_null()
     }
     #[inline]
-    pub fn set_file(&self, _value : ()) {
+    pub fn set_file(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(6, 0);
     }
     #[inline]
-    pub fn init_struct(&self, ) -> ::schema_capnp::node::struct_::Builder<'a> {
+    pub fn init_struct(&mut self) -> ::schema_capnp::node::struct_::Builder<'a> {
       self.builder.set_data_field::<u16>(6, 1);
       self.builder.set_data_field::<u16>(7, 0);
       self.builder.set_data_field::<u16>(12, 0);
@@ -200,27 +200,27 @@ pub mod node {
       FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_enum(&self, ) -> ::schema_capnp::node::enum_::Builder<'a> {
+    pub fn init_enum(&mut self) -> ::schema_capnp::node::enum_::Builder<'a> {
       self.builder.set_data_field::<u16>(6, 2);
       self.builder.get_pointer_field(3).clear();
       FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_interface(&self, ) -> ::schema_capnp::node::interface::Builder<'a> {
+    pub fn init_interface(&mut self) -> ::schema_capnp::node::interface::Builder<'a> {
       self.builder.set_data_field::<u16>(6, 3);
       self.builder.get_pointer_field(3).clear();
       self.builder.get_pointer_field(4).clear();
       FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_const(&self, ) -> ::schema_capnp::node::const_::Builder<'a> {
+    pub fn init_const(&mut self) -> ::schema_capnp::node::const_::Builder<'a> {
       self.builder.set_data_field::<u16>(6, 4);
       self.builder.get_pointer_field(3).clear();
       self.builder.get_pointer_field(4).clear();
       FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_annotation(&self, ) -> ::schema_capnp::node::annotation::Builder<'a> {
+    pub fn init_annotation(&mut self) -> ::schema_capnp::node::annotation::Builder<'a> {
       self.builder.set_data_field::<u16>(6, 5);
       self.builder.get_pointer_field(3).clear();
       self.builder.set_bool_field(112, false);
@@ -352,11 +352,11 @@ pub mod node {
         self.builder.get_pointer_field(0).get_text(::std::ptr::null(), 0)
       }
       #[inline]
-      pub fn set_name(&self, value : text::Reader) {
+      pub fn set_name(&mut self, value : text::Reader) {
         self.builder.get_pointer_field(0).set_text(value);
       }
       #[inline]
-      pub fn init_name(&self, size : u32) -> text::Builder<'a> {
+      pub fn init_name(&mut self, size : u32) -> text::Builder<'a> {
         self.builder.get_pointer_field(0).init_text(size)
       }
       pub fn has_name(&self) -> bool {
@@ -367,7 +367,7 @@ pub mod node {
         self.builder.get_data_field::<u64>(0)
       }
       #[inline]
-      pub fn set_id(&self, value : u64) {
+      pub fn set_id(&mut self, value : u64) {
         self.builder.set_data_field::<u64>(0, value);
       }
     }
@@ -452,7 +452,7 @@ pub mod node {
         self.builder.get_data_field::<u16>(7)
       }
       #[inline]
-      pub fn set_data_word_count(&self, value : u16) {
+      pub fn set_data_word_count(&mut self, value : u16) {
         self.builder.set_data_field::<u16>(7, value);
       }
       #[inline]
@@ -460,7 +460,7 @@ pub mod node {
         self.builder.get_data_field::<u16>(12)
       }
       #[inline]
-      pub fn set_pointer_count(&self, value : u16) {
+      pub fn set_pointer_count(&mut self, value : u16) {
         self.builder.set_data_field::<u16>(12, value);
       }
       #[inline]
@@ -468,7 +468,7 @@ pub mod node {
         FromPrimitive::from_u16(self.builder.get_data_field::<u16>(13))
       }
       #[inline]
-      pub fn set_preferred_list_encoding(&self, value : ::schema_capnp::element_size::Reader) {
+      pub fn set_preferred_list_encoding(&mut self, value : ::schema_capnp::element_size::Reader) {
         self.builder.set_data_field::<u16>(13, value as u16)
       }
       #[inline]
@@ -476,7 +476,7 @@ pub mod node {
         self.builder.get_bool_field(224)
       }
       #[inline]
-      pub fn set_is_group(&self, value : bool) {
+      pub fn set_is_group(&mut self, value : bool) {
         self.builder.set_bool_field(224, value);
       }
       #[inline]
@@ -484,7 +484,7 @@ pub mod node {
         self.builder.get_data_field::<u16>(15)
       }
       #[inline]
-      pub fn set_discriminant_count(&self, value : u16) {
+      pub fn set_discriminant_count(&mut self, value : u16) {
         self.builder.set_data_field::<u16>(15, value);
       }
       #[inline]
@@ -492,7 +492,7 @@ pub mod node {
         self.builder.get_data_field::<u32>(8)
       }
       #[inline]
-      pub fn set_discriminant_offset(&self, value : u32) {
+      pub fn set_discriminant_offset(&mut self, value : u32) {
         self.builder.set_data_field::<u32>(8, value);
       }
       #[inline]
@@ -500,11 +500,11 @@ pub mod node {
         struct_list::Builder::new(self.builder.get_pointer_field(3).get_struct_list(::schema_capnp::field::STRUCT_SIZE, ::std::ptr::null()))
       }
       #[inline]
-      pub fn set_fields(&self, value : struct_list::Reader<'a,::schema_capnp::field::Reader<'a>>) {
+      pub fn set_fields(&mut self, value : struct_list::Reader<'a,::schema_capnp::field::Reader<'a>>) {
         self.builder.get_pointer_field(3).set_list(&value.reader)
       }
       #[inline]
-      pub fn init_fields(&self, size : u32) -> struct_list::Builder<'a,::schema_capnp::field::Builder<'a>> {
+      pub fn init_fields(&mut self, size : u32) -> struct_list::Builder<'a,::schema_capnp::field::Builder<'a>> {
         struct_list::Builder::<'a, ::schema_capnp::field::Builder<'a>>::new(
           self.builder.get_pointer_field(3).init_struct_list(size, ::schema_capnp::field::STRUCT_SIZE))
       }
@@ -569,11 +569,11 @@ pub mod node {
         struct_list::Builder::new(self.builder.get_pointer_field(3).get_struct_list(::schema_capnp::enumerant::STRUCT_SIZE, ::std::ptr::null()))
       }
       #[inline]
-      pub fn set_enumerants(&self, value : struct_list::Reader<'a,::schema_capnp::enumerant::Reader<'a>>) {
+      pub fn set_enumerants(&mut self, value : struct_list::Reader<'a,::schema_capnp::enumerant::Reader<'a>>) {
         self.builder.get_pointer_field(3).set_list(&value.reader)
       }
       #[inline]
-      pub fn init_enumerants(&self, size : u32) -> struct_list::Builder<'a,::schema_capnp::enumerant::Builder<'a>> {
+      pub fn init_enumerants(&mut self, size : u32) -> struct_list::Builder<'a,::schema_capnp::enumerant::Builder<'a>> {
         struct_list::Builder::<'a, ::schema_capnp::enumerant::Builder<'a>>::new(
           self.builder.get_pointer_field(3).init_struct_list(size, ::schema_capnp::enumerant::STRUCT_SIZE))
       }
@@ -645,11 +645,11 @@ pub mod node {
         struct_list::Builder::new(self.builder.get_pointer_field(3).get_struct_list(::schema_capnp::method::STRUCT_SIZE, ::std::ptr::null()))
       }
       #[inline]
-      pub fn set_methods(&self, value : struct_list::Reader<'a,::schema_capnp::method::Reader<'a>>) {
+      pub fn set_methods(&mut self, value : struct_list::Reader<'a,::schema_capnp::method::Reader<'a>>) {
         self.builder.get_pointer_field(3).set_list(&value.reader)
       }
       #[inline]
-      pub fn init_methods(&self, size : u32) -> struct_list::Builder<'a,::schema_capnp::method::Builder<'a>> {
+      pub fn init_methods(&mut self, size : u32) -> struct_list::Builder<'a,::schema_capnp::method::Builder<'a>> {
         struct_list::Builder::<'a, ::schema_capnp::method::Builder<'a>>::new(
           self.builder.get_pointer_field(3).init_struct_list(size, ::schema_capnp::method::STRUCT_SIZE))
       }
@@ -661,11 +661,11 @@ pub mod node {
         primitive_list::Builder::new(self.builder.get_pointer_field(4).get_list(layout::EightBytes, ::std::ptr::null()))
       }
       #[inline]
-      pub fn set_extends(&self, value : primitive_list::Reader<'a,u64>) {
+      pub fn set_extends(&mut self, value : primitive_list::Reader<'a,u64>) {
         self.builder.get_pointer_field(4).set_list(&value.reader)
       }
       #[inline]
-      pub fn init_extends(&self, size : u32) -> primitive_list::Builder<'a,u64> {
+      pub fn init_extends(&mut self, size : u32) -> primitive_list::Builder<'a,u64> {
         primitive_list::Builder::<'a,u64>::new(
           self.builder.get_pointer_field(4).init_list(layout::EightBytes,size)
         )
@@ -738,11 +738,11 @@ pub mod node {
         FromStructBuilder::new(self.builder.get_pointer_field(3).get_struct(::schema_capnp::type_::STRUCT_SIZE, ::std::ptr::null()))
       }
       #[inline]
-      pub fn set_type(&self, value : ::schema_capnp::type_::Reader) {
+      pub fn set_type(&mut self, value : ::schema_capnp::type_::Reader) {
         self.builder.get_pointer_field(3).set_struct(&value.struct_reader())
       }
       #[inline]
-      pub fn init_type(&self, ) -> ::schema_capnp::type_::Builder<'a> {
+      pub fn init_type(&mut self) -> ::schema_capnp::type_::Builder<'a> {
         FromStructBuilder::new(self.builder.get_pointer_field(3).init_struct(::schema_capnp::type_::STRUCT_SIZE))
       }
       pub fn has_type(&self) -> bool {
@@ -753,11 +753,11 @@ pub mod node {
         FromStructBuilder::new(self.builder.get_pointer_field(4).get_struct(::schema_capnp::value::STRUCT_SIZE, ::std::ptr::null()))
       }
       #[inline]
-      pub fn set_value(&self, value : ::schema_capnp::value::Reader) {
+      pub fn set_value(&mut self, value : ::schema_capnp::value::Reader) {
         self.builder.get_pointer_field(4).set_struct(&value.struct_reader())
       }
       #[inline]
-      pub fn init_value(&self, ) -> ::schema_capnp::value::Builder<'a> {
+      pub fn init_value(&mut self) -> ::schema_capnp::value::Builder<'a> {
         FromStructBuilder::new(self.builder.get_pointer_field(4).init_struct(::schema_capnp::value::STRUCT_SIZE))
       }
       pub fn has_value(&self) -> bool {
@@ -875,11 +875,11 @@ pub mod node {
         FromStructBuilder::new(self.builder.get_pointer_field(3).get_struct(::schema_capnp::type_::STRUCT_SIZE, ::std::ptr::null()))
       }
       #[inline]
-      pub fn set_type(&self, value : ::schema_capnp::type_::Reader) {
+      pub fn set_type(&mut self, value : ::schema_capnp::type_::Reader) {
         self.builder.get_pointer_field(3).set_struct(&value.struct_reader())
       }
       #[inline]
-      pub fn init_type(&self, ) -> ::schema_capnp::type_::Builder<'a> {
+      pub fn init_type(&mut self) -> ::schema_capnp::type_::Builder<'a> {
         FromStructBuilder::new(self.builder.get_pointer_field(3).init_struct(::schema_capnp::type_::STRUCT_SIZE))
       }
       pub fn has_type(&self) -> bool {
@@ -890,7 +890,7 @@ pub mod node {
         self.builder.get_bool_field(112)
       }
       #[inline]
-      pub fn set_targets_file(&self, value : bool) {
+      pub fn set_targets_file(&mut self, value : bool) {
         self.builder.set_bool_field(112, value);
       }
       #[inline]
@@ -898,7 +898,7 @@ pub mod node {
         self.builder.get_bool_field(113)
       }
       #[inline]
-      pub fn set_targets_const(&self, value : bool) {
+      pub fn set_targets_const(&mut self, value : bool) {
         self.builder.set_bool_field(113, value);
       }
       #[inline]
@@ -906,7 +906,7 @@ pub mod node {
         self.builder.get_bool_field(114)
       }
       #[inline]
-      pub fn set_targets_enum(&self, value : bool) {
+      pub fn set_targets_enum(&mut self, value : bool) {
         self.builder.set_bool_field(114, value);
       }
       #[inline]
@@ -914,7 +914,7 @@ pub mod node {
         self.builder.get_bool_field(115)
       }
       #[inline]
-      pub fn set_targets_enumerant(&self, value : bool) {
+      pub fn set_targets_enumerant(&mut self, value : bool) {
         self.builder.set_bool_field(115, value);
       }
       #[inline]
@@ -922,7 +922,7 @@ pub mod node {
         self.builder.get_bool_field(116)
       }
       #[inline]
-      pub fn set_targets_struct(&self, value : bool) {
+      pub fn set_targets_struct(&mut self, value : bool) {
         self.builder.set_bool_field(116, value);
       }
       #[inline]
@@ -930,7 +930,7 @@ pub mod node {
         self.builder.get_bool_field(117)
       }
       #[inline]
-      pub fn set_targets_field(&self, value : bool) {
+      pub fn set_targets_field(&mut self, value : bool) {
         self.builder.set_bool_field(117, value);
       }
       #[inline]
@@ -938,7 +938,7 @@ pub mod node {
         self.builder.get_bool_field(118)
       }
       #[inline]
-      pub fn set_targets_union(&self, value : bool) {
+      pub fn set_targets_union(&mut self, value : bool) {
         self.builder.set_bool_field(118, value);
       }
       #[inline]
@@ -946,7 +946,7 @@ pub mod node {
         self.builder.get_bool_field(119)
       }
       #[inline]
-      pub fn set_targets_group(&self, value : bool) {
+      pub fn set_targets_group(&mut self, value : bool) {
         self.builder.set_bool_field(119, value);
       }
       #[inline]
@@ -954,7 +954,7 @@ pub mod node {
         self.builder.get_bool_field(120)
       }
       #[inline]
-      pub fn set_targets_interface(&self, value : bool) {
+      pub fn set_targets_interface(&mut self, value : bool) {
         self.builder.set_bool_field(120, value);
       }
       #[inline]
@@ -962,7 +962,7 @@ pub mod node {
         self.builder.get_bool_field(121)
       }
       #[inline]
-      pub fn set_targets_method(&self, value : bool) {
+      pub fn set_targets_method(&mut self, value : bool) {
         self.builder.set_bool_field(121, value);
       }
       #[inline]
@@ -970,7 +970,7 @@ pub mod node {
         self.builder.get_bool_field(122)
       }
       #[inline]
-      pub fn set_targets_param(&self, value : bool) {
+      pub fn set_targets_param(&mut self, value : bool) {
         self.builder.set_bool_field(122, value);
       }
       #[inline]
@@ -978,7 +978,7 @@ pub mod node {
         self.builder.get_bool_field(123)
       }
       #[inline]
-      pub fn set_targets_annotation(&self, value : bool) {
+      pub fn set_targets_annotation(&mut self, value : bool) {
         self.builder.set_bool_field(123, value);
       }
     }
@@ -1085,11 +1085,11 @@ pub mod field {
       self.builder.get_pointer_field(0).get_text(::std::ptr::null(), 0)
     }
     #[inline]
-    pub fn set_name(&self, value : text::Reader) {
+    pub fn set_name(&mut self, value : text::Reader) {
       self.builder.get_pointer_field(0).set_text(value);
     }
     #[inline]
-    pub fn init_name(&self, size : u32) -> text::Builder<'a> {
+    pub fn init_name(&mut self, size : u32) -> text::Builder<'a> {
       self.builder.get_pointer_field(0).init_text(size)
     }
     pub fn has_name(&self) -> bool {
@@ -1100,7 +1100,7 @@ pub mod field {
       self.builder.get_data_field::<u16>(0)
     }
     #[inline]
-    pub fn set_code_order(&self, value : u16) {
+    pub fn set_code_order(&mut self, value : u16) {
       self.builder.set_data_field::<u16>(0, value);
     }
     #[inline]
@@ -1108,11 +1108,11 @@ pub mod field {
       struct_list::Builder::new(self.builder.get_pointer_field(1).get_struct_list(::schema_capnp::annotation::STRUCT_SIZE, ::std::ptr::null()))
     }
     #[inline]
-    pub fn set_annotations(&self, value : struct_list::Reader<'a,::schema_capnp::annotation::Reader<'a>>) {
+    pub fn set_annotations(&mut self, value : struct_list::Reader<'a,::schema_capnp::annotation::Reader<'a>>) {
       self.builder.get_pointer_field(1).set_list(&value.reader)
     }
     #[inline]
-    pub fn init_annotations(&self, size : u32) -> struct_list::Builder<'a,::schema_capnp::annotation::Builder<'a>> {
+    pub fn init_annotations(&mut self, size : u32) -> struct_list::Builder<'a,::schema_capnp::annotation::Builder<'a>> {
       struct_list::Builder::<'a, ::schema_capnp::annotation::Builder<'a>>::new(
         self.builder.get_pointer_field(1).init_struct_list(size, ::schema_capnp::annotation::STRUCT_SIZE))
     }
@@ -1124,11 +1124,11 @@ pub mod field {
       self.builder.get_data_field_mask::<u16>(1, 65535u16)
     }
     #[inline]
-    pub fn set_discriminant_value(&self, value : u16) {
+    pub fn set_discriminant_value(&mut self, value : u16) {
       self.builder.set_data_field_mask::<u16>(1, value, 65535);
     }
     #[inline]
-    pub fn init_slot(&self, ) -> ::schema_capnp::field::slot::Builder<'a> {
+    pub fn init_slot(&mut self) -> ::schema_capnp::field::slot::Builder<'a> {
       self.builder.set_data_field::<u16>(4, 0);
       self.builder.set_data_field::<u32>(1, 0);
       self.builder.get_pointer_field(2).clear();
@@ -1137,7 +1137,7 @@ pub mod field {
       FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_group(&self, ) -> ::schema_capnp::field::group::Builder<'a> {
+    pub fn init_group(&mut self) -> ::schema_capnp::field::group::Builder<'a> {
       self.builder.set_data_field::<u16>(4, 1);
       self.builder.set_data_field::<u64>(2, 0);
       FromStructBuilder::new(self.builder)
@@ -1147,7 +1147,7 @@ pub mod field {
       FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_ordinal(&self, ) -> ::schema_capnp::field::ordinal::Builder<'a> {
+    pub fn init_ordinal(&mut self) -> ::schema_capnp::field::ordinal::Builder<'a> {
       self.builder.set_data_field::<u16>(5, 0);
       self.builder.set_data_field::<u16>(6, 0);
       FromStructBuilder::new(self.builder)
@@ -1250,7 +1250,7 @@ pub mod field {
         self.builder.get_data_field::<u32>(1)
       }
       #[inline]
-      pub fn set_offset(&self, value : u32) {
+      pub fn set_offset(&mut self, value : u32) {
         self.builder.set_data_field::<u32>(1, value);
       }
       #[inline]
@@ -1258,11 +1258,11 @@ pub mod field {
         FromStructBuilder::new(self.builder.get_pointer_field(2).get_struct(::schema_capnp::type_::STRUCT_SIZE, ::std::ptr::null()))
       }
       #[inline]
-      pub fn set_type(&self, value : ::schema_capnp::type_::Reader) {
+      pub fn set_type(&mut self, value : ::schema_capnp::type_::Reader) {
         self.builder.get_pointer_field(2).set_struct(&value.struct_reader())
       }
       #[inline]
-      pub fn init_type(&self, ) -> ::schema_capnp::type_::Builder<'a> {
+      pub fn init_type(&mut self) -> ::schema_capnp::type_::Builder<'a> {
         FromStructBuilder::new(self.builder.get_pointer_field(2).init_struct(::schema_capnp::type_::STRUCT_SIZE))
       }
       pub fn has_type(&self) -> bool {
@@ -1273,11 +1273,11 @@ pub mod field {
         FromStructBuilder::new(self.builder.get_pointer_field(3).get_struct(::schema_capnp::value::STRUCT_SIZE, ::std::ptr::null()))
       }
       #[inline]
-      pub fn set_default_value(&self, value : ::schema_capnp::value::Reader) {
+      pub fn set_default_value(&mut self, value : ::schema_capnp::value::Reader) {
         self.builder.get_pointer_field(3).set_struct(&value.struct_reader())
       }
       #[inline]
-      pub fn init_default_value(&self, ) -> ::schema_capnp::value::Builder<'a> {
+      pub fn init_default_value(&mut self) -> ::schema_capnp::value::Builder<'a> {
         FromStructBuilder::new(self.builder.get_pointer_field(3).init_struct(::schema_capnp::value::STRUCT_SIZE))
       }
       pub fn has_default_value(&self) -> bool {
@@ -1288,7 +1288,7 @@ pub mod field {
         self.builder.get_bool_field(128)
       }
       #[inline]
-      pub fn set_had_explicit_default(&self, value : bool) {
+      pub fn set_had_explicit_default(&mut self, value : bool) {
         self.builder.set_bool_field(128, value);
       }
     }
@@ -1352,7 +1352,7 @@ pub mod field {
         self.builder.get_data_field::<u64>(2)
       }
       #[inline]
-      pub fn set_type_id(&self, value : u64) {
+      pub fn set_type_id(&mut self, value : u64) {
         self.builder.set_data_field::<u64>(2, value);
       }
     }
@@ -1418,11 +1418,11 @@ pub mod field {
         FromStructReader::new(self.builder.as_reader())
       }
       #[inline]
-      pub fn set_implicit(&self, _value : ()) {
+      pub fn set_implicit(&mut self, _value : ()) {
         self.builder.set_data_field::<u16>(5, 0);
       }
       #[inline]
-      pub fn set_explicit(&self, value : u16) {
+      pub fn set_explicit(&mut self, value : u16) {
         self.builder.set_data_field::<u16>(5, 1);
         self.builder.set_data_field::<u16>(6, value);
       }
@@ -1526,11 +1526,11 @@ pub mod enumerant {
       self.builder.get_pointer_field(0).get_text(::std::ptr::null(), 0)
     }
     #[inline]
-    pub fn set_name(&self, value : text::Reader) {
+    pub fn set_name(&mut self, value : text::Reader) {
       self.builder.get_pointer_field(0).set_text(value);
     }
     #[inline]
-    pub fn init_name(&self, size : u32) -> text::Builder<'a> {
+    pub fn init_name(&mut self, size : u32) -> text::Builder<'a> {
       self.builder.get_pointer_field(0).init_text(size)
     }
     pub fn has_name(&self) -> bool {
@@ -1541,7 +1541,7 @@ pub mod enumerant {
       self.builder.get_data_field::<u16>(0)
     }
     #[inline]
-    pub fn set_code_order(&self, value : u16) {
+    pub fn set_code_order(&mut self, value : u16) {
       self.builder.set_data_field::<u16>(0, value);
     }
     #[inline]
@@ -1549,11 +1549,11 @@ pub mod enumerant {
       struct_list::Builder::new(self.builder.get_pointer_field(1).get_struct_list(::schema_capnp::annotation::STRUCT_SIZE, ::std::ptr::null()))
     }
     #[inline]
-    pub fn set_annotations(&self, value : struct_list::Reader<'a,::schema_capnp::annotation::Reader<'a>>) {
+    pub fn set_annotations(&mut self, value : struct_list::Reader<'a,::schema_capnp::annotation::Reader<'a>>) {
       self.builder.get_pointer_field(1).set_list(&value.reader)
     }
     #[inline]
-    pub fn init_annotations(&self, size : u32) -> struct_list::Builder<'a,::schema_capnp::annotation::Builder<'a>> {
+    pub fn init_annotations(&mut self, size : u32) -> struct_list::Builder<'a,::schema_capnp::annotation::Builder<'a>> {
       struct_list::Builder::<'a, ::schema_capnp::annotation::Builder<'a>>::new(
         self.builder.get_pointer_field(1).init_struct_list(size, ::schema_capnp::annotation::STRUCT_SIZE))
     }
@@ -1645,11 +1645,11 @@ pub mod method {
       self.builder.get_pointer_field(0).get_text(::std::ptr::null(), 0)
     }
     #[inline]
-    pub fn set_name(&self, value : text::Reader) {
+    pub fn set_name(&mut self, value : text::Reader) {
       self.builder.get_pointer_field(0).set_text(value);
     }
     #[inline]
-    pub fn init_name(&self, size : u32) -> text::Builder<'a> {
+    pub fn init_name(&mut self, size : u32) -> text::Builder<'a> {
       self.builder.get_pointer_field(0).init_text(size)
     }
     pub fn has_name(&self) -> bool {
@@ -1660,7 +1660,7 @@ pub mod method {
       self.builder.get_data_field::<u16>(0)
     }
     #[inline]
-    pub fn set_code_order(&self, value : u16) {
+    pub fn set_code_order(&mut self, value : u16) {
       self.builder.set_data_field::<u16>(0, value);
     }
     #[inline]
@@ -1668,7 +1668,7 @@ pub mod method {
       self.builder.get_data_field::<u64>(1)
     }
     #[inline]
-    pub fn set_param_struct_type(&self, value : u64) {
+    pub fn set_param_struct_type(&mut self, value : u64) {
       self.builder.set_data_field::<u64>(1, value);
     }
     #[inline]
@@ -1676,7 +1676,7 @@ pub mod method {
       self.builder.get_data_field::<u64>(2)
     }
     #[inline]
-    pub fn set_result_struct_type(&self, value : u64) {
+    pub fn set_result_struct_type(&mut self, value : u64) {
       self.builder.set_data_field::<u64>(2, value);
     }
     #[inline]
@@ -1684,11 +1684,11 @@ pub mod method {
       struct_list::Builder::new(self.builder.get_pointer_field(1).get_struct_list(::schema_capnp::annotation::STRUCT_SIZE, ::std::ptr::null()))
     }
     #[inline]
-    pub fn set_annotations(&self, value : struct_list::Reader<'a,::schema_capnp::annotation::Reader<'a>>) {
+    pub fn set_annotations(&mut self, value : struct_list::Reader<'a,::schema_capnp::annotation::Reader<'a>>) {
       self.builder.get_pointer_field(1).set_list(&value.reader)
     }
     #[inline]
-    pub fn init_annotations(&self, size : u32) -> struct_list::Builder<'a,::schema_capnp::annotation::Builder<'a>> {
+    pub fn init_annotations(&mut self, size : u32) -> struct_list::Builder<'a,::schema_capnp::annotation::Builder<'a>> {
       struct_list::Builder::<'a, ::schema_capnp::annotation::Builder<'a>>::new(
         self.builder.get_pointer_field(1).init_struct_list(size, ::schema_capnp::annotation::STRUCT_SIZE))
     }
@@ -1851,87 +1851,87 @@ pub mod type_ {
       FromStructReader::new(self.builder.as_reader())
     }
     #[inline]
-    pub fn set_void(&self, _value : ()) {
+    pub fn set_void(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 0);
     }
     #[inline]
-    pub fn set_bool(&self, _value : ()) {
+    pub fn set_bool(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 1);
     }
     #[inline]
-    pub fn set_int8(&self, _value : ()) {
+    pub fn set_int8(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 2);
     }
     #[inline]
-    pub fn set_int16(&self, _value : ()) {
+    pub fn set_int16(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 3);
     }
     #[inline]
-    pub fn set_int32(&self, _value : ()) {
+    pub fn set_int32(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 4);
     }
     #[inline]
-    pub fn set_int64(&self, _value : ()) {
+    pub fn set_int64(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 5);
     }
     #[inline]
-    pub fn set_uint8(&self, _value : ()) {
+    pub fn set_uint8(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 6);
     }
     #[inline]
-    pub fn set_uint16(&self, _value : ()) {
+    pub fn set_uint16(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 7);
     }
     #[inline]
-    pub fn set_uint32(&self, _value : ()) {
+    pub fn set_uint32(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 8);
     }
     #[inline]
-    pub fn set_uint64(&self, _value : ()) {
+    pub fn set_uint64(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 9);
     }
     #[inline]
-    pub fn set_float32(&self, _value : ()) {
+    pub fn set_float32(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 10);
     }
     #[inline]
-    pub fn set_float64(&self, _value : ()) {
+    pub fn set_float64(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 11);
     }
     #[inline]
-    pub fn set_text(&self, _value : ()) {
+    pub fn set_text(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 12);
     }
     #[inline]
-    pub fn set_data(&self, _value : ()) {
+    pub fn set_data(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 13);
     }
     #[inline]
-    pub fn init_list(&self, ) -> ::schema_capnp::type_::list::Builder<'a> {
+    pub fn init_list(&mut self) -> ::schema_capnp::type_::list::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 14);
       self.builder.get_pointer_field(0).clear();
       FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_enum(&self, ) -> ::schema_capnp::type_::enum_::Builder<'a> {
+    pub fn init_enum(&mut self) -> ::schema_capnp::type_::enum_::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 15);
       self.builder.set_data_field::<u64>(1, 0);
       FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_struct(&self, ) -> ::schema_capnp::type_::struct_::Builder<'a> {
+    pub fn init_struct(&mut self) -> ::schema_capnp::type_::struct_::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 16);
       self.builder.set_data_field::<u64>(1, 0);
       FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_interface(&self, ) -> ::schema_capnp::type_::interface::Builder<'a> {
+    pub fn init_interface(&mut self) -> ::schema_capnp::type_::interface::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 17);
       self.builder.set_data_field::<u64>(1, 0);
       FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn set_any_pointer(&self, _value : ()) {
+    pub fn set_any_pointer(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 18);
     }
     #[inline]
@@ -2115,11 +2115,11 @@ pub mod type_ {
         FromStructBuilder::new(self.builder.get_pointer_field(0).get_struct(::schema_capnp::type_::STRUCT_SIZE, ::std::ptr::null()))
       }
       #[inline]
-      pub fn set_element_type(&self, value : ::schema_capnp::type_::Reader) {
+      pub fn set_element_type(&mut self, value : ::schema_capnp::type_::Reader) {
         self.builder.get_pointer_field(0).set_struct(&value.struct_reader())
       }
       #[inline]
-      pub fn init_element_type(&self, ) -> ::schema_capnp::type_::Builder<'a> {
+      pub fn init_element_type(&mut self) -> ::schema_capnp::type_::Builder<'a> {
         FromStructBuilder::new(self.builder.get_pointer_field(0).init_struct(::schema_capnp::type_::STRUCT_SIZE))
       }
       pub fn has_element_type(&self) -> bool {
@@ -2183,7 +2183,7 @@ pub mod type_ {
         self.builder.get_data_field::<u64>(1)
       }
       #[inline]
-      pub fn set_type_id(&self, value : u64) {
+      pub fn set_type_id(&mut self, value : u64) {
         self.builder.set_data_field::<u64>(1, value);
       }
     }
@@ -2241,7 +2241,7 @@ pub mod type_ {
         self.builder.get_data_field::<u64>(1)
       }
       #[inline]
-      pub fn set_type_id(&self, value : u64) {
+      pub fn set_type_id(&mut self, value : u64) {
         self.builder.set_data_field::<u64>(1, value);
       }
     }
@@ -2299,7 +2299,7 @@ pub mod type_ {
         self.builder.get_data_field::<u64>(1)
       }
       #[inline]
-      pub fn set_type_id(&self, value : u64) {
+      pub fn set_type_id(&mut self, value : u64) {
         self.builder.set_data_field::<u64>(1, value);
       }
     }
@@ -2479,71 +2479,71 @@ pub mod value {
       FromStructReader::new(self.builder.as_reader())
     }
     #[inline]
-    pub fn set_void(&self, _value : ()) {
+    pub fn set_void(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 0);
     }
     #[inline]
-    pub fn set_bool(&self, value : bool) {
+    pub fn set_bool(&mut self, value : bool) {
       self.builder.set_data_field::<u16>(0, 1);
       self.builder.set_bool_field(16, value);
     }
     #[inline]
-    pub fn set_int8(&self, value : i8) {
+    pub fn set_int8(&mut self, value : i8) {
       self.builder.set_data_field::<u16>(0, 2);
       self.builder.set_data_field::<i8>(2, value);
     }
     #[inline]
-    pub fn set_int16(&self, value : i16) {
+    pub fn set_int16(&mut self, value : i16) {
       self.builder.set_data_field::<u16>(0, 3);
       self.builder.set_data_field::<i16>(1, value);
     }
     #[inline]
-    pub fn set_int32(&self, value : i32) {
+    pub fn set_int32(&mut self, value : i32) {
       self.builder.set_data_field::<u16>(0, 4);
       self.builder.set_data_field::<i32>(1, value);
     }
     #[inline]
-    pub fn set_int64(&self, value : i64) {
+    pub fn set_int64(&mut self, value : i64) {
       self.builder.set_data_field::<u16>(0, 5);
       self.builder.set_data_field::<i64>(1, value);
     }
     #[inline]
-    pub fn set_uint8(&self, value : u8) {
+    pub fn set_uint8(&mut self, value : u8) {
       self.builder.set_data_field::<u16>(0, 6);
       self.builder.set_data_field::<u8>(2, value);
     }
     #[inline]
-    pub fn set_uint16(&self, value : u16) {
+    pub fn set_uint16(&mut self, value : u16) {
       self.builder.set_data_field::<u16>(0, 7);
       self.builder.set_data_field::<u16>(1, value);
     }
     #[inline]
-    pub fn set_uint32(&self, value : u32) {
+    pub fn set_uint32(&mut self, value : u32) {
       self.builder.set_data_field::<u16>(0, 8);
       self.builder.set_data_field::<u32>(1, value);
     }
     #[inline]
-    pub fn set_uint64(&self, value : u64) {
+    pub fn set_uint64(&mut self, value : u64) {
       self.builder.set_data_field::<u16>(0, 9);
       self.builder.set_data_field::<u64>(1, value);
     }
     #[inline]
-    pub fn set_float32(&self, value : f32) {
+    pub fn set_float32(&mut self, value : f32) {
       self.builder.set_data_field::<u16>(0, 10);
       self.builder.set_data_field::<f32>(1, value);
     }
     #[inline]
-    pub fn set_float64(&self, value : f64) {
+    pub fn set_float64(&mut self, value : f64) {
       self.builder.set_data_field::<u16>(0, 11);
       self.builder.set_data_field::<f64>(1, value);
     }
     #[inline]
-    pub fn set_text(&self, value : text::Reader) {
+    pub fn set_text(&mut self, value : text::Reader) {
       self.builder.set_data_field::<u16>(0, 12);
       self.builder.get_pointer_field(0).set_text(value);
     }
     #[inline]
-    pub fn init_text(&self, size : u32) -> text::Builder<'a> {
+    pub fn init_text(&mut self, size : u32) -> text::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 12);
       self.builder.get_pointer_field(0).init_text(size)
     }
@@ -2552,12 +2552,12 @@ pub mod value {
       !self.builder.get_pointer_field(0).is_null()
     }
     #[inline]
-    pub fn set_data(&self, value : data::Reader) {
+    pub fn set_data(&mut self, value : data::Reader) {
       self.builder.set_data_field::<u16>(0, 13);
       self.builder.get_pointer_field(0).set_data(value);
     }
     #[inline]
-    pub fn init_data(&self, size : u32) -> data::Builder<'a> {
+    pub fn init_data(&mut self, size : u32) -> data::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 13);
       self.builder.get_pointer_field(0).init_data(size)
     }
@@ -2566,9 +2566,9 @@ pub mod value {
       !self.builder.get_pointer_field(0).is_null()
     }
     #[inline]
-    pub fn init_list(&self, ) -> any_pointer::Builder<'a> {
+    pub fn init_list(&mut self) -> any_pointer::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 14);
-      let result = any_pointer::Builder::new(self.builder.get_pointer_field(0));
+      let mut result = any_pointer::Builder::new(self.builder.get_pointer_field(0));
       result.clear();
       result
     }
@@ -2577,14 +2577,14 @@ pub mod value {
       !self.builder.get_pointer_field(0).is_null()
     }
     #[inline]
-    pub fn set_enum(&self, value : u16) {
+    pub fn set_enum(&mut self, value : u16) {
       self.builder.set_data_field::<u16>(0, 15);
       self.builder.set_data_field::<u16>(1, value);
     }
     #[inline]
-    pub fn init_struct(&self, ) -> any_pointer::Builder<'a> {
+    pub fn init_struct(&mut self) -> any_pointer::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 16);
-      let result = any_pointer::Builder::new(self.builder.get_pointer_field(0));
+      let mut result = any_pointer::Builder::new(self.builder.get_pointer_field(0));
       result.clear();
       result
     }
@@ -2593,13 +2593,13 @@ pub mod value {
       !self.builder.get_pointer_field(0).is_null()
     }
     #[inline]
-    pub fn set_interface(&self, _value : ()) {
+    pub fn set_interface(&mut self, _value : ()) {
       self.builder.set_data_field::<u16>(0, 17);
     }
     #[inline]
-    pub fn init_any_pointer(&self, ) -> any_pointer::Builder<'a> {
+    pub fn init_any_pointer(&mut self) -> any_pointer::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 18);
-      let result = any_pointer::Builder::new(self.builder.get_pointer_field(0));
+      let mut result = any_pointer::Builder::new(self.builder.get_pointer_field(0));
       result.clear();
       result
     }
@@ -2801,7 +2801,7 @@ pub mod annotation {
       self.builder.get_data_field::<u64>(0)
     }
     #[inline]
-    pub fn set_id(&self, value : u64) {
+    pub fn set_id(&mut self, value : u64) {
       self.builder.set_data_field::<u64>(0, value);
     }
     #[inline]
@@ -2809,11 +2809,11 @@ pub mod annotation {
       FromStructBuilder::new(self.builder.get_pointer_field(0).get_struct(::schema_capnp::value::STRUCT_SIZE, ::std::ptr::null()))
     }
     #[inline]
-    pub fn set_value(&self, value : ::schema_capnp::value::Reader) {
+    pub fn set_value(&mut self, value : ::schema_capnp::value::Reader) {
       self.builder.get_pointer_field(0).set_struct(&value.struct_reader())
     }
     #[inline]
-    pub fn init_value(&self, ) -> ::schema_capnp::value::Builder<'a> {
+    pub fn init_value(&mut self) -> ::schema_capnp::value::Builder<'a> {
       FromStructBuilder::new(self.builder.get_pointer_field(0).init_struct(::schema_capnp::value::STRUCT_SIZE))
     }
     pub fn has_value(&self) -> bool {
@@ -2917,11 +2917,11 @@ pub mod code_generator_request {
       struct_list::Builder::new(self.builder.get_pointer_field(0).get_struct_list(::schema_capnp::node::STRUCT_SIZE, ::std::ptr::null()))
     }
     #[inline]
-    pub fn set_nodes(&self, value : struct_list::Reader<'a,::schema_capnp::node::Reader<'a>>) {
+    pub fn set_nodes(&mut self, value : struct_list::Reader<'a,::schema_capnp::node::Reader<'a>>) {
       self.builder.get_pointer_field(0).set_list(&value.reader)
     }
     #[inline]
-    pub fn init_nodes(&self, size : u32) -> struct_list::Builder<'a,::schema_capnp::node::Builder<'a>> {
+    pub fn init_nodes(&mut self, size : u32) -> struct_list::Builder<'a,::schema_capnp::node::Builder<'a>> {
       struct_list::Builder::<'a, ::schema_capnp::node::Builder<'a>>::new(
         self.builder.get_pointer_field(0).init_struct_list(size, ::schema_capnp::node::STRUCT_SIZE))
     }
@@ -2933,11 +2933,11 @@ pub mod code_generator_request {
       struct_list::Builder::new(self.builder.get_pointer_field(1).get_struct_list(::schema_capnp::code_generator_request::requested_file::STRUCT_SIZE, ::std::ptr::null()))
     }
     #[inline]
-    pub fn set_requested_files(&self, value : struct_list::Reader<'a,::schema_capnp::code_generator_request::requested_file::Reader<'a>>) {
+    pub fn set_requested_files(&mut self, value : struct_list::Reader<'a,::schema_capnp::code_generator_request::requested_file::Reader<'a>>) {
       self.builder.get_pointer_field(1).set_list(&value.reader)
     }
     #[inline]
-    pub fn init_requested_files(&self, size : u32) -> struct_list::Builder<'a,::schema_capnp::code_generator_request::requested_file::Builder<'a>> {
+    pub fn init_requested_files(&mut self, size : u32) -> struct_list::Builder<'a,::schema_capnp::code_generator_request::requested_file::Builder<'a>> {
       struct_list::Builder::<'a, ::schema_capnp::code_generator_request::requested_file::Builder<'a>>::new(
         self.builder.get_pointer_field(1).init_struct_list(size, ::schema_capnp::code_generator_request::requested_file::STRUCT_SIZE))
     }
@@ -3020,7 +3020,7 @@ pub mod code_generator_request {
         self.builder.get_data_field::<u64>(0)
       }
       #[inline]
-      pub fn set_id(&self, value : u64) {
+      pub fn set_id(&mut self, value : u64) {
         self.builder.set_data_field::<u64>(0, value);
       }
       #[inline]
@@ -3028,11 +3028,11 @@ pub mod code_generator_request {
         self.builder.get_pointer_field(0).get_text(::std::ptr::null(), 0)
       }
       #[inline]
-      pub fn set_filename(&self, value : text::Reader) {
+      pub fn set_filename(&mut self, value : text::Reader) {
         self.builder.get_pointer_field(0).set_text(value);
       }
       #[inline]
-      pub fn init_filename(&self, size : u32) -> text::Builder<'a> {
+      pub fn init_filename(&mut self, size : u32) -> text::Builder<'a> {
         self.builder.get_pointer_field(0).init_text(size)
       }
       pub fn has_filename(&self) -> bool {
@@ -3043,11 +3043,11 @@ pub mod code_generator_request {
         struct_list::Builder::new(self.builder.get_pointer_field(1).get_struct_list(::schema_capnp::code_generator_request::requested_file::import::STRUCT_SIZE, ::std::ptr::null()))
       }
       #[inline]
-      pub fn set_imports(&self, value : struct_list::Reader<'a,::schema_capnp::code_generator_request::requested_file::import::Reader<'a>>) {
+      pub fn set_imports(&mut self, value : struct_list::Reader<'a,::schema_capnp::code_generator_request::requested_file::import::Reader<'a>>) {
         self.builder.get_pointer_field(1).set_list(&value.reader)
       }
       #[inline]
-      pub fn init_imports(&self, size : u32) -> struct_list::Builder<'a,::schema_capnp::code_generator_request::requested_file::import::Builder<'a>> {
+      pub fn init_imports(&mut self, size : u32) -> struct_list::Builder<'a,::schema_capnp::code_generator_request::requested_file::import::Builder<'a>> {
         struct_list::Builder::<'a, ::schema_capnp::code_generator_request::requested_file::import::Builder<'a>>::new(
           self.builder.get_pointer_field(1).init_struct_list(size, ::schema_capnp::code_generator_request::requested_file::import::STRUCT_SIZE))
       }
@@ -3123,7 +3123,7 @@ pub mod code_generator_request {
           self.builder.get_data_field::<u64>(0)
         }
         #[inline]
-        pub fn set_id(&self, value : u64) {
+        pub fn set_id(&mut self, value : u64) {
           self.builder.set_data_field::<u64>(0, value);
         }
         #[inline]
@@ -3131,11 +3131,11 @@ pub mod code_generator_request {
           self.builder.get_pointer_field(0).get_text(::std::ptr::null(), 0)
         }
         #[inline]
-        pub fn set_name(&self, value : text::Reader) {
+        pub fn set_name(&mut self, value : text::Reader) {
           self.builder.get_pointer_field(0).set_text(value);
         }
         #[inline]
-        pub fn init_name(&self, size : u32) -> text::Builder<'a> {
+        pub fn init_name(&mut self, size : u32) -> text::Builder<'a> {
           self.builder.get_pointer_field(0).init_text(size)
         }
         pub fn has_name(&self) -> bool {


### PR DESCRIPTION
This changes the mutation methods to take a `&mut self`. I think I got everything, but one edge case I couldn't figure out was how to deal with the list `.get()` method. It feels like it should be returning a `&T` or a `&mut T`, but right now it's by value that contains a `'a` type.
