### PR TITLE
Replace float transmutes with safe std functions.

### DIFF
--- a/capnp/src/private/endian.rs
+++ b/capnp/src/private/endian.rs
@@ -84,18 +84,18 @@ endian_impl!(i64, to_le);
 
 impl Endian for f32 {
     fn get(&self) -> f32 {
-        unsafe { mem::transmute(mem::transmute::<f32, u32>(*self).to_le()) }
+        f32::from_bits(self.to_bits().to_le())
     }
     fn set(&mut self, value : f32) {
-        *self = unsafe { mem::transmute(mem::transmute::<f32, u32>(value).to_le()) };
+        *self = f32::from_bits(value.to_bits().to_le());
     }
 }
 
 impl Endian for f64 {
     fn get(&self) -> f64 {
-        unsafe { mem::transmute(mem::transmute::<f64, u64>(*self).to_le()) }
+        f64::from_bits(self.to_bits().to_le())
     }
     fn set(&mut self, value : f64) {
-        *self = unsafe { mem::transmute(mem::transmute::<f64, u64>(value).to_le()) };
+        *self = f64::from_bits(value.to_bits().to_le());
     }
 }

--- a/capnp/src/private/mask.rs
+++ b/capnp/src/private/mask.rs
@@ -51,10 +51,7 @@ impl Mask for f32 {
     type T = u32;
     #[inline]
     fn mask(value: f32, mask: u32) -> f32 {
-        unsafe {
-            let v: u32 = mem::transmute(value);
-            mem::transmute(v ^ mask)
-        }
+        f32::from_bits(value.to_bits() ^ mask)
     }
 }
 
@@ -62,9 +59,6 @@ impl Mask for f64 {
     type T = u64;
     #[inline]
     fn mask(value: f64, mask: u64) -> f64 {
-        unsafe {
-            let v: u64 = mem::transmute(value);
-            mem::transmute(v ^ mask)
-        }
+        f64::from_bits(value.to_bits() ^ mask)
     }
 }

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -321,12 +321,12 @@ fn prim_default(value: &schema_capnp::value::Reader) -> ::capnp::Result<Option<S
         value::Float32(f) =>
             match f.classify() {
                 ::std::num::FpCategory::Zero => Ok(None),
-                _ => Ok(Some(format!("{}u32", unsafe {::std::mem::transmute::<f32, u32>(f)}.to_string())))
+                _ => Ok(Some(format!("{}u32", f.to_bits().to_string())))
             },
         value::Float64(f) =>
             match f.classify() {
                 ::std::num::FpCategory::Zero => Ok(None),
-                _ => Ok(Some(format!("{}u64", unsafe {::std::mem::transmute::<f64, u64>(f)}.to_string())))
+                _ => Ok(Some(format!("{}u64", f.to_bits().to_string())))
             },
         _ => Err(Error::failed("Non-primitive value found where primitive was expected.".to_string())),
     }
@@ -423,9 +423,9 @@ pub fn getter_text(gen: &GeneratorContext,
                 (type_::Uint32(()), value::Uint32(i)) => primitive_case(&*typ, member, offset, i, 0),
                 (type_::Uint64(()), value::Uint64(i)) => primitive_case(&*typ, member, offset, i, 0),
                 (type_::Float32(()), value::Float32(f)) =>
-                    primitive_case(&*typ, member, offset, unsafe { ::std::mem::transmute::<f32, u32>(f) }, 0),
+                    primitive_case(&*typ, member, offset, f.to_bits(), 0),
                 (type_::Float64(()), value::Float64(f)) =>
-                    primitive_case(&*typ, member, offset, unsafe { ::std::mem::transmute::<f64, u64>(f) }, 0),
+                    primitive_case(&*typ, member, offset, f.to_bits(), 0),
                 (type_::Enum(_), value::Enum(d)) => {
                     if d == 0 {
                         Line(format!("::capnp::traits::FromU16::from_u16(self.{}.get_data_field::<u16>({}))",


### PR DESCRIPTION
This particular usecase has been safely abstracted in these `std` functions: [f32::to_bits](https://doc.rust-lang.org/std/primitive.f32.html#method.to_bits), [f32::from_bits](https://doc.rust-lang.org/std/primitive.f32.html#method.from_bits), [f64::to_bits](https://doc.rust-lang.org/std/primitive.f64.html#method.to_bits), [f64::from_bits](https://doc.rust-lang.org/std/primitive.f64.html#method.from_bits). One less `unsafe` to worry about in code review!