### PR TITLE
Add no_std feature

### DIFF
--- a/capnp/Cargo.toml
+++ b/capnp/Cargo.toml
@@ -20,16 +20,16 @@ path = "src/lib.rs"
 
 [dependencies]
 quickcheck = { version = "0.2", optional = true }
-core_io = { version = "0.1.20190701", features = [ "alloc", "collections" ], optional = true }
+core_io = { version = "0.1.20190701", features = [ "alloc", "collections" ] }
 
 [dev-dependencies]
 quickcheck = "0.2"
 
 [features]
-no_std = ["core_io"]
+std = []
 rpc = ["futures"]
 rpc_try = []
-default = []
+default = ["std"]
 
 [dependencies.futures]
 version = "0.1"

--- a/capnp/Cargo.toml
+++ b/capnp/Cargo.toml
@@ -20,13 +20,16 @@ path = "src/lib.rs"
 
 [dependencies]
 quickcheck = { version = "0.2", optional = true }
+core_io = { version = "0.1.20190701", features = [ "alloc", "collections" ], optional = true }
 
 [dev-dependencies]
 quickcheck = "0.2"
 
 [features]
+no_std = ["core_io"]
 rpc = ["futures"]
 rpc_try = []
+default = []
 
 [dependencies.futures]
 version = "0.1"

--- a/capnp/Cargo.toml
+++ b/capnp/Cargo.toml
@@ -20,16 +20,16 @@ path = "src/lib.rs"
 
 [dependencies]
 quickcheck = { version = "0.2", optional = true }
-core_io = { version = "0.1.20190701", features = [ "alloc", "collections" ] }
+core_io = { version = "0.1.20190701", features = [ "alloc", "collections" ], optional = true }
 
 [dev-dependencies]
 quickcheck = "0.2"
 
 [features]
-std = []
+no_std = ["core_io"]
 rpc = ["futures"]
 rpc_try = []
-default = ["std"]
+default = []
 
 [dependencies.futures]
 version = "0.1"

--- a/capnp/src/any_pointer.rs
+++ b/capnp/src/any_pointer.rs
@@ -21,7 +21,7 @@
 
 //! Dynamically typed value.
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 use crate::io::prelude::*;
 
 use crate::capability::FromClientHook;

--- a/capnp/src/any_pointer.rs
+++ b/capnp/src/any_pointer.rs
@@ -21,6 +21,9 @@
 
 //! Dynamically typed value.
 
+#[cfg(feature = "no_std")]
+use crate::io::prelude::*;
+
 use crate::capability::FromClientHook;
 use crate::private::capability::{ClientHook, PipelineHook, PipelineOp};
 use crate::private::layout::{PointerReader, PointerBuilder};

--- a/capnp/src/any_pointer.rs
+++ b/capnp/src/any_pointer.rs
@@ -21,7 +21,7 @@
 
 //! Dynamically typed value.
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use crate::io::prelude::*;
 
 use crate::capability::FromClientHook;

--- a/capnp/src/any_pointer_list.rs
+++ b/capnp/src/any_pointer_list.rs
@@ -23,6 +23,7 @@
 //! Note: this cannot be used for a list of structs, since such lists are not encoded
 //! as pointer lists.
 
+use core;
 use crate::traits::{FromPointerReader, FromPointerBuilder, ListIter, IndexMove};
 use crate::private::layout::{ListReader, ListBuilder, PointerReader, PointerBuilder, Pointer};
 use crate::Result;
@@ -124,7 +125,7 @@ impl <'a> crate::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
     }
 }
 
-impl <'a> ::std::iter::IntoIterator for Reader<'a> {
+impl <'a> core::iter::IntoIterator for Reader<'a> {
     type Item = Result<crate::any_pointer::Reader<'a>>;
     type IntoIter = ListIter<Reader<'a>, Self::Item>;
 

--- a/capnp/src/capability.rs
+++ b/capnp/src/capability.rs
@@ -23,7 +23,7 @@
 //!
 //! Roughly corresponds to capability.h in the C++ implementation.
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use crate::io::prelude::*;
 use core::marker::PhantomData;
 

--- a/capnp/src/capability.rs
+++ b/capnp/src/capability.rs
@@ -23,7 +23,7 @@
 //!
 //! Roughly corresponds to capability.h in the C++ implementation.
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 use crate::io::prelude::*;
 use core::marker::PhantomData;
 

--- a/capnp/src/capability.rs
+++ b/capnp/src/capability.rs
@@ -23,6 +23,10 @@
 //!
 //! Roughly corresponds to capability.h in the C++ implementation.
 
+#[cfg(feature = "no_std")]
+use crate::io::prelude::*;
+use core::marker::PhantomData;
+
 use crate::{any_pointer, Error, MessageSize};
 use crate::traits::{Pipelined, Owned};
 use crate::private::capability::{ClientHook, ParamsHook, RequestHook, ResponseHook, ResultsHook};
@@ -31,8 +35,6 @@ use crate::private::capability::{ClientHook, ParamsHook, RequestHook, ResponseHo
 use futures::Future;
 #[cfg(feature = "rpc_try")]
 use std::ops::Try;
-
-use std::marker::PhantomData;
 
 /// A computation that might eventually resolve to a value of type `T` or to an error
 ///  of type `E`. Dropping the promise cancels the computation.

--- a/capnp/src/capability_list.rs
+++ b/capnp/src/capability_list.rs
@@ -20,7 +20,7 @@
 
 //! List of capabilities.
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use crate::io::prelude::*;
 use core::{self, marker::PhantomData};
 

--- a/capnp/src/capability_list.rs
+++ b/capnp/src/capability_list.rs
@@ -20,7 +20,9 @@
 
 //! List of capabilities.
 
-use std::marker::PhantomData;
+#[cfg(feature = "no_std")]
+use crate::io::prelude::*;
+use core::{self, marker::PhantomData};
 
 use crate::capability::{FromClientHook};
 use crate::private::capability::ClientHook;
@@ -152,7 +154,7 @@ impl <'a, T> crate::traits::SetPointerBuilder<Builder<'a, T>> for Reader<'a, T>
     }
 }
 
-impl <'a, T> ::std::iter::IntoIterator for Reader<'a, T>
+impl <'a, T> core::iter::IntoIterator for Reader<'a, T>
     where T: FromClientHook
 {
     type Item = Result<T>;

--- a/capnp/src/capability_list.rs
+++ b/capnp/src/capability_list.rs
@@ -20,7 +20,7 @@
 
 //! List of capabilities.
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 use crate::io::prelude::*;
 use core::{self, marker::PhantomData};
 

--- a/capnp/src/constant.rs
+++ b/capnp/src/constant.rs
@@ -23,8 +23,7 @@
 //! `constant::Reader` does not do bounds-checking, so it is unsafe to
 //! manually construct one of these.
 
-use std::marker::PhantomData;
-
+use core::marker::PhantomData;
 use crate::any_pointer;
 use crate::private::layout::PointerReader;
 use crate::traits::Owned;

--- a/capnp/src/data.rs
+++ b/capnp/src/data.rs
@@ -21,6 +21,7 @@
 
 //! Sequence of bytes.
 
+use core;
 use crate::private::layout::{PointerBuilder, PointerReader};
 use crate::Result;
 
@@ -35,7 +36,7 @@ impl<'a> crate::traits::Owned<'a> for Owned {
 pub type Reader<'a> = &'a [u8];
 
 pub fn new_reader<'a>(p : *const u8, len : u32) -> Reader<'a> {
-    unsafe { ::std::slice::from_raw_parts(p, len as usize) }
+    unsafe { core::slice::from_raw_parts(p, len as usize) }
 }
 
 impl <'a> crate::traits::FromPointerReader<'a> for Reader<'a> {
@@ -47,7 +48,7 @@ impl <'a> crate::traits::FromPointerReader<'a> for Reader<'a> {
 pub type Builder<'a> = &'a mut [u8];
 
 pub fn new_builder<'a>(p : *mut u8, len : u32) -> Builder<'a> {
-    unsafe { ::std::slice::from_raw_parts_mut(p, len as usize) }
+    unsafe { core::slice::from_raw_parts_mut(p, len as usize) }
 }
 
 impl <'a> crate::traits::FromPointerBuilder<'a> for Builder<'a> {

--- a/capnp/src/data_list.rs
+++ b/capnp/src/data_list.rs
@@ -21,6 +21,7 @@
 
 //! List of sequences of bytes.
 
+use core;
 use crate::traits::{FromPointerReader, FromPointerBuilder, IndexMove, ListIter};
 use crate::private::layout::*;
 use crate::Result;
@@ -133,7 +134,7 @@ impl <'a> crate::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
     }
 }
 
-impl <'a> ::std::iter::IntoIterator for Reader<'a> {
+impl <'a> core::iter::IntoIterator for Reader<'a> {
     type Item = Result<crate::data::Reader<'a>>;
     type IntoIter = ListIter<Reader<'a>, Self::Item>;
 

--- a/capnp/src/enum_list.rs
+++ b/capnp/src/enum_list.rs
@@ -21,13 +21,13 @@
 
 //! List of enums.
 
+use core::{self, marker::PhantomData};
+
 use crate::traits::{FromPointerReader, FromPointerBuilder,
                     ToU16, FromU16, ListIter, IndexMove};
 use crate::private::layout::{ListReader, ListBuilder, PointerReader, PointerBuilder,
                              TwoBytes, PrimitiveElement};
 use crate::{NotInSchema, Result};
-
-use std::marker::PhantomData;
 
 #[derive(Clone, Copy)]
 pub struct Owned<T> {
@@ -52,7 +52,7 @@ impl <'a, T: FromU16> Reader<'a, T> {
 
     pub fn len(&self) -> u32 { self.reader.len() }
 
-    pub fn iter(self) -> ListIter<Reader<'a, T>, ::std::result::Result<T, NotInSchema>>{
+    pub fn iter(self) -> ListIter<Reader<'a, T>, core::result::Result<T, NotInSchema>>{
         let l = self.len();
         ListIter::new(self, l)
     }
@@ -65,14 +65,14 @@ impl <'a, T : FromU16> FromPointerReader<'a> for Reader<'a, T> {
     }
 }
 
-impl <'a, T: FromU16>  IndexMove<u32, ::std::result::Result<T, NotInSchema>> for Reader<'a, T>{
-    fn index_move(&self, index: u32) -> ::std::result::Result<T, NotInSchema> {
+impl <'a, T: FromU16>  IndexMove<u32, core::result::Result<T, NotInSchema>> for Reader<'a, T>{
+    fn index_move(&self, index: u32) -> core::result::Result<T, NotInSchema> {
         self.get(index)
     }
 }
 
 impl <'a, T : FromU16> Reader<'a, T> {
-    pub fn get(&self, index: u32) -> ::std::result::Result<T, NotInSchema> {
+    pub fn get(&self, index: u32) -> core::result::Result<T, NotInSchema> {
         assert!(index < self.len());
         let result: u16 = PrimitiveElement::get(&self.reader, index);
         FromU16::from_u16(result)
@@ -119,7 +119,7 @@ impl <'a, T : FromU16> FromPointerBuilder<'a> for Builder<'a, T> {
 }
 
 impl <'a, T : ToU16 + FromU16>  Builder<'a, T> {
-    pub fn get(&self, index: u32) -> ::std::result::Result<T, NotInSchema> {
+    pub fn get(&self, index: u32) -> core::result::Result<T, NotInSchema> {
         assert!(index < self.len());
         let result: u16 = PrimitiveElement::get_from_builder(&self.builder, index);
         FromU16::from_u16(result)
@@ -138,8 +138,8 @@ impl <'a, T> crate::traits::SetPointerBuilder<Builder<'a, T>> for Reader<'a, T> 
     }
 }
 
-impl <'a, T: FromU16> ::std::iter::IntoIterator for Reader<'a, T> {
-    type Item = ::std::result::Result<T, NotInSchema>;
+impl <'a, T: FromU16> core::iter::IntoIterator for Reader<'a, T> {
+    type Item = core::result::Result<T, NotInSchema>;
     type IntoIter = ListIter<Reader<'a, T>, Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/capnp/src/lib.rs
+++ b/capnp/src/lib.rs
@@ -27,7 +27,7 @@
 //! [capnpc-rust](https://github.com/capnproto/capnproto-rust/capnpc) crate.
 #![cfg_attr(feature = "rpc_try", feature(try_trait))]
 
-#![cfg_attr(feature = "no_std", no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(any(feature="quickcheck", test))]
 extern crate quickcheck;
@@ -35,29 +35,29 @@ extern crate quickcheck;
 #[cfg(feature = "rpc")]
 extern crate futures;
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate alloc;
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 extern crate core_io;
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std as core;
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use core_io as io;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::io as io;
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use alloc::string as string;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::string as string;
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use alloc::str as str;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::str as str;
 
 /// Constructs a [`Word`](struct.Word.html) from its constituent bytes, accounting
@@ -112,9 +112,9 @@ pub mod text;
 pub mod text_list;
 pub mod traits;
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use io::prelude::*;
 
 /// Eight bytes of memory with opaque interior. Use [`capnp_word!()`](macro.capnp_word!.html)

--- a/capnp/src/lib.rs
+++ b/capnp/src/lib.rs
@@ -27,7 +27,7 @@
 //! [capnpc-rust](https://github.com/capnproto/capnproto-rust/capnpc) crate.
 #![cfg_attr(feature = "rpc_try", feature(try_trait))]
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "no_std", no_std)]
 
 #[cfg(any(feature="quickcheck", test))]
 extern crate quickcheck;
@@ -35,29 +35,29 @@ extern crate quickcheck;
 #[cfg(feature = "rpc")]
 extern crate futures;
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 #[macro_use]
 extern crate alloc;
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 extern crate core_io;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "no_std"))]
 use std as core;
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 use core_io as io;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "no_std"))]
 use std::io as io;
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 use alloc::string as string;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "no_std"))]
 use std::string as string;
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 use alloc::str as str;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "no_std"))]
 use std::str as str;
 
 /// Constructs a [`Word`](struct.Word.html) from its constituent bytes, accounting
@@ -112,9 +112,9 @@ pub mod text;
 pub mod text_list;
 pub mod traits;
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 use alloc::string::String;
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 use io::prelude::*;
 
 /// Eight bytes of memory with opaque interior. Use [`capnp_word!()`](macro.capnp_word!.html)

--- a/capnp/src/list_list.rs
+++ b/capnp/src/list_list.rs
@@ -21,13 +21,14 @@
 
 //! List of lists.
 
+use core;
 use crate::traits::{FromPointerReader, FromPointerBuilder, ListIter, IndexMove};
 use crate::private::layout::{ListReader, ListBuilder, PointerReader, PointerBuilder, Pointer};
 use crate::Result;
 
 #[derive(Clone, Copy)]
 pub struct Owned<T> where T: for<'a> crate::traits::Owned<'a> {
-    marker: ::std::marker::PhantomData<T>,
+    marker: core::marker::PhantomData<T>,
 }
 
 impl<'a, T> crate::traits::Owned<'a> for Owned<T> where T: for<'b> crate::traits::Owned<'b> {
@@ -36,13 +37,13 @@ impl<'a, T> crate::traits::Owned<'a> for Owned<T> where T: for<'b> crate::traits
 }
 
 pub struct Reader<'a, T> where T: for<'b> crate::traits::Owned<'b> {
-    marker: ::std::marker::PhantomData<<T as crate::traits::Owned<'a>>::Reader>,
+    marker: core::marker::PhantomData<<T as crate::traits::Owned<'a>>::Reader>,
     reader: ListReader<'a>
 }
 
 impl <'a, T> Reader<'a, T> where T: for<'b> crate::traits::Owned<'b> {
     pub fn new<'b>(reader: ListReader<'b>) -> Reader<'b, T> {
-        Reader::<'b, T> { reader: reader, marker: ::std::marker::PhantomData }
+        Reader::<'b, T> { reader: reader, marker: core::marker::PhantomData }
     }
 
     pub fn len(&self) -> u32 { self.reader.len() }
@@ -69,7 +70,7 @@ where T: for<'b> crate::traits::Owned<'b> {
 impl <'a, T> FromPointerReader<'a> for Reader<'a, T> where T: for<'b> crate::traits::Owned<'b> {
     fn get_from_pointer(reader: &PointerReader<'a>, default: Option<&'a [crate::Word]>) -> Result<Reader<'a, T>> {
         Ok(Reader { reader: reader.get_list(Pointer, default)?,
-                    marker: ::std::marker::PhantomData })
+                    marker: core::marker::PhantomData })
     }
 }
 
@@ -81,19 +82,19 @@ impl <'a, T> Reader<'a, T> where T: for<'b> crate::traits::Owned<'b> {
 }
 
 pub struct Builder<'a, T> where T: for<'b> crate::traits::Owned<'b> {
-    marker: ::std::marker::PhantomData<T>,
+    marker: core::marker::PhantomData<T>,
     builder: ListBuilder<'a>
 }
 
 impl <'a, T> Builder<'a, T> where T: for<'b> crate::traits::Owned<'b> {
     pub fn new(builder: ListBuilder<'a>) -> Builder<'a, T> {
-        Builder { builder: builder, marker: ::std::marker::PhantomData }
+        Builder { builder: builder, marker: core::marker::PhantomData }
     }
 
     pub fn len(&self) -> u32 { self.builder.len() }
 
     pub fn into_reader(self) -> Reader<'a, T> {
-        Reader { reader: self.builder.into_reader(), marker: ::std::marker::PhantomData }
+        Reader { reader: self.builder.into_reader(), marker: core::marker::PhantomData }
     }
 }
 
@@ -105,20 +106,20 @@ impl <'a, T> Builder<'a, T> where T: for<'b> crate::traits::Owned<'b> {
 
 impl <'a, T> Builder<'a, T> where T: for<'b> crate::traits::Owned<'b> {
     pub fn reborrow<'b>(&'b mut self) -> Builder<'b, T> {
-        Builder {builder: self.builder.borrow(), marker: ::std::marker::PhantomData}
+        Builder {builder: self.builder.borrow(), marker: core::marker::PhantomData}
     }
 }
 
 impl <'a, T> FromPointerBuilder<'a> for Builder<'a, T> where T: for<'b> crate::traits::Owned<'b> {
     fn init_pointer(builder: PointerBuilder<'a>, size : u32) -> Builder<'a, T> {
         Builder {
-            marker: ::std::marker::PhantomData,
+            marker: core::marker::PhantomData,
             builder: builder.init_list(Pointer, size)
         }
     }
     fn get_from_pointer(builder: PointerBuilder<'a>, default: Option<&'a [crate::Word]>) -> Result<Builder<'a, T>> {
         Ok(Builder {
-            marker: ::std::marker::PhantomData,
+            marker: core::marker::PhantomData,
             builder: builder.get_list(Pointer, default)?
         })
     }
@@ -141,7 +142,7 @@ impl <'a, T> crate::traits::SetPointerBuilder<Builder<'a, T>> for Reader<'a, T>
     }
 }
 
-impl <'a, T> ::std::iter::IntoIterator for Reader<'a, T>
+impl <'a, T> core::iter::IntoIterator for Reader<'a, T>
     where T: for<'b> crate::traits::Owned<'b>
 {
     type Item = Result<<T as crate::traits::Owned<'a>>::Reader>;

--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -21,7 +21,7 @@
 
 //! Untyped root container for a Cap'n Proto value.
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 use crate::io::prelude::*;
 use core::{self, convert::From};
 

--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -21,7 +21,9 @@
 
 //! Untyped root container for a Cap'n Proto value.
 
-use std::convert::From;
+#[cfg(feature = "no_std")]
+use crate::io::prelude::*;
+use core::{self, convert::From};
 
 use crate::any_pointer;
 use crate::private::arena::{BuilderArenaImpl, ReaderArenaImpl, BuilderArena, ReaderArena};
@@ -177,7 +179,7 @@ impl <S> Reader<S> where S: ReaderSegments {
 
         let pointer_reader = layout::PointerReader::get_root(
             &self.arena, 0, segment_start, self.nesting_limit)?;
-        let read_head = ::std::cell::Cell::new(unsafe {segment_start.offset(1)});
+        let read_head = core::cell::Cell::new(unsafe {segment_start.offset(1)});
         let root_is_canonical = pointer_reader.is_canonical(&read_head)?;
         let all_words_consumed =
             (read_head.get() as usize - segment_start as usize) / BYTES_PER_WORD == seg_len as usize;
@@ -210,7 +212,7 @@ impl <S> Reader<S> where S: ReaderSegments {
 pub struct TypedReader<S, T>
     where S: ReaderSegments,
           T: for<'a> Owned<'a> {
-    marker: ::std::marker::PhantomData<T>,
+    marker: core::marker::PhantomData<T>,
     message: Reader<S>,
 }
 
@@ -220,7 +222,7 @@ impl <S, T> TypedReader<S, T>
 
     pub fn new(message: Reader<S>) -> Self {
         TypedReader {
-            marker: ::std::marker::PhantomData,
+            marker: core::marker::PhantomData,
             message: message,
         }
     }
@@ -419,7 +421,7 @@ impl HeapAllocator {
 
 unsafe impl Allocator for HeapAllocator {
     fn allocate_segment(&mut self, minimum_size: u32) -> (*mut Word, u32) {
-        let size = ::std::cmp::max(minimum_size, self.next_size);
+        let size = core::cmp::max(minimum_size, self.next_size);
         let mut new_words = Word::allocate_zeroed_vec(size as usize);
         let ptr = new_words.as_mut_ptr();
         self.owned_memory.push(new_words);
@@ -487,7 +489,7 @@ unsafe impl <'a, 'b: 'a> Allocator for ScratchSpaceHeapAllocator<'a, 'b> {
     fn pre_drop(&mut self, segment0_currently_allocated: u32) {
         let ptr = self.scratch_space.slice.as_mut_ptr();
         unsafe {
-            ::std::ptr::write_bytes(ptr, 0u8, segment0_currently_allocated as usize);
+            core::ptr::write_bytes(ptr, 0u8, segment0_currently_allocated as usize);
         }
         self.scratch_space.in_use = false;
     }

--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -21,7 +21,7 @@
 
 //! Untyped root container for a Cap'n Proto value.
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use crate::io::prelude::*;
 use core::{self, convert::From};
 

--- a/capnp/src/primitive_list.rs
+++ b/capnp/src/primitive_list.rs
@@ -21,7 +21,7 @@
 
 //! List of primitives.
 
-use std::{marker};
+use core::{self, marker};
 
 use crate::traits::{FromPointerReader, FromPointerBuilder, IndexMove, ListIter};
 use crate::private::layout::{ListReader, ListBuilder, PointerReader, PointerBuilder,
@@ -139,7 +139,7 @@ impl <'a, T> crate::traits::SetPointerBuilder<Builder<'a, T>> for Reader<'a, T>
     }
 }
 
-impl <'a, T> ::std::iter::IntoIterator for Reader<'a, T>
+impl <'a, T> core::iter::IntoIterator for Reader<'a, T>
     where T: PrimitiveElement
 {
     type Item = T;

--- a/capnp/src/private/arena.rs
+++ b/capnp/src/private/arena.rs
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 use crate::io::prelude::*;
 
 use core::cell::{Cell, RefCell};

--- a/capnp/src/private/arena.rs
+++ b/capnp/src/private/arena.rs
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use crate::io::prelude::*;
 
 use core::cell::{Cell, RefCell};

--- a/capnp/src/private/arena.rs
+++ b/capnp/src/private/arena.rs
@@ -18,9 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use std::cell::{Cell, RefCell};
-use std::slice;
-use std::u64;
+#[cfg(feature = "no_std")]
+use crate::io::prelude::*;
+
+use core::cell::{Cell, RefCell};
+use core::{self, u64, slice};
 
 use crate::private::units::*;
 use crate::message;
@@ -309,7 +311,7 @@ impl BuilderArena for NullArena {
     }
 
     fn get_segment_mut(&self, _id: u32) -> (*mut Word, u32) {
-        (::std::ptr::null_mut(), 0)
+        (core::ptr::null_mut(), 0)
     }
 
     fn as_reader<'a>(&'a self) -> &'a dyn ReaderArena {

--- a/capnp/src/private/capability.rs
+++ b/capnp/src/private/capability.rs
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use crate::io::prelude::*;
 use core;
 

--- a/capnp/src/private/capability.rs
+++ b/capnp/src/private/capability.rs
@@ -19,6 +19,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#[cfg(feature = "no_std")]
+use crate::io::prelude::*;
+use core;
+
 use crate::any_pointer;
 use crate::MessageSize;
 use crate::capability::{Params, Promise, Request, RemotePromise, Results};
@@ -105,15 +109,15 @@ pub trait ParamsHook {
 
 // Where should this live?
 pub fn internal_get_typed_params<T>(typeless: Params<any_pointer::Owned>) -> Params<T> {
-    Params { hook: typeless.hook, marker: ::std::marker::PhantomData }
+    Params { hook: typeless.hook, marker: core::marker::PhantomData }
 }
 
 pub fn internal_get_typed_results<T>(typeless: Results<any_pointer::Owned>) -> Results<T> {
-    Results { hook: typeless.hook, marker: ::std::marker::PhantomData }
+    Results { hook: typeless.hook, marker: core::marker::PhantomData }
 }
 
 pub fn internal_get_untyped_results<T>(typeful: Results<T>) -> Results<any_pointer::Owned> {
-    Results { hook: typeful.hook, marker: ::std::marker::PhantomData }
+    Results { hook: typeful.hook, marker: core::marker::PhantomData }
 }
 
 pub trait PipelineHook {

--- a/capnp/src/private/capability.rs
+++ b/capnp/src/private/capability.rs
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 use crate::io::prelude::*;
 use core;
 

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use crate::io::prelude::*;
 
 use core::{self, mem, ptr, cell::Cell};
@@ -311,7 +311,7 @@ impl WirePointer {
 }
 
 mod wire_helpers {
-    #[cfg(feature = "no_std")]
+    #[cfg(not(feature = "std"))]
     use crate::io::prelude::*;
 
     use core::{self, mem, ptr, slice};

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 use crate::io::prelude::*;
 
 use core::{self, mem, ptr, cell::Cell};
@@ -311,7 +311,7 @@ impl WirePointer {
 }
 
 mod wire_helpers {
-    #[cfg(not(feature = "std"))]
+    #[cfg(feature = "no_std")]
     use crate::io::prelude::*;
 
     use core::{self, mem, ptr, slice};

--- a/capnp/src/private/units.rs
+++ b/capnp/src/private/units.rs
@@ -19,6 +19,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+use core;
+
 pub type BitCount0 = usize; // `BitCount` clashes with a standard trait
 pub type BitCount8 = u8;
 pub type BitCount16 = u16;
@@ -60,9 +62,9 @@ pub const WORDS_PER_POINTER : WordCount = 1;
 pub const POINTER_SIZE_IN_WORDS : WordCount = 1;
 
 pub fn _bytes_per_element<T>() -> ByteCount {
-    ::std::mem::size_of::<T>()
+    core::mem::size_of::<T>()
 }
 
 pub fn bits_per_element<T>() -> BitCount0 {
-    8 * ::std::mem::size_of::<T>()
+    8 * core::mem::size_of::<T>()
 }

--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -296,7 +296,7 @@ pub fn compute_serialized_size_in_words<A>(message: &crate::message::Builder<A>)
 
 #[cfg(test)]
 pub mod test {
-    use crate::io::{prelude::*, Cursor};
+    use crate::io::{self, prelude::*};
 
     use quickcheck::{quickcheck, TestResult};
 
@@ -323,7 +323,7 @@ pub mod test {
         buf.extend([0,0,0,0, // 1 segments
                     0,0,0,0] // 0 length
                     .iter().cloned());
-        let (words, segment_slices) = read_segment_table(&mut Cursor::new(&buf[..]),
+        let (words, segment_slices) = read_segment_table(&mut io::Cursor::new(&buf[..]),
                                                          message::ReaderOptions::new()).unwrap();
         assert_eq!(0, words);
         assert_eq!(vec![(0,0)], segment_slices);
@@ -332,7 +332,7 @@ pub mod test {
         buf.extend([0,0,0,0, // 1 segments
                     1,0,0,0] // 1 length
                     .iter().cloned());
-        let (words, segment_slices) = read_segment_table(&mut Cursor::new(&buf[..]),
+        let (words, segment_slices) = read_segment_table(&mut io::Cursor::new(&buf[..]),
                                                          message::ReaderOptions::new()).unwrap();
         assert_eq!(1, words);
         assert_eq!(vec![(0,1)], segment_slices);
@@ -343,7 +343,7 @@ pub mod test {
                     1,0,0,0, // 1 length
                     0,0,0,0] // padding
                     .iter().cloned());
-        let (words, segment_slices) = read_segment_table(&mut Cursor::new(&buf[..]),
+        let (words, segment_slices) = read_segment_table(&mut io::Cursor::new(&buf[..]),
                                                          message::ReaderOptions::new()).unwrap();
         assert_eq!(2, words);
         assert_eq!(vec![(0,1), (1, 2)], segment_slices);
@@ -354,7 +354,7 @@ pub mod test {
                     1,0,0,0, // 1 length
                     0,1,0,0] // 256 length
                     .iter().cloned());
-        let (words, segment_slices) = read_segment_table(&mut Cursor::new(&buf[..]),
+        let (words, segment_slices) = read_segment_table(&mut io::Cursor::new(&buf[..]),
                                                          message::ReaderOptions::new()).unwrap();
         assert_eq!(258, words);
         assert_eq!(vec![(0,1), (1, 2), (2, 258)], segment_slices);
@@ -367,7 +367,7 @@ pub mod test {
                     99,0,0,0, // 99 length
                     0,0,0,0]  // padding
                     .iter().cloned());
-        let (words, segment_slices) = read_segment_table(&mut Cursor::new(&buf[..]),
+        let (words, segment_slices) = read_segment_table(&mut io::Cursor::new(&buf[..]),
                                                          message::ReaderOptions::new()).unwrap();
         assert_eq!(200, words);
         assert_eq!(vec![(0,77), (77, 100), (100, 101), (101, 200)], segment_slices);
@@ -381,23 +381,23 @@ pub mod test {
 
         buf.extend([0,2,0,0].iter().cloned()); // 513 segments
         buf.extend([0; 513 * 4].iter().cloned());
-        assert!(read_segment_table(&mut Cursor::new(&buf[..]),
+        assert!(read_segment_table(&mut io::Cursor::new(&buf[..]),
                                    message::ReaderOptions::new()).is_err());
         buf.clear();
 
         buf.extend([0,0,0,0].iter().cloned()); // 1 segments
-        assert!(read_segment_table(&mut Cursor::new(&buf[..]),
+        assert!(read_segment_table(&mut io::Cursor::new(&buf[..]),
                                    message::ReaderOptions::new()).is_err());
         buf.clear();
 
         buf.extend([0,0,0,0].iter().cloned()); // 1 segments
         buf.extend([0; 3].iter().cloned());
-        assert!(read_segment_table(&mut Cursor::new(&buf[..]),
+        assert!(read_segment_table(&mut io::Cursor::new(&buf[..]),
                                    message::ReaderOptions::new()).is_err());
         buf.clear();
 
         buf.extend([255,255,255,255].iter().cloned()); // 0 segments
-        assert!(read_segment_table(&mut Cursor::new(&buf[..]),
+        assert!(read_segment_table(&mut io::Cursor::new(&buf[..]),
                                    message::ReaderOptions::new()).is_err());
         buf.clear();
     }
@@ -464,7 +464,7 @@ pub mod test {
     fn check_round_trip() {
         fn round_trip(segments: Vec<Vec<Word>>) -> TestResult {
             if segments.len() == 0 { return TestResult::discard(); }
-            let mut cursor = Cursor::new(Vec::new());
+            let mut cursor = io::Cursor::new(Vec::new());
 
             write_message_segments(&mut cursor, &segments);
             cursor.set_position(0);

--- a/capnp/src/serialize_packed.rs
+++ b/capnp/src/serialize_packed.rs
@@ -22,8 +22,8 @@
 //! Reading and writing of messages using the
 //! [packed stream encoding](https://capnproto.org/encoding.html#packing).
 
-use std::{io, mem, ptr, slice};
-use std::io::{Read, BufRead, Write};
+use core::{mem, ptr, slice};
+use crate::io::{self, prelude::*};
 
 use crate::serialize;
 use crate::Result;
@@ -370,9 +370,8 @@ pub fn write_message<W, A>(write: &mut W, message: &crate::message::Builder<A>) 
 
 #[cfg(test)]
 mod tests {
-    use std::io::{Write, Read};
+    use crate::io::{Write, Read, Cursor};
 
-    use std::io::Cursor;
     use quickcheck::{quickcheck, TestResult};
 
     use crate::{Word};

--- a/capnp/src/struct_list.rs
+++ b/capnp/src/struct_list.rs
@@ -21,7 +21,7 @@
 
 //! List of structs.
 
-use std::marker::PhantomData;
+use core::{self, marker::PhantomData};
 
 use crate::private::layout::{ListReader, ListBuilder, PointerReader, PointerBuilder, InlineComposite};
 use crate::traits::{FromPointerReader, FromPointerBuilder,
@@ -171,7 +171,7 @@ impl <'a, T> crate::traits::SetPointerBuilder<Builder<'a, T>> for Reader<'a, T>
     }
 }
 
-impl <'a, T> ::std::iter::IntoIterator for Reader<'a, T>
+impl <'a, T> core::iter::IntoIterator for Reader<'a, T>
     where T: for<'b> crate::traits::OwnedStruct<'b>
 {
     type Item = <T as crate::traits::OwnedStruct<'a>>::Reader;

--- a/capnp/src/text.rs
+++ b/capnp/src/text.rs
@@ -21,8 +21,7 @@
 
 //! UTF-8 encoded text.
 
-use std::{convert, str, ops};
-
+use core::{convert, str, ops};
 use crate::{Error, Result};
 
 #[derive(Copy, Clone)]

--- a/capnp/src/text_list.rs
+++ b/capnp/src/text_list.rs
@@ -21,6 +21,7 @@
 
 //! List of strings containing UTF-8 encoded text.
 
+use core;
 use crate::traits::{FromPointerReader, FromPointerBuilder, IndexMove, ListIter};
 use crate::private::layout::{ListBuilder, ListReader, Pointer, PointerBuilder, PointerReader};
 use crate::Result;
@@ -129,7 +130,7 @@ impl <'a> crate::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
     }
 }
 
-impl <'a> ::std::iter::IntoIterator for Reader<'a> {
+impl <'a> core::iter::IntoIterator for Reader<'a> {
     type Item = Result<crate::text::Reader<'a>>;
     type IntoIter = ListIter<Reader<'a>, Self::Item>;
 

--- a/capnp/src/traits.rs
+++ b/capnp/src/traits.rs
@@ -19,11 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+use core::{self, marker::PhantomData};
+
 use crate::{Word, Result};
 use crate::private::layout::{CapTable, ListReader, StructReader, StructBuilder, StructSize,
                              PointerBuilder, PointerReader};
-
-use std::marker::PhantomData;
 
 pub trait FromStructReader<'a> {
     fn new(reader: StructReader<'a>) -> Self;
@@ -100,7 +100,7 @@ pub trait ToU16 {
 }
 
 pub trait FromU16 : Sized {
-    fn from_u16(value: u16) -> ::std::result::Result<Self, crate::NotInSchema>;
+    fn from_u16(value: u16) -> core::result::Result<Self, crate::NotInSchema>;
 }
 
 pub trait IndexMove<I, T> {
@@ -120,9 +120,9 @@ impl <T, U> ListIter<T, U>{
     }
 }
 
-impl <U, T : IndexMove<u32, U>> ::std::iter::Iterator for ListIter<T, U> {
+impl <U, T : IndexMove<u32, U>> core::iter::Iterator for ListIter<T, U> {
     type Item = U;
-    fn next(&mut self) -> ::std::option::Option<U> {
+    fn next(&mut self) -> core::option::Option<U> {
         if self.index < self.size {
             let result = self.list.index_move(self.index);
             self.index += 1;
@@ -147,14 +147,14 @@ impl <U, T : IndexMove<u32, U>> ::std::iter::Iterator for ListIter<T, U> {
     }
 }
 
-impl <U, T: IndexMove<u32, U>> ::std::iter::ExactSizeIterator for ListIter<T, U>{
+impl <U, T: IndexMove<u32, U>> core::iter::ExactSizeIterator for ListIter<T, U>{
     fn len(&self) -> usize{
         self.size as usize
     }
 }
 
-impl <U, T: IndexMove<u32, U>> ::std::iter::DoubleEndedIterator for ListIter<T, U>{
-    fn next_back(&mut self) -> ::std::option::Option<U> {
+impl <U, T: IndexMove<u32, U>> core::iter::DoubleEndedIterator for ListIter<T, U>{
+    fn next_back(&mut self) -> core::option::Option<U> {
         if self.size > self.index {
             self.size -= 1;
             Some(self.list.index_move(self.size))

--- a/capnpc/Cargo.toml
+++ b/capnpc/Cargo.toml
@@ -24,5 +24,5 @@ name = "capnpc-rust"
 path = "src/capnpc-rust.rs"
 
 [dependencies]
-capnp = { version = "0.10", path = "../capnp", default-features = false }
+capnp = { version = "0.10", path = "../capnp" }
 

--- a/capnpc/Cargo.toml
+++ b/capnpc/Cargo.toml
@@ -24,5 +24,5 @@ name = "capnpc-rust"
 path = "src/capnpc-rust.rs"
 
 [dependencies]
-capnp = { version = "0.10", path = "../capnp" }
+capnp = { version = "0.10", path = "../capnp", default-features = false }
 

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1859,7 +1859,8 @@ pub fn generate_code<T>(mut inp: T, out_dir: &::std::path::Path) -> ::capnp::Res
         let requested = ::std::path::PathBuf::from(requested_file.get_filename()?);
         filepath.push(requested);
         if let Some(parent) = filepath.parent() {
-            ::std::fs::create_dir_all(parent)?;
+            ::std::fs::create_dir_all(parent)
+                .map_err(|err| ::capnp::Error::failed(err.to_string()))?;
         }
 
         let root_name = path_to_stem_string(&filepath)?.replace("-", "_");
@@ -1878,12 +1879,13 @@ pub fn generate_code<T>(mut inp: T, out_dir: &::std::path::Path) -> ::capnp::Res
         // would not include `filepath`.
         match ::std::fs::File::create(&filepath) {
             Ok(ref mut writer) => {
-                writer.write_all(text.as_bytes())?;
+                writer.write_all(text.as_bytes())
+                    .map_err(|err| ::capnp::Error::failed(err.to_string()))?;
             }
             Err(e) => {
                 let _ = writeln!(&mut ::std::io::stderr(),
                                  "could not open file {:?} for writing: {}", filepath, e);
-                return Err(e.into());
+                return Err(::capnp::Error::failed(e.to_string()));
             }
         }
     }

--- a/capnpc/src/lib.rs
+++ b/capnpc/src/lib.rs
@@ -78,9 +78,9 @@ pub enum RustEdition {
 }
 
 fn run_command(mut command: ::std::process::Command, path: &PathBuf) -> ::capnp::Result<()> {
-    let mut p = command.spawn()?;
+    let mut p = command.spawn().map_err(|err| capnp::Error::failed(err.to_string()))?;
     crate::codegen::generate_code(p.stdout.take().unwrap(), path.as_path())?;
-    let exit_status = p.wait()?;
+    let exit_status = p.wait().map_err(|err| ::capnp::Error::failed(err.to_string()))?;
     if !exit_status.success() {
         Err(::capnp::Error::failed(format!(
             "Non-success exit status: {}",


### PR DESCRIPTION
Hey there! I've been wanting to have capnproto-rust available on no_std for awhile (per #71), and I've given it a few shots in the past but I think now I'm actually pretty close to nailing it. I wanted to open up a PR to get some feedback on my approach and ask some questions about things I've gotten hung up on.

Things I've done:

* Added a `no_std` feature flag to the `capnp` crate. This feature is used in a few `#[cfg(...)]` conditional compilations around the codebase.
* Included the `core_io` crate as an optional dependency to be included when the `no_std` feature flag is set. This crate is mostly autogenerated in that it applies patches against std::io to take out all std usages and replace them using the `alloc` crate.
* Replaced all references to `std::` within the `capnp` crate to use `core::` instead. In capnp's `lib.rs` file, there is a conditional import based on `#[cfg(feature = "no_std")]`. If `no_std` is enabled, then the name `core::` references `core_io::` items. If `no_std` is not enabled, then `core::` references `std::` items. A similar strategy handles deciding between e.g. `std::string` and `alloc::string` and between `std::str` and `alloc::str`.

Problems I'm having now:

It seems that everything in the `capnp` crate is now building properly both when `no_std` is enabled and disabled. However, when I add the `capnpc::CompilerCommand::new().file("schema.capnp").run().unwrap();` buildscript to a no_std project of mine, there's an interesting compilation problem. `capnp` needs to be compiled as no_std in order to comply with my no_std application, but since that is the case, the std-compiled `capnpc` seems to now be linking against the no_std-compiled `capnp`, whereas I think it _should_ build a separate instance of capnp (std-compiled) to link against. The problem that this creates is that e.g. in `capnpc/src/lib.rs:81: let mut p = command.spawn()?;`, the `spawn()` call returns a `Result` in which the error type is `std::io::Error`. Typically, when capnp is std-compiled, it would implement `From<std::io::Error> for capnp::Error`. However, since it is linking against the no_std-compiled version of capnp, the implementation that is actually implemented is `From<core_io::Error> for capnp::Error`. It seems that I can get around this by simply mapping the error each time capnpc deals with an `io::Result`, e.g. like this:

```rust
let mut p = command.spawn().map_err(|err| capnp::Error::failed(err.to_string()))?;
```

There are only perhaps five or so instances of this problem, but I figured I should ask if anybody has any suggestions on a strategy to take. I don't think it makes sense to force the no_std requirements to leak up into capnpc, but I also don't necessarily want to destroy ergonomics by forcing the client to use `map_err` everywhere. I think I'll probably work on adding a commit that does do that, just in order to get a working solution together, but any alternative suggestions are certainly welcome!

Edit:

I forgot to mention, since the `core_io` crate is built by applying patches against certain builds of std::io, you'll need a fixed version of nightly rust to build it using the `no_std` feature. You should be able to satisfy it using this override which corresponds to the last patch of the core_io crate:

```
rustup override set nightly-2019-07-01
```