### PR TITLE
More clippy linter improvements

### DIFF
--- a/capnp/src/any_pointer.rs
+++ b/capnp/src/any_pointer.rs
@@ -157,7 +157,7 @@ impl <'a> Builder<'a> {
     }
 
     #[inline]
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a> {
         self.into_reader()
     }

--- a/capnp/src/capability_list.rs
+++ b/capnp/src/capability_list.rs
@@ -101,7 +101,7 @@ impl <'a, T> Builder<'a, T> where T: FromClientHook {
 
     pub fn len(&self) -> u32 { self.builder.len() }
 
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a, T> {
         self.into_reader()
     }

--- a/capnp/src/data_list.rs
+++ b/capnp/src/data_list.rs
@@ -81,7 +81,7 @@ impl <'a> Builder<'a> {
 
     pub fn len(&self) -> u32 { self.builder.len() }
 
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a> {
         self.into_reader()
     }

--- a/capnp/src/enum_list.rs
+++ b/capnp/src/enum_list.rs
@@ -90,7 +90,7 @@ impl <'a, T : ToU16 + FromU16> Builder<'a, T> {
 
     pub fn len(&self) -> u32 { self.builder.len() }
 
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a, T> {
         self.into_reader()
     }

--- a/capnp/src/list_list.rs
+++ b/capnp/src/list_list.rs
@@ -92,7 +92,7 @@ impl <'a, T> Builder<'a, T> where T: for<'b> ::traits::Owned<'b> {
 
     pub fn len(&self) -> u32 { self.builder.len() }
 
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a, T> {
         self.into_reader()
     }

--- a/capnp/src/primitive_list.rs
+++ b/capnp/src/primitive_list.rs
@@ -89,7 +89,7 @@ impl <'a, T> Builder<'a, T> where T: PrimitiveElement {
 
     pub fn len(&self) -> u32 { self.builder.len() }
 
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a, T> {
         self.into_reader()
     }

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -2192,7 +2192,7 @@ pub enum CapTableBuilder {
 }
 
 impl CapTableBuilder {
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> CapTableReader {
         self.into_reader()
     }
@@ -2610,7 +2610,7 @@ impl <'a> PointerBuilder<'a> {
         }
     }
 
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> PointerReader<'a> {
         self.into_reader()
     }
@@ -2803,7 +2803,7 @@ pub struct StructBuilder<'a> {
 }
 
 impl <'a> StructBuilder<'a> {
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> StructReader<'a> {
         self.into_reader()
     }
@@ -3102,7 +3102,7 @@ impl <'a> ListBuilder<'a> {
         }
     }
 
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> ListReader<'a> {
         self.into_reader()
     }

--- a/capnp/src/struct_list.rs
+++ b/capnp/src/struct_list.rs
@@ -102,7 +102,7 @@ impl <'a, T> Builder<'a, T> where T: for<'b> ::traits::OwnedStruct<'b> {
 
     pub fn len(&self) -> u32 { self.builder.len() }
 
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a, T> {
         self.into_reader()
     }

--- a/capnp/src/text_list.rs
+++ b/capnp/src/text_list.rs
@@ -86,7 +86,7 @@ impl <'a> Builder<'a> {
         self.builder.borrow().get_pointer_element(index).set_text(value);
     }
 
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a> {
         self.into_reader()
     }

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1346,6 +1346,7 @@ fn generate_node(gen: &GeneratorContext,
                 Indent(
                     Box::new(Branch(vec![
                         Line("#[deprecated(since=\"0.9.2\", note=\"use into_reader()\")]".to_string()),
+                        Line("#[allow(clippy::wrong_self_convention)]".to_string()),
                         Line(format!("pub fn as_reader(self) -> Reader<'a,{}> {{", params.params)),
                         Indent(Box::new(Line("self.into_reader()".to_string()))),
                         Line("}".to_string()),
@@ -1666,6 +1667,7 @@ fn generate_node(gen: &GeneratorContext,
                     }),
                     Indent(Box::new(Branch( vec!(
                         Line("#[deprecated(since=\"0.9.2\", note=\"use into_client()\")]".to_string()),
+                        Line("#[allow(clippy::wrong_self_convention)]".to_string()),
                         Line(format!("pub fn from_server<_T: ::capnp::private::capability::ServerHook>(self) -> Client{} {{", bracketed_params)),
                         Indent(
                             Box::new(Line("self.into_client::<_T>()".to_string()))),

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1371,7 +1371,6 @@ fn generate_node(gen: &GeneratorContext,
                 Indent(
                     Box::new(Branch(vec![
                         Line("#[deprecated(since=\"0.9.2\", note=\"use into_reader()\")]".to_string()),
-                        Line("#[allow(clippy::wrong_self_convention)]".to_string()),
                         Line(format!("pub fn as_reader(self) -> Reader<'a,{}> {{", params.params)),
                         Indent(Box::new(Line("self.into_reader()".to_string()))),
                         Line("}".to_string()),
@@ -1692,7 +1691,6 @@ fn generate_node(gen: &GeneratorContext,
                     }),
                     Indent(Box::new(Branch( vec!(
                         Line("#[deprecated(since=\"0.9.2\", note=\"use into_client()\")]".to_string()),
-                        Line("#[allow(clippy::wrong_self_convention)]".to_string()),
                         Line(format!("pub fn from_server<_T: ::capnp::private::capability::ServerHook>(self) -> Client{} {{", bracketed_params)),
                         Indent(
                             Box::new(Line("self.into_client::<_T>()".to_string()))),

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1345,7 +1345,7 @@ fn generate_node(gen: &GeneratorContext,
                 Line(format!("impl <'a,{0}> Builder<'a,{0}> {1} {{", params.params, params.where_clause)),
                 Indent(
                     Box::new(Branch(vec![
-                        Line("#[deprecated(since=\"capnpc-v0.9.2\", note=\"use into_reader()\")]".to_string()),
+                        Line("#[deprecated(since=\"0.9.2\", note=\"use into_reader()\")]".to_string()),
                         Line(format!("pub fn as_reader(self) -> Reader<'a,{}> {{", params.params)),
                         Indent(Box::new(Line("self.into_reader()".to_string()))),
                         Line("}".to_string()),
@@ -1665,7 +1665,7 @@ fn generate_node(gen: &GeneratorContext,
                         ))
                     }),
                     Indent(Box::new(Branch( vec!(
-                        Line("#[deprecated(since=\"capnpc-v0.9.2\", note=\"use into_client()\")]".to_string()),
+                        Line("#[deprecated(since=\"0.9.2\", note=\"use into_client()\")]".to_string()),
                         Line(format!("pub fn from_server<_T: ::capnp::private::capability::ServerHook>(self) -> Client{} {{", bracketed_params)),
                         Indent(
                             Box::new(Line("self.into_client::<_T>()".to_string()))),

--- a/capnpc/src/schema_capnp.rs
+++ b/capnpc/src/schema_capnp.rs
@@ -162,7 +162,7 @@ pub mod node {
   }
 
   impl <'a,> Builder<'a,>  {
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a,> {
       self.into_reader()
     }
@@ -471,7 +471,7 @@ pub mod node {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -608,7 +608,7 @@ pub mod node {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -760,7 +760,7 @@ pub mod node {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -915,7 +915,7 @@ pub mod node {
       }
 
       impl <'a,> Builder<'a,>  {
-        #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+        #[deprecated(since="0.9.2", note="use into_reader()")]
         pub fn as_reader(self) -> Reader<'a,> {
           self.into_reader()
         }
@@ -1073,7 +1073,7 @@ pub mod node {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -1254,7 +1254,7 @@ pub mod node {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -1394,7 +1394,7 @@ pub mod node {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -1549,7 +1549,7 @@ pub mod node {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -1751,7 +1751,7 @@ pub mod node {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -2021,7 +2021,7 @@ pub mod field {
   }
 
   impl <'a,> Builder<'a,>  {
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a,> {
       self.into_reader()
     }
@@ -2250,7 +2250,7 @@ pub mod field {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -2417,7 +2417,7 @@ pub mod field {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -2554,7 +2554,7 @@ pub mod field {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -2715,7 +2715,7 @@ pub mod enumerant {
   }
 
   impl <'a,> Builder<'a,>  {
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a,> {
       self.into_reader()
     }
@@ -2875,7 +2875,7 @@ pub mod superclass {
   }
 
   impl <'a,> Builder<'a,>  {
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a,> {
       self.into_reader()
     }
@@ -3059,7 +3059,7 @@ pub mod method {
   }
 
   impl <'a,> Builder<'a,>  {
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a,> {
       self.into_reader()
     }
@@ -3378,7 +3378,7 @@ pub mod type_ {
   }
 
   impl <'a,> Builder<'a,>  {
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a,> {
       self.into_reader()
     }
@@ -3712,7 +3712,7 @@ pub mod type_ {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -3852,7 +3852,7 @@ pub mod type_ {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -4000,7 +4000,7 @@ pub mod type_ {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -4148,7 +4148,7 @@ pub mod type_ {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -4308,7 +4308,7 @@ pub mod type_ {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -4493,7 +4493,7 @@ pub mod type_ {
       }
 
       impl <'a,> Builder<'a,>  {
-        #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+        #[deprecated(since="0.9.2", note="use into_reader()")]
         pub fn as_reader(self) -> Reader<'a,> {
           self.into_reader()
         }
@@ -4662,7 +4662,7 @@ pub mod type_ {
       }
 
       impl <'a,> Builder<'a,>  {
-        #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+        #[deprecated(since="0.9.2", note="use into_reader()")]
         pub fn as_reader(self) -> Reader<'a,> {
           self.into_reader()
         }
@@ -4793,7 +4793,7 @@ pub mod type_ {
       }
 
       impl <'a,> Builder<'a,>  {
-        #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+        #[deprecated(since="0.9.2", note="use into_reader()")]
         pub fn as_reader(self) -> Reader<'a,> {
           self.into_reader()
         }
@@ -4921,7 +4921,7 @@ pub mod brand {
   }
 
   impl <'a,> Builder<'a,>  {
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a,> {
       self.into_reader()
     }
@@ -5072,7 +5072,7 @@ pub mod brand {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -5253,7 +5253,7 @@ pub mod brand {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -5528,7 +5528,7 @@ pub mod value {
   }
 
   impl <'a,> Builder<'a,>  {
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a,> {
       self.into_reader()
     }
@@ -5910,7 +5910,7 @@ pub mod annotation {
   }
 
   impl <'a,> Builder<'a,>  {
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a,> {
       self.into_reader()
     }
@@ -6114,7 +6114,7 @@ pub mod capnp_version {
   }
 
   impl <'a,> Builder<'a,>  {
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a,> {
       self.into_reader()
     }
@@ -6277,7 +6277,7 @@ pub mod code_generator_request {
   }
 
   impl <'a,> Builder<'a,>  {
-    #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+    #[deprecated(since="0.9.2", note="use into_reader()")]
     pub fn as_reader(self) -> Reader<'a,> {
       self.into_reader()
     }
@@ -6468,7 +6468,7 @@ pub mod code_generator_request {
     }
 
     impl <'a,> Builder<'a,>  {
-      #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+      #[deprecated(since="0.9.2", note="use into_reader()")]
       pub fn as_reader(self) -> Reader<'a,> {
         self.into_reader()
       }
@@ -6627,7 +6627,7 @@ pub mod code_generator_request {
       }
 
       impl <'a,> Builder<'a,>  {
-        #[deprecated(since="capnpc-v0.9.2", note="use into_reader()")]
+        #[deprecated(since="0.9.2", note="use into_reader()")]
         pub fn as_reader(self) -> Reader<'a,> {
           self.into_reader()
         }


### PR DESCRIPTION
This includes ~~3~~ 2 changes:

* ~~#113 deprecated methods that produced clippy warnings, but they still produce warnings. This adds ignores for those lints, restricted to the deprecated methods only.~~ Could not apply this, due to an issue with stable/beta: https://github.com/rust-lang/rust/issues/54406
* #113 introduces a new clippy warning, because the `since` field in the `deprecated` annotation should be a semver string. This fixes that.
* Removed cases of unneeded unit expressions: https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#unused_unit

These are all in separate commits, so I can cherry-pick and open a new PR if you'd like only a subset of these fixes.