### PR TITLE
Problem: capnp::traits::Owned trait requirement (capnpc)

### DIFF
--- a/capnpc/Cargo.toml
+++ b/capnpc/Cargo.toml
@@ -30,3 +30,5 @@ path = "src/capnpc-rust2018.rs"
 [dependencies]
 capnp = { version = "0.9.5", path = "../capnp" }
 
+[build-dependencies]
+rustc_version = "0.2"

--- a/capnpc/build.rs
+++ b/capnpc/build.rs
@@ -1,0 +1,9 @@
+extern crate rustc_version;
+use rustc_version::{version, Version};
+
+fn main() {
+
+    if version().unwrap() >= Version::parse("1.30.0").unwrap() {
+        println!("cargo:rustc-cfg=rustc_at_least_1_30");
+    }
+}

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1704,14 +1704,14 @@ fn generate_node(gen: &GeneratorContext,
                 Branch(vec!(
                     (if is_generic {
                         Branch(vec!(
-                            Line(format!("pub struct ToClient<U,{}> {{", params.params)),
+                            Line(format!("pub struct ToClient<U,{}> {} {{", params.params, params.where_clause)),
                             Indent(Box::new(Branch(vec!(
                                 Line("pub u: U,".to_string()),
                                 Line(format!("_phantom: ::std::marker::PhantomData<({})>", params.params))
                             )))),
                             Line("}".to_string()),
-                            Line(format!("impl <{0}, U: Server<{0}> + 'static> ToClient<U,{0}> {1} {{",
-                                         params.params, params.where_clause_with_send)),
+                            Line(format!("impl <{0}, U: Server<{0}> + 'static> ToClient<U,{0}> {1}, {2} {{",
+                                         params.params, params.where_clause_with_send, params.where_clause.trim_start_matches("where "))),
                             Indent(Box::new(Line(format!(
                                 "pub fn new(u: U) -> ToClient<U, {}> {{ ToClient {{u: u, _phantom: ::std::marker::PhantomData}} }}",
                                 params.params)))),
@@ -1758,7 +1758,7 @@ fn generate_node(gen: &GeneratorContext,
                             Indent(Box::new(Branch(client_impl_interior))),
                             Line("}".to_string()))));
 
-            mod_interior.push(Branch(vec!(Line(format!("pub trait Server<{}> {} {{", params.params, server_base)),
+            mod_interior.push(Branch(vec!(Line(format!("pub trait Server<{}> {} {} {{", params.params, server_base, params.where_clause)),
                                           Indent(Box::new(Branch(server_interior))),
                                           Line("}".to_string()))));
 
@@ -1771,7 +1771,7 @@ fn generate_node(gen: &GeneratorContext,
             mod_interior.push(
                 Branch(vec!(
                     (if is_generic {
-                        Line(format!("impl <{}, _T: Server{}> ::capnp::capability::Server for ServerDispatch<_T,{}> {{", params.params, bracketed_params, params.params))
+                        Line(format!("impl <{}, _T: Server{}> ::capnp::capability::Server for ServerDispatch<_T,{}> {} {{", params.params, bracketed_params, params.params, params.where_clause))
                     } else {
                         Line("impl <_T: Server> ::capnp::capability::Server for ServerDispatch<_T> {".to_string())
                     }),
@@ -1788,7 +1788,7 @@ fn generate_node(gen: &GeneratorContext,
             mod_interior.push(
                 Branch(vec!(
                     (if is_generic {
-                        Line(format!("impl <{}, _T: Server{}> ServerDispatch<_T,{}> {{", params.params, bracketed_params, params.params))
+                        Line(format!("impl <{}, _T: Server{}> ServerDispatch<_T,{}> {} {{", params.params, bracketed_params, params.params, params.where_clause))
                     } else {
                         Line("impl <_T :Server> ServerDispatch<_T> {".to_string())
                     }),

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1703,6 +1703,10 @@ fn generate_node(gen: &GeneratorContext,
             mod_interior.push(
                 Branch(vec!(
                     (if is_generic {
+                        #[cfg(rustc_at_least_1_30)]
+                        let where_clause_trimmed = params.where_clause.trim_start_matches("where ");
+                        #[cfg(not(rustc_at_least_1_30))]
+                        let where_clause_trimmed = params.where_clause.trim_left_matches("where ");
                         Branch(vec!(
                             Line(format!("pub struct ToClient<U,{}> {} {{", params.params, params.where_clause)),
                             Indent(Box::new(Branch(vec!(
@@ -1711,7 +1715,7 @@ fn generate_node(gen: &GeneratorContext,
                             )))),
                             Line("}".to_string()),
                             Line(format!("impl <{0}, U: Server<{0}> + 'static> ToClient<U,{0}> {1}, {2} {{",
-                                         params.params, params.where_clause_with_send, params.where_clause.trim_start_matches("where "))),
+                                         params.params, params.where_clause_with_send, where_clause_trimmed)),
                             Indent(Box::new(Line(format!(
                                 "pub fn new(u: U) -> ToClient<U, {}> {{ ToClient {{u: u, _phantom: ::std::marker::PhantomData}} }}",
                                 params.params)))),


### PR DESCRIPTION
When trying to generate code for this:

```
interface Base(T) {}

interface A(T) extends (Base(T)) {}

interface A(T) extends (Base(Base(T))) {}
```

Compiling generated code fails with an error:

```
660 | /   pub trait Server<T> : crate::test_capnp::base::Server<crate::test_capnp::base::Owned<T>> {
661 | |   }
    | |___^ the trait `for<'c> capnp::traits::Owned<'c>` is not implemented for `T`
    |
    = help: consider adding a `where for<'c> T: capnp::traits::Owned<'c>` bound
note: required by `test_capnp::base::Owned`
   -->
    |
429 |   pub struct Owned<T> where T: for<'c> ::capnp::traits::Owned<'c>  {
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Solution: supplement required traits in the generated code

Closes #128