### PR TITLE
Update Calculator RPC example to use Tokio

### DIFF
--- a/capnp-rpc/examples/calculator/Cargo.toml
+++ b/capnp-rpc/examples/calculator/Cargo.toml
@@ -16,8 +16,7 @@ capnpc = { path = "../../../capnpc" }
 [dependencies]
 capnp = { path = "../../../capnp" }
 futures = "0.1"
-tokio-core = "0.1"
-tokio-io = "0.1"
+tokio = "0.1"
 
 [dependencies.capnp-rpc]
 path = "../.."

--- a/capnp-rpc/examples/calculator/client.rs
+++ b/capnp-rpc/examples/calculator/client.rs
@@ -60,9 +60,9 @@ fn try_main(args: Vec<String>) -> Result<(), ::capnp::Error> {
 
     let mut runtime = ::tokio::runtime::current_thread::Runtime::new().unwrap();
 
-    let addr = try!(args[2].to_socket_addrs()).next().expect("could not parse address");
+    let addr = args[2].to_socket_addrs()?.next().expect("could not parse address");
     let stream = runtime.block_on(::tokio::net::TcpStream::connect(&addr)).unwrap();
-    try!(stream.set_nodelay(true));
+    stream.set_nodelay(true)?;
     let (reader, writer) = stream.split();
 
     let network =
@@ -89,10 +89,10 @@ fn try_main(args: Vec<String>) -> Result<(), ::capnp::Error> {
         request.get().init_expression().set_literal(123.0);
         let value = request.send().pipeline.get_value();
         let request = value.read_request();
-        try!(runtime.block_on(request.send().promise.and_then(|response| {
+        runtime.block_on(request.send().promise.and_then(|response| {
             assert_eq!(pry!(response.get()).get_value(), 123.0);
             Promise::ok(())
-        })));
+        }))?;
         println!("PASS");
     }
 
@@ -142,8 +142,8 @@ fn try_main(args: Vec<String>) -> Result<(), ::capnp::Error> {
         let eval_promise = request.send();
         let read_promise = eval_promise.pipeline.get_value().read_request().send();
 
-        let response = try!(runtime.block_on(read_promise.promise));
-        assert_eq!(try!(response.get()).get_value(), 101.0);
+        let response = runtime.block_on(read_promise.promise)?;
+        assert_eq!(response.get()?.get_value(), 101.0);
 
         println!("PASS");
     }
@@ -210,8 +210,8 @@ fn try_main(args: Vec<String>) -> Result<(), ::capnp::Error> {
         let add5_promise = add5_request.send().pipeline.get_value().read_request().send();
 
         // Now wait for the results.
-        assert!(try!(try!(runtime.block_on(add3_promise.promise)).get()).get_value() == 27.0);
-        assert!(try!(try!(runtime.block_on(add5_promise.promise)).get()).get_value() == 29.0);
+        assert!(runtime.block_on(add3_promise.promise)?.get()?.get_value() == 27.0);
+        assert!(runtime.block_on(add5_promise.promise)?.get()?.get_value() == 29.0);
 
         println!("PASS")
     }
@@ -306,8 +306,8 @@ fn try_main(args: Vec<String>) -> Result<(), ::capnp::Error> {
         }
         let g_eval_promise = g_eval_request.send().pipeline.get_value().read_request().send();
 
-        assert!(try!(try!(runtime.block_on(f_eval_promise.promise)).get()).get_value() == 1234.0);
-        assert!(try!(try!(runtime.block_on(g_eval_promise.promise)).get()).get_value() == 4244.0);
+        assert!(runtime.block_on(f_eval_promise.promise)?.get()?.get_value() == 1234.0);
+        assert!(runtime.block_on(g_eval_promise.promise)?.get()?.get_value() == 4244.0);
 
         println!("PASS")
     }
@@ -352,7 +352,7 @@ fn try_main(args: Vec<String>) -> Result<(), ::capnp::Error> {
 
         let response_promise = request.send().pipeline.get_value().read_request().send();
 
-        assert!(try!(try!(runtime.block_on(response_promise.promise)).get()).get_value() == 512.0);
+        assert!(runtime.block_on(response_promise.promise)?.get()?.get_value() == 512.0);
 
         println!("PASS");
     }

--- a/capnp-rpc/examples/calculator/client.rs
+++ b/capnp-rpc/examples/calculator/client.rs
@@ -24,7 +24,7 @@ use calculator_capnp::calculator;
 use capnp::capability::Promise;
 
 use futures::Future;
-use tokio_io::{AsyncRead};
+use tokio::io::{AsyncRead};
 
 #[derive(Clone, Copy)]
 pub struct PowerFunction;
@@ -58,11 +58,10 @@ pub fn main() {
 fn try_main(args: Vec<String>) -> Result<(), ::capnp::Error> {
     use std::net::ToSocketAddrs;
 
-    let mut core = try!(::tokio_core::reactor::Core::new());
-    let handle = core.handle();
+    let mut runtime = ::tokio::runtime::current_thread::Runtime::new().unwrap();
 
     let addr = try!(args[2].to_socket_addrs()).next().expect("could not parse address");
-    let stream = core.run(::tokio_core::net::TcpStream::connect(&addr, &handle)).unwrap();
+    let stream = runtime.block_on(::tokio::net::TcpStream::connect(&addr)).unwrap();
     try!(stream.set_nodelay(true));
     let (reader, writer) = stream.split();
 
@@ -72,7 +71,7 @@ fn try_main(args: Vec<String>) -> Result<(), ::capnp::Error> {
                                            Default::default()));
     let mut rpc_system = RpcSystem::new(network, None);
     let calculator: calculator::Client = rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
-    handle.spawn(rpc_system.map_err(|_e| ()));
+    runtime.spawn(rpc_system.map_err(|_e| ()));
 
     {
         // Make a request that just evaluates the literal value 123.
@@ -90,7 +89,7 @@ fn try_main(args: Vec<String>) -> Result<(), ::capnp::Error> {
         request.get().init_expression().set_literal(123.0);
         let value = request.send().pipeline.get_value();
         let request = value.read_request();
-        try!(core.run(request.send().promise.and_then(|response| {
+        try!(runtime.block_on(request.send().promise.and_then(|response| {
             assert_eq!(pry!(response.get()).get_value(), 123.0);
             Promise::ok(())
         })));
@@ -143,7 +142,7 @@ fn try_main(args: Vec<String>) -> Result<(), ::capnp::Error> {
         let eval_promise = request.send();
         let read_promise = eval_promise.pipeline.get_value().read_request().send();
 
-        let response = try!(core.run(read_promise.promise));
+        let response = try!(runtime.block_on(read_promise.promise));
         assert_eq!(try!(response.get()).get_value(), 101.0);
 
         println!("PASS");
@@ -211,8 +210,8 @@ fn try_main(args: Vec<String>) -> Result<(), ::capnp::Error> {
         let add5_promise = add5_request.send().pipeline.get_value().read_request().send();
 
         // Now wait for the results.
-        assert!(try!(try!(core.run(add3_promise.promise)).get()).get_value() == 27.0);
-        assert!(try!(try!(core.run(add5_promise.promise)).get()).get_value() == 29.0);
+        assert!(try!(try!(runtime.block_on(add3_promise.promise)).get()).get_value() == 27.0);
+        assert!(try!(try!(runtime.block_on(add5_promise.promise)).get()).get_value() == 29.0);
 
         println!("PASS")
     }
@@ -307,8 +306,8 @@ fn try_main(args: Vec<String>) -> Result<(), ::capnp::Error> {
         }
         let g_eval_promise = g_eval_request.send().pipeline.get_value().read_request().send();
 
-        assert!(try!(try!(core.run(f_eval_promise.promise)).get()).get_value() == 1234.0);
-        assert!(try!(try!(core.run(g_eval_promise.promise)).get()).get_value() == 4244.0);
+        assert!(try!(try!(runtime.block_on(f_eval_promise.promise)).get()).get_value() == 1234.0);
+        assert!(try!(try!(runtime.block_on(g_eval_promise.promise)).get()).get_value() == 4244.0);
 
         println!("PASS")
     }
@@ -353,7 +352,7 @@ fn try_main(args: Vec<String>) -> Result<(), ::capnp::Error> {
 
         let response_promise = request.send().pipeline.get_value().read_request().send();
 
-        assert!(try!(try!(core.run(response_promise.promise)).get()).get_value() == 512.0);
+        assert!(try!(try!(runtime.block_on(response_promise.promise)).get()).get_value() == 512.0);
 
         println!("PASS");
     }

--- a/capnp-rpc/examples/calculator/main.rs
+++ b/capnp-rpc/examples/calculator/main.rs
@@ -22,8 +22,7 @@
 extern crate capnp;
 #[macro_use] extern crate capnp_rpc;
 extern crate futures;
-extern crate tokio_core;
-extern crate tokio_io;
+extern crate tokio;
 
 pub mod calculator_capnp {
   include!(concat!(env!("OUT_DIR"), "/calculator_capnp.rs"));

--- a/capnp-rpc/examples/calculator/server.rs
+++ b/capnp-rpc/examples/calculator/server.rs
@@ -62,7 +62,7 @@ fn evaluate_impl(expression: calculator::expression::Reader,
         },
         calculator::expression::PreviousResult(p) => {
             Promise::from_future(pry!(p).read_request().send().promise.and_then(|v| {
-                Ok(try!(v.get()).get_value())
+                Ok(v.get()?.get_value())
             }))
         }
         calculator::expression::Parameter(p) => {
@@ -91,7 +91,7 @@ fn evaluate_impl(expression: calculator::expression::Reader,
                     }
                 }
                 request.send().promise.and_then(|result| {
-                    Ok(try!(result.get()).get_value())
+                    Ok(result.get()?.get_value())
                 })
             }))
         }
@@ -109,7 +109,7 @@ impl FunctionImpl {
             param_count: param_count,
             body: ::capnp_rpc::ImbuedMessageBuilder::new(::capnp::message::HeapAllocator::new()),
         };
-        try!(result.body.set_root(body));
+        result.body.set_root(body)?;
         Ok(result)
     }
 }
@@ -213,7 +213,7 @@ pub fn main() {
         calculator::ToClient::new(CalculatorImpl).from_server::<::capnp_rpc::Server>();
 
     let done = socket.incoming().for_each(move |socket| {
-        try!(socket.set_nodelay(true));
+        socket.set_nodelay(true)?;
         let (reader, writer) = socket.split();
 
         let network =

--- a/capnp-rpc/examples/calculator/test_client_and_server.bash
+++ b/capnp-rpc/examples/calculator/test_client_and_server.bash
@@ -3,11 +3,11 @@
 set -x
 set -e
 
-cargo build
-./target/debug/calculator server 127.0.0.1:6569 &
+cargo build --package calculator
+../../../target/debug/calculator server 127.0.0.1:6569 &
 SERVER=$!
 sleep 1
-./target/debug/calculator client 127.0.0.1:6569
+../../../target/debug/calculator client 127.0.0.1:6569
 
 kill $SERVER
 


### PR DESCRIPTION
This just updates the Calculator example to use `tokio` instead of `tokio-core`, since the latter is now deprecated.