### PR TITLE
Select custom executable for 'capnp' command

### DIFF
--- a/capnpc/src/lib.rs
+++ b/capnpc/src/lib.rs
@@ -106,7 +106,7 @@ impl CompilerCommand {
     }
 
     /// Adds a file to be compiled.
-    pub fn file<'a, P>(&'a mut self, path: P) -> &'a mut CompilerCommand
+    pub fn file<P>(&mut self, path: P) -> &mut CompilerCommand
     where
         P: AsRef<Path>,
     {
@@ -116,7 +116,7 @@ impl CompilerCommand {
 
     /// Adds a --src-prefix flag. For all files specified for compilation that start
     /// with `prefix`, removes the prefix when computing output filenames.
-    pub fn src_prefix<'a, P>(&'a mut self, prefix: P) -> &'a mut CompilerCommand
+    pub fn src_prefix<P>(&mut self, prefix: P) -> &mut CompilerCommand
     where
         P: AsRef<Path>,
     {
@@ -126,7 +126,7 @@ impl CompilerCommand {
 
     /// Adds an --import_path flag. Adds `dir` to the list of directories searched
     /// for absolute imports.
-    pub fn import_path<'a, P>(&'a mut self, dir: P) -> &'a mut CompilerCommand
+    pub fn import_path<P>(&mut self, dir: P) -> &mut CompilerCommand
     where
         P: AsRef<Path>,
     {
@@ -136,13 +136,13 @@ impl CompilerCommand {
 
     /// Adds the --no-standard-import flag, indicating that the default import paths of
     /// /usr/include and /usr/local/include should not bet included.
-    pub fn no_standard_import<'a>(&'a mut self) -> &'a mut CompilerCommand {
+    pub fn no_standard_import(&mut self) -> &mut CompilerCommand {
         self.no_standard_import = true;
         self
     }
 
     ///Sets the output directory of generated code. Default is OUT_DIR
-    pub fn output_path<'a, P>(&'a mut self, path: P) -> &'a mut CompilerCommand
+    pub fn output_path<P>(&mut self, path: P) -> &mut CompilerCommand
     where
         P: AsRef<Path>,
     {

--- a/capnpc/src/lib.rs
+++ b/capnpc/src/lib.rs
@@ -150,10 +150,19 @@ impl CompilerCommand {
         self
     }
 
-    /// Runs the command. Returns an error if `OUT_DIR` or a custom output directory was not set
-    /// or if `capnp compile` fails.
+    /// Runs the command, assuming a 'capnp' executable is accessible from current working directory (e.g. locally or in PATH environment variable).
+    /// Returns an error if `OUT_DIR` or a custom output directory was not set or if `capnp compile` fails.
     pub fn run(&mut self) -> ::capnp::Result<()> {
-        let mut command = ::std::process::Command::new("capnp");
+        self.run_with("capnp")
+    }
+
+    /// Runs the command, using a custom capnp `executable` path (not a directory).
+    /// Returns an error if `OUT_DIR` or a custom output directory was not set or if `<executable> compile` fails.
+    pub fn run_with<P>(&mut self, executable: P) -> ::capnp::Result<()>
+    where
+        P: AsRef<Path>
+    {
+        let mut command = ::std::process::Command::new(executable.as_ref());
         command.arg("compile").arg("-o").arg("-");
 
         if self.no_standard_import {

--- a/capnpc/src/lib.rs
+++ b/capnpc/src/lib.rs
@@ -90,6 +90,7 @@ pub struct CompilerCommand {
     src_prefixes: Vec<PathBuf>,
     import_paths: Vec<PathBuf>,
     no_standard_import: bool,
+    executable_path: Option<PathBuf>,
     output_path: Option<PathBuf>,
 }
 
@@ -101,6 +102,7 @@ impl CompilerCommand {
             src_prefixes: Vec::new(),
             import_paths: Vec::new(),
             no_standard_import: false,
+            executable_path: None,
             output_path: None,
         }
     }
@@ -137,32 +139,44 @@ impl CompilerCommand {
     /// Adds the --no-standard-import flag, indicating that the default import paths of
     /// /usr/include and /usr/local/include should not bet included.
     pub fn no_standard_import(&mut self) -> &mut CompilerCommand {
+        assert!(!self.no_standard_import, "no_standard_import() must only be called once");
+
         self.no_standard_import = true;
         self
     }
 
-    ///Sets the output directory of generated code. Default is OUT_DIR
+    /// Sets the output directory of generated code. Default is OUT_DIR
     pub fn output_path<P>(&mut self, path: P) -> &mut CompilerCommand
     where
         P: AsRef<Path>,
     {
+        assert!(self.executable_path.is_none(), "output_path() must only be called once");
+
         self.output_path = Some(path.as_ref().to_path_buf());
         self
     }
 
-    /// Runs the command, assuming a 'capnp' executable is accessible from current working directory (e.g. locally or in PATH environment variable).
-    /// Returns an error if `OUT_DIR` or a custom output directory was not set or if `capnp compile` fails.
-    pub fn run(&mut self) -> ::capnp::Result<()> {
-        self.run_with("capnp")
-    }
-
-    /// Runs the command, using a custom capnp `executable` path (not a directory).
-    /// Returns an error if `OUT_DIR` or a custom output directory was not set or if `<executable> compile` fails.
-    pub fn run_with<P>(&mut self, executable: P) -> ::capnp::Result<()>
+    /// Specify the executable which is used for the 'capnp' tool. When this method is not called, the command looks for a name 'capnp'
+    /// on the system (e.g. in working directory or in PATH environment variable).
+    pub fn capnp_executable<P>(&mut self, path: P) -> &mut CompilerCommand
     where
         P: AsRef<Path>
     {
-        let mut command = ::std::process::Command::new(executable.as_ref());
+        assert!(self.executable_path.is_none(), "capnp_executable() must only be called once");
+
+        self.executable_path = Some(path.as_ref().to_path_buf());
+        self
+    }
+
+    /// Runs the command.
+    /// Returns an error if `OUT_DIR` or a custom output directory was not set, or if `capnp compile` fails.
+    pub fn run(&mut self) -> ::capnp::Result<()> {
+        let mut command = if let Some(executable) = &self.executable_path {
+            ::std::process::Command::new(executable)
+        } else {
+            ::std::process::Command::new("capnp")
+        };
+
         command.arg("compile").arg("-o").arg("-");
 
         if self.no_standard_import {


### PR DESCRIPTION
Hello! There seems to be no current API for selecting the `capnp` executable that is used to run the schema generation. Instead, the `CompilerCommand.run()` method assumes a `capnp` name is visible either relative to the Rust working directory, or in PATH. This disallows use cases such as shipping the `capnp` executable in a custom directory within the project.

I added the following method to `CompilerCommand`:
```rust
pub fn run_with<P>(&mut self, executable: P) -> ::capnp::Result<()>
where
    P: AsRef<Path>
```
which allows `build.rs` configurations with custom paths, such as:
```rust
capnpc::CompilerCommand::new()
    .file("src/schema/Point.capnp")
    .run_with("tools/external/capnp.exe")
    .expect("compiling schema");
```

The 2nd commit fixes some warnings regarding explicit lifetime annotations, which can be elided. Let me know if you prefer keeping those, and I'll remove the commit.

---

Maybe a general question related to the `capnp` generator: what is considered best practice for a self-contained and portable Rust project using Cap'n'Proto? Would you recommend providing binaries for the major platforms (Windows, Linux, Mac OS)? I fear a custom C++ build step might add a lot of complexity.