### PR TITLE
Treat UnexpectedEof as Disconnect

### DIFF
--- a/capnp/src/lib.rs
+++ b/capnp/src/lib.rs
@@ -238,6 +238,7 @@ impl ::std::convert::From<::std::io::Error> for Error {
         use std::io;
         let kind = match err.kind() {
             io::ErrorKind::TimedOut => ErrorKind::Overloaded,
+            io::ErrorKind::UnexpectedEof |
             io::ErrorKind::BrokenPipe |
             io::ErrorKind::ConnectionRefused |
             io::ErrorKind::ConnectionReset |


### PR DESCRIPTION
After the other end of a unix domain socket or a pipe disconnects, calls to `read_exact` will return an `UnexpectedEof` error.

I believe that this should be treated as an `ErrorKind::Disconnect` and not a generic `ErrorKind::Failure`.