### PR TITLE
Added output path option for build scripts

### DIFF
--- a/capnpc/src/lib.rs
+++ b/capnpc/src/lib.rs
@@ -74,16 +74,22 @@ use std::path::{Path, PathBuf};
 #[derive(Copy, Clone)]
 pub enum RustEdition {
     Rust2015,
-    Rust2018
+    Rust2018,
 }
 
-fn run_command(mut command: ::std::process::Command, edition: RustEdition) -> ::capnp::Result<()> {
+fn run_command(
+    mut command: ::std::process::Command,
+    edition: RustEdition,
+    path: &PathBuf,
+) -> ::capnp::Result<()> {
     let mut p = command.spawn()?;
-    ::codegen::generate_code(p.stdout.take().unwrap(),
-                         ::std::path::Path::new(&::std::env::var("OUT_DIR").unwrap()), edition)?;
+    ::codegen::generate_code(p.stdout.take().unwrap(), path.as_path(), edition)?;
     let exit_status = p.wait()?;
     if !exit_status.success() {
-        Err(::capnp::Error::failed(format!("Non-success exit status: {}", exit_status)))
+        Err(::capnp::Error::failed(format!(
+            "Non-success exit status: {}",
+            exit_status
+        )))
     } else {
         Ok(())
     }
@@ -95,6 +101,7 @@ pub struct CompilerCommand {
     src_prefixes: Vec<PathBuf>,
     import_paths: Vec<PathBuf>,
     no_standard_import: bool,
+    output_path: PathBuf,
     rust_edition: RustEdition,
 }
 
@@ -106,13 +113,15 @@ impl CompilerCommand {
             src_prefixes: Vec::new(),
             import_paths: Vec::new(),
             no_standard_import: false,
+            output_path: PathBuf::from(&::std::env::var("OUT_DIR").unwrap()),
             rust_edition: RustEdition::Rust2015,
         }
     }
 
     /// Adds a file to be compiled.
     pub fn file<'a, P>(&'a mut self, path: P) -> &'a mut CompilerCommand
-        where P: AsRef<Path>,
+    where
+        P: AsRef<Path>,
     {
         self.files.push(path.as_ref().to_path_buf());
         self
@@ -121,7 +130,8 @@ impl CompilerCommand {
     /// Adds a --src-prefix flag. For all files specified for compilation that start
     /// with `prefix`, removes the prefix when computing output filenames.
     pub fn src_prefix<'a, P>(&'a mut self, prefix: P) -> &'a mut CompilerCommand
-        where P: AsRef<Path>,
+    where
+        P: AsRef<Path>,
     {
         self.src_prefixes.push(prefix.as_ref().to_path_buf());
         self
@@ -130,7 +140,8 @@ impl CompilerCommand {
     /// Adds an --import_path flag. Adds `dir` to the list of directories searched
     /// for absolute imports.
     pub fn import_path<'a, P>(&'a mut self, dir: P) -> &'a mut CompilerCommand
-        where P: AsRef<Path>,
+    where
+        P: AsRef<Path>,
     {
         self.import_paths.push(dir.as_ref().to_path_buf());
         self
@@ -146,6 +157,15 @@ impl CompilerCommand {
     /// Sets the Rust edition of the generated code.
     pub fn edition(&mut self, rust_edition: RustEdition) -> &mut Self {
         self.rust_edition = rust_edition;
+        self
+    }
+
+    ///Sets the output directory of generated code. Default is OUT_DIR
+    pub fn output_path<'a, P>(&'a mut self, path: P) -> &'a mut CompilerCommand
+    where
+        P: AsRef<Path>,
+    {
+        self.output_path = path.as_ref().to_path_buf();
         self
     }
 
@@ -173,11 +193,13 @@ impl CompilerCommand {
         command.stdout(::std::process::Stdio::piped());
         command.stderr(::std::process::Stdio::inherit());
 
-        run_command(command, self.rust_edition).map_err(|error| {
+        run_command(command, self.rust_edition, &self.output_path).map_err(|error| {
             ::capnp::Error::failed(format!(
                 "Error while trying to execute `capnp compile`: {}.  \
                  Please verify that version 0.5.2 or higher of the capnp executable \
                  is installed on your system. See https://capnproto.org/install.html",
-                error))})
+                error
+            ))
+        })
     }
 }


### PR DESCRIPTION
While it is not particularly rusty - being able to specify the out directory of the compiled code is useful, particularly in a test environment. If it is not set, it defaults to the environment set OUT_DIR