### PR TITLE
Remove static lifetime requirement

### DIFF
--- a/capnp-futures/src/read_stream.rs
+++ b/capnp-futures/src/read_stream.rs
@@ -28,21 +28,21 @@ use capnp::{Error, message};
 
 async fn read_next_message<R>(mut reader: R, options: message::ReaderOptions)
                               -> Result<(R, Option<message::Reader<capnp::serialize::OwnedSegments>>), Error>
-    where R: AsyncRead + Unpin + 'static
+    where R: AsyncRead + Unpin
 {
     let m = crate::serialize::read_message(&mut reader, options).await?;
     Ok((reader, m))
 }
 
 #[must_use = "streams do nothing unless polled"]
-pub struct ReadStream<R> where R: AsyncRead + Unpin + 'static {
+pub struct ReadStream<'a, R> where R: AsyncRead + Unpin  {
     options: message::ReaderOptions,
-    read: Pin<Box<dyn Future<Output=Result<(R, Option<message::Reader<capnp::serialize::OwnedSegments>>), Error>> + 'static>>,
+    read: Pin<Box<dyn Future<Output=Result<(R, Option<message::Reader<capnp::serialize::OwnedSegments>>), Error>> + 'a >>,
 }
 
-impl <R> Unpin for ReadStream<R> where R: AsyncRead + Unpin + 'static {}
+impl <'a, R> Unpin for ReadStream<'a, R> where R: AsyncRead + Unpin  {}
 
-impl <R> ReadStream<R> where R: AsyncRead + Unpin + 'static {
+impl <'a, R> ReadStream<'a, R> where R: AsyncRead + Unpin + 'a  {
     pub fn new(reader: R, options: message::ReaderOptions) -> Self
     {
         ReadStream {
@@ -52,7 +52,7 @@ impl <R> ReadStream<R> where R: AsyncRead + Unpin + 'static {
     }
 }
 
-impl <R> Stream for ReadStream<R> where R: AsyncRead + Unpin + 'static {
+impl <'a, R> Stream for ReadStream<'a, R> where R: AsyncRead + Unpin + 'a  {
     type Item = Result<message::Reader<capnp::serialize::OwnedSegments>, Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {

--- a/capnp-futures/src/write_queue.rs
+++ b/capnp-futures/src/write_queue.rs
@@ -42,8 +42,8 @@ impl <M> Clone for Sender<M> where M: AsOutputSegments {
 }
 
 /// Creates a new WriteQueue that wraps the given writer.
-pub fn write_queue<W, M>(mut writer: W) -> (Sender<M>, impl Future<Output=Result<(),Error>> + 'static)
-    where W: AsyncWrite + Unpin + 'static, M: AsOutputSegments + 'static
+pub fn write_queue<W, M>(mut writer: W) -> (Sender<M>, impl Future<Output=Result<(),Error>> )
+    where W: AsyncWrite + Unpin , M: AsOutputSegments
 {
     let (tx, mut rx) = futures::channel::mpsc::unbounded();
 
@@ -69,10 +69,10 @@ pub fn write_queue<W, M>(mut writer: W) -> (Sender<M>, impl Future<Output=Result
     (sender, queue)
 }
 
-impl <M> Sender<M> where M: AsOutputSegments + 'static {
+impl <M> Sender<M> where M: AsOutputSegments  {
     /// Enqueues a message to be written. The returned future resolves once the write
     /// has completed.
-    pub fn send(&mut self, message: M) -> impl Future<Output=Result<M,Error>> + Unpin + 'static {
+    pub fn send(&mut self, message: M) -> impl Future<Output=Result<M,Error>> + Unpin  {
         let (complete, oneshot) = oneshot::channel();
 
         let _ = self.sender.unbounded_send(Item::Message(message, complete));
@@ -89,7 +89,7 @@ impl <M> Sender<M> where M: AsOutputSegments + 'static {
     /// Commands the queue to stop writing messages once it is empty. After this method has been called,
     /// any new calls to `send()` will return a future that immediately resolves to an error.
     /// If the passed-in `result` is an error, then the `WriteQueue` will resolve to that error.
-    pub fn terminate(&mut self, result: Result<(), Error>) -> impl Future<Output=Result<(),Error>> + Unpin + 'static {
+    pub fn terminate(&mut self, result: Result<(), Error>) -> impl Future<Output=Result<(),Error>> + Unpin  {
         let (complete, receiver) = oneshot::channel();
 
         let _ = self.sender.unbounded_send(Item::Done(result, complete));

--- a/capnp-futures/test/test.rs
+++ b/capnp-futures/test/test.rs
@@ -173,8 +173,8 @@ mod tests {
 
         let (mut write, mut read) =
             async_std::os::unix::net::UnixStream::pair().expect("socket pair");
-        serialize::read_message(&mut read, message::ReaderOptions::default());
-        serialize::write_message(&mut write, message::Builder::new_default());
+        let _ = serialize::read_message(&mut read, message::ReaderOptions::default());
+        let _ = serialize::write_message(&mut write, message::Builder::new_default());
         drop(write);
         drop(read);
     }
@@ -186,8 +186,8 @@ mod tests {
 
         let (mut write, mut read) =
             async_std::os::unix::net::UnixStream::pair().expect("socket pair");
-        capnp_futures::ReadStream::new(&mut read, message::ReaderOptions::default());
-        capnp_futures::write_queue::<_, message::Builder<message::HeapAllocator>>(&mut write);
+        let _ = capnp_futures::ReadStream::new(&mut read, message::ReaderOptions::default());
+        let _ = capnp_futures::write_queue::<_, message::Builder<message::HeapAllocator>>(&mut write);
         drop(write);
         drop(read);
     }

--- a/capnp-futures/test/test.rs
+++ b/capnp-futures/test/test.rs
@@ -165,4 +165,30 @@ mod tests {
             .first_segment_words(1).allocation_strategy(capnp::message::AllocationStrategy::FixedSize);
         fill_and_send_message(capnp::message::Builder::new(builder_options));
     }
+
+    #[test]
+    fn static_lifetime_not_required_funcs() {
+        use capnp::message;
+        use capnp_futures::serialize;
+
+        let (mut write, mut read) =
+            async_std::os::unix::net::UnixStream::pair().expect("socket pair");
+        serialize::read_message(&mut read, message::ReaderOptions::default());
+        serialize::write_message(&mut write, message::Builder::new_default());
+        drop(write);
+        drop(read);
+    }
+
+    #[test]
+    fn static_lifetime_not_required_on_highlevel() {
+        use capnp::message;
+        use capnp_futures;
+
+        let (mut write, mut read) =
+            async_std::os::unix::net::UnixStream::pair().expect("socket pair");
+        capnp_futures::ReadStream::new(&mut read, message::ReaderOptions::default());
+        capnp_futures::write_queue::<_, message::Builder<message::HeapAllocator>>(&mut write);
+        drop(write);
+        drop(read);
+    }
 }


### PR DESCRIPTION
This PR attempts to remove the static lifetime requirement placed on futures.

I understand that I could be missing something given that this library is about providing bindings for a c++ library. That said looking at it, it seems to be correct.

I should note that this is a breaking change for the `ReadStream` struct, so a version bump will be required.