### PR TITLE
fix read_segment_table read bug

### DIFF
--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -218,7 +218,7 @@ fn read_segment_table<R>(read: &mut R,
     // read the first Word, which contains segment_count and the 1st segment length
     let mut read_count = 0;
     while read_count < 8 {
-        let n = read.read(&mut buf)?;
+        let n = read.read(&mut buf[read_count..])?;
         if n == 0 {
             if read_count == 0 {
                 // clean EOF on message boundary


### PR DESCRIPTION
I was getting a corrupted read error.  I tracked the error down to this read_segment_table.

It has a loop that seems to suggest it was meant to repeatedly read even if the Read() call returns less than 8 bytes.  But if this happens, it reads again into the start of the buffer, instead of reading into the correct position.

I'm still trying to learn Rust, so please excuse me if this is not the correct fix.  But it does solve my case (with added prints, I found that Read() returned 7 instead o 8 after a few hundred messages).