### PR TITLE
Don't write output files if their content is unchanged

### DIFF
--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1874,6 +1874,15 @@ pub fn generate_code<T>(mut inp: T, out_dir: &::std::path::Path) -> ::capnp::Res
 
         let text = stringify(&lines);
 
+        let previous_text = ::std::fs::read(&filepath);
+        if previous_text.is_ok() && previous_text.unwrap() == text.as_bytes() {
+            // File is unchanged. Do not write it so that builds with the
+            // output as part of the source work in read-only filesystems
+            // and so timestamp-based build systems and watchers do not get
+            // confused.
+            continue;
+        }
+
         // It would be simpler to use the ? operator instead of a pattern match, but then the error message
         // would not include `filepath`.
         match ::std::fs::File::create(&filepath) {


### PR DESCRIPTION
Why would you want to do this? The issue is if you are writing the
output to your source directory, rather than your build directory,
which is a perfectly reasonable thing to do for various reasons.

In that case *always* writing the output causes issues in at least
two places so far:

1. If you have the rust-analyzer extension and tell it to watch the
   code for changes, it will get stuck in a loop. I suspect
   `cargo watch` will suffer from that too.
2. If you try to cross-compile using `cross` it will fail because it
   mounts the source code as a read-only filesystem.

I made a similar pull request for Prost here: https://github.com/danburkert/prost/pull/232