### PR TITLE
Add support for BufWriter wrapper

### DIFF
--- a/capnp-futures/src/serialize.rs
+++ b/capnp-futures/src/serialize.rs
@@ -357,6 +357,7 @@ enum InnerWriteState {
         /// The byte offset into the next segment to write.
         idx: usize,
     },
+    Flush
 }
 
 impl InnerWriteState {
@@ -408,7 +409,23 @@ impl InnerWriteState {
                         }
                     }
 
-                    return Ok(Async::Ready(()))
+                    InnerWriteState::Flush
+                }
+                InnerWriteState::Flush => {
+                    match writer.flush(){
+                        Ok(_) => {
+                            return Ok(Async::Ready(()));
+                        },
+                        Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                            return Ok(Async::NotReady);
+                        }
+                        Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {
+                            InnerWriteState::Flush
+                        }
+                        Err(e) => {
+                            return Err(e);
+                        }
+                    }
                 }
             };
 

--- a/capnp-rpc/examples/calculator/client.rs
+++ b/capnp-rpc/examples/calculator/client.rs
@@ -66,7 +66,7 @@ fn try_main(args: Vec<String>) -> Result<(), ::capnp::Error> {
     let (reader, writer) = stream.split();
 
     let network =
-        Box::new(twoparty::VatNetwork::new(reader, writer,
+        Box::new(twoparty::VatNetwork::new(reader, std::io::BufWriter::new(writer),
                                            rpc_twoparty_capnp::Side::Client,
                                            Default::default()));
     let mut rpc_system = RpcSystem::new(network, None);

--- a/capnp-rpc/examples/calculator/server.rs
+++ b/capnp-rpc/examples/calculator/server.rs
@@ -217,7 +217,7 @@ pub fn main() {
         let (reader, writer) = socket.split();
 
         let network =
-            twoparty::VatNetwork::new(reader, writer,
+            twoparty::VatNetwork::new(reader, std::io::BufWriter::new(writer),
                                       rpc_twoparty_capnp::Side::Server, Default::default());
 
         let rpc_system = RpcSystem::new(Box::new(network), Some(calc.clone().client));


### PR DESCRIPTION
Enables usage of `std::io::BufWriter` to prevent message being
sent as separate packages.
Fixes https://github.com/capnproto/capnproto-rust/issues/93

Now `write_message` and `Transport` will flush (until success or error) after each message, 
allowing to write into buffered stream