### PR TITLE
Implemented set_with_caveats in struct_list

### DIFF
--- a/capnp/src/struct_list.rs
+++ b/capnp/src/struct_list.rs
@@ -23,8 +23,8 @@
 
 use std::marker::PhantomData;
 
-use private::layout::{ListReader, ListBuilder, PointerReader, PointerBuilder, InlineComposite};
-use traits::{FromPointerReader, FromPointerBuilder,
+use private::layout::{ListReader, ListBuilder, PointerReader, StructReader, PointerBuilder, InlineComposite};
+use traits::{FromPointerReader, FromPointerBuilder, 
              FromStructBuilder, FromStructReader, HasStructSize,
              IndexMove, ListIter};
 use Result;
@@ -114,8 +114,9 @@ impl <'a, T> Builder<'a, T> where T: for<'b> ::traits::OwnedStruct<'b> {
         }
     }
 
-    //        pub fn set_with_caveats(&self, index : uint, value : T) {
-    //        }
+    pub fn set_with_caveats(&self, index: u32, value: &StructReader, canonicalize: bool) -> Result<()> {
+        self.builder.get_struct_element(index).copy_content_from(value, canonicalize)
+    }
 }
 
 impl <'a, T> Builder<'a, T> where T: for<'b> ::traits::OwnedStruct<'b> {

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -676,7 +676,8 @@ fn generate_setter(gen: &GeneratorContext, discriminant_offset: u32,
                     initter_interior.push(
                         Line(format!("::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field({}), size)", offset)));
 
-                    match try!(try!(ot1.get_element_type()).which()) {
+                    let element_type = try!(ot1.get_element_type());
+                    let (reader_type, builder_type) = match try!(element_type.which()) {
                         type_::List(_) => {
                             setter_generic_param = "<'b>".to_string();
                             (Some(try!(try!(reg_field.get_type()).type_string(gen, Leaf::Reader("'b")))),
@@ -685,7 +686,20 @@ fn generate_setter(gen: &GeneratorContext, discriminant_offset: u32,
                         _ =>
                             (Some(try!(try!(reg_field.get_type()).type_string(gen, Leaf::Reader("'a")))),
                              Some(try!(try!(reg_field.get_type()).type_string(gen, Leaf::Builder("'a")))))
+                    };
+                    if let type_::Struct(_) = try!(element_type.which()) {
+                        let reader_type = try!(element_type.type_string(gen, Leaf::Reader("'a")));
+                        let return_type = "-> ::capnp::Result<()>";
+                        result.push(Line("#[inline]".to_string()));
+                        result.push(Line(format!("pub fn set_{}_element_with_caveats{}(&mut self, idx: u32, {}: {}, canonicalize: bool) {} {{",
+                                                styled_name, setter_generic_param, setter_param,
+                                                reader_type, return_type)));
+                        let getter = format!("::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field({}))?", offset);
+                        result.push(Indent(Box::new(Line(format!("let element: {} = {};", builder_type.as_ref().unwrap(), getter)))));
+                        result.push(Indent(Box::new(Line(format!("element.set_with_caveats(idx, &value.reader, canonicalize)")))));
+                        result.push(Line("}".to_string()));
                     }
+                    (reader_type, builder_type)
                 }
                 type_::Enum(e) => {
                     let id = e.get_type_id();
@@ -1261,12 +1275,12 @@ fn generate_node(gen: &GeneratorContext,
                 BlankLine,
                 Line("#[derive(Clone, Copy)]".to_string()),
                 (if !is_generic {
-                    Line("pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }".to_string())
+                    Line("pub struct Reader<'a> { pub(crate) reader: ::capnp::private::layout::StructReader<'a> }".to_string())
                 } else {
                     Branch(vec!(
                         Line(format!("pub struct Reader<'a,{}> {} {{", params.params, params.where_clause)),
                         Indent(Box::new(Branch(vec!(
-                            Line("reader: ::capnp::private::layout::StructReader<'a>,".to_string()),
+                            Line("pub(crate) reader: ::capnp::private::layout::StructReader<'a>,".to_string()),
                             Line(format!("_phantom: ::std::marker::PhantomData<({})>", params.params)),
                         )))),
                         Line("}".to_string())

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -140,9 +140,29 @@ mod tests {
             struct_list.get(0).init_uint8_list(1).set(0, 5u8);
         }
 
+        let mut message_copy = message::Builder::new_default();
+
+        let mut struct_list_copy = message_copy.init_root::<test_struct_list::Builder>();
+
         {
             let reader = test_struct_list.into_reader();
             assert_eq!(reader.get_struct_list().unwrap().get(0).get_uint8_list().unwrap().get(0), 5u8);
+
+            {
+                let other_list = reader.get_struct_list().unwrap();
+                struct_list_copy.reborrow().init_struct_list(other_list.len());
+                {
+                    for (idx, value) in other_list.iter().enumerate() {
+                        struct_list_copy.set_struct_list_element_with_caveats(idx as u32, value, false).unwrap();
+                    }
+                }
+            }
+        }
+
+        {
+            let mut struct_list = struct_list_copy.reborrow().get_struct_list().unwrap();
+            assert_eq!(4, struct_list.len());
+            assert_eq!(5u8, struct_list.reborrow().get(0).get_uint8_list().unwrap().get(0));
         }
     }
 


### PR DESCRIPTION
I ran into an issue where I wanted to accumulate structs from other messages and put them into a struct_list in a fresh message. Unfortunately, struct_list didn't have an equivalent to the C++ setWithCaveats, so I implemented it in this PR with StructBuilder::copy_content_from and struct_list::Builder::set_with_caveats.

I couldn't figure out how to actually implement struct_list::Builder::set_with_caveats for OwnedStruct 
type parameters though, because I needed a StructReader but couldn't get one from OwnedStruct::Reader. So this PR has some horrible codegen hacks to get at the StructReader in generated code, and exposes this with set_*_element_with_caveats. I'd love some feedback on how to solve this in a prettier way.