### PR TITLE
Avoid leaking internal pointers with 'static lifetimes

### DIFF
--- a/src/capnp/message.rs
+++ b/src/capnp/message.rs
@@ -147,13 +147,13 @@ impl BuilderOptions {
 }
 
 
-pub trait MessageBuilder {
-    fn mut_arena<'a>(&'a mut self) -> &'a mut BuilderArena;
-    fn arena<'a>(&'a self) -> &'a BuilderArena;
+pub trait MessageBuilder<'a> {
+    fn mut_arena(&mut self) -> &mut BuilderArena;
+    fn arena(&self) -> &BuilderArena;
 
 
     // XXX is there a way to make this private?
-    fn get_root_internal(&mut self) -> any_pointer::Builder<'static> {
+    fn get_root_internal(&mut self) -> any_pointer::Builder<'a> {
         let root_segment = &mut self.mut_arena().segment0 as *mut SegmentBuilder;
 
         if self.arena().segment0.current_size() == 0 {
@@ -175,15 +175,15 @@ pub trait MessageBuilder {
 
     }
 
-    fn init_root<T : FromStructBuilder<'static> + HasStructSize>(&mut self) -> T {
+    fn init_root<T : FromStructBuilder<'a> + HasStructSize>(&mut self) -> T {
         self.get_root_internal().init_as_struct()
     }
 
-    fn get_root<T : FromStructBuilder<'static> + HasStructSize>(&mut self) -> T {
+    fn get_root<T : FromStructBuilder<'a> + HasStructSize>(&mut self) -> T {
         self.get_root_internal().get_as_struct()
     }
 
-    fn set_root<'a, T : layout::ToStructReader<'a>>(&mut self, value : &T) {
+    fn set_root<T : layout::ToStructReader<'a>>(&mut self, value : &T) {
         self.get_root_internal().set_as_struct(value);
     }
 
@@ -220,11 +220,11 @@ impl MallocMessageBuilder {
 
 }
 
-impl MessageBuilder for MallocMessageBuilder {
-    fn mut_arena<'a>(&'a mut self) -> &'a mut BuilderArena {
+impl <'a> MessageBuilder<'a> for MallocMessageBuilder {
+    fn mut_arena(&mut self) -> &mut BuilderArena {
         &mut *self.arena
     }
-    fn arena<'a>(&'a self) -> &'a BuilderArena {
+    fn arena(&self) -> &BuilderArena {
         & *self.arena
     }
 }
@@ -266,11 +266,11 @@ impl <'a> ScratchSpaceMallocMessageBuilder<'a> {
 
 }
 
-impl <'a> MessageBuilder for ScratchSpaceMallocMessageBuilder<'a> {
-    fn mut_arena<'a>(&'a mut self) -> &'a mut BuilderArena {
+impl <'a> MessageBuilder<'a> for ScratchSpaceMallocMessageBuilder<'a> {
+    fn mut_arena(&mut self) -> &mut BuilderArena {
         &mut *self.arena
     }
-    fn arena<'a>(&'a self) -> &'a BuilderArena {
+    fn arena(&self) -> &BuilderArena {
         & *self.arena
     }
 }

--- a/src/capnp/serialize.rs
+++ b/src/capnp/serialize.rs
@@ -130,7 +130,7 @@ pub fn new_reader<U : std::io::Reader>(input_stream : &mut U,
 }
 
 
-pub fn write_message<T : std::io::Writer, U : MessageBuilder>(
+pub fn write_message<'a, T : std::io::Writer, U : MessageBuilder<'a>>(
     output_stream : &mut T,
     message : &U) -> std::io::IoResult<()> {
 

--- a/src/capnp/serialize_packed.rs
+++ b/src/capnp/serialize_packed.rs
@@ -349,14 +349,14 @@ impl <'a, W : io::BufferedOutputStream> std::io::Writer for PackedOutputStream<'
    fn flush(&mut self) -> std::io::IoResult<()> { self.inner.flush() }
 }
 
-pub fn write_packed_message<T:io::BufferedOutputStream,U:MessageBuilder>(
+pub fn write_packed_message<'a, T: io::BufferedOutputStream, U: MessageBuilder<'a>>(
     output : &mut T, message : &U) -> std::io::IoResult<()> {
     let mut packed_output_stream = PackedOutputStream {inner : output};
     serialize::write_message(&mut packed_output_stream, message)
 }
 
 
-pub fn write_packed_message_unbuffered<T:std::io::Writer,U:MessageBuilder>(
+pub fn write_packed_message_unbuffered<'a, T: std::io::Writer, U: MessageBuilder<'a>>(
     output : &mut T, message : &U) -> std::io::IoResult<()> {
     let mut buffered = io::BufferedOutputStreamWrapper::new(output);
     try!(write_packed_message(&mut buffered, message));


### PR DESCRIPTION
the `get_root` methods were tripping over the bug https://github.com/rust-lang/rust/issues/13853, which is unable to handle a method like `fn foo<'a, T: Bar<'a>>(...)`. This PR avoids that bug by moving the lifetime onto the trait.
