### PR TITLE
Experimenting with no_std for capnp-rpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 Cargo.lock
 /target/
 
+# JetBrains
+.idea/

--- a/capnp-futures/Cargo.toml
+++ b/capnp-futures/Cargo.toml
@@ -11,19 +11,29 @@ edition = "2018"
 
 keywords = ["async"]
 
-[dependencies]
-capnp = { version = "0.13.0", path = "../capnp" }
+[dependencies.capnp]
+version = "0.13.0"
+path = "../capnp"
+default-features = false
 
 [dependencies.futures]
 version = "0.3.0"
 default-features = false
-features = ["std", "executor"]
+features = ["alloc"]
 
 [dev-dependencies.futures]
 version = "0.3.0"
 default-features = false
-features = ["executor"]
 
-[dev-dependencies]
-capnp = { version = "0.13.0", path = "../capnp", features = ["quickcheck"] }
-quickcheck = "0.9"
+[dev-dependencies.capnp]
+version = "0.13.0"
+path = "../capnp"
+default-features = false
+
+#[dev-dependencies]
+#capnp = { version = "0.13.0", path = "../capnp", features = ["quickcheck"] }
+#quickcheck = "0.9"
+
+[features]
+default = ["std"]
+std = ["futures/std", "futures/executor", "capnp/std"]

--- a/capnp-futures/src/async_io/mod.rs
+++ b/capnp-futures/src/async_io/mod.rs
@@ -1,0 +1,349 @@
+
+use core::pin::Pin;
+use core::task::Poll;
+use core::task::Context;
+
+use capnp::Result;
+
+pub use async_ext::AsyncReadExt;
+pub use async_ext::AsyncWriteExt;
+
+pub trait AsyncRead {
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8])
+        -> Poll<Result<usize>>;
+}
+
+pub trait AsyncBufRead: AsyncRead {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>)
+        -> Poll<Result<&[u8]>>;
+
+    fn consume(self: Pin<&mut Self>, amt: usize);
+}
+
+pub trait AsyncWrite {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8])
+        -> Poll<Result<usize>>;
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>>;
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>>;
+}
+
+#[cfg(feature="std")]
+mod std_impls {
+    use crate::async_io::{AsyncRead, AsyncBufRead, AsyncWrite};
+    use capnp::Result;
+    use futures::task::{Context, Poll};
+    use std::pin::Pin;
+
+    impl<R> AsyncRead for R where R: futures::AsyncRead {
+        fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize>> {
+            match futures::AsyncRead::poll_read(self, cx, buf) {
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+                Poll::Ready(Ok(n)) => Poll::Ready(Ok(n)),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+
+    impl<R> AsyncBufRead for R where R: futures::AsyncBufRead {
+        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>> {
+            match futures::AsyncBufRead::poll_fill_buf(self, cx) {
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+                Poll::Ready(Ok(buf)) => Poll::Ready(Ok(buf)),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+
+        fn consume(self: Pin<&mut Self>, amt: usize) {
+            futures::AsyncBufRead::consume(self, amt)
+        }
+    }
+
+    impl<W> AsyncWrite for W where W: futures::AsyncWrite {
+        fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
+            match futures::AsyncWrite::poll_write(self, cx, buf) {
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+                Poll::Ready(Ok(n)) => Poll::Ready(Ok(n)),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+            match futures::AsyncWrite::poll_flush(self, cx) {
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+                Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+
+        fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+            match futures::AsyncWrite::poll_close(self, cx) {
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+                Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+}
+
+#[cfg(not(feature="std"))]
+mod no_std_impls {
+    use crate::async_io::{AsyncRead, AsyncBufRead, AsyncWrite};
+    use core::pin::Pin;
+    use core::task::{Context, Poll};
+    use capnp::Result;
+
+    impl AsyncRead for &[u8] {
+        fn poll_read(mut self: Pin<&mut Self>, _: &mut Context<'_>, buf: &mut [u8])
+             -> Poll<Result<usize>>
+        {
+            Poll::Ready(capnp::io::Read::read(&mut *self, buf))
+        }
+    }
+
+    impl<R: ?Sized + AsyncRead + Unpin> AsyncRead for &mut R {
+        fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize>> {
+            Pin::new(&mut **self).poll_read(cx, buf)
+        }
+    }
+
+    impl AsyncBufRead for &[u8] {
+        fn poll_fill_buf(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<&[u8]>> {
+            Poll::Ready(capnp::io::BufRead::fill_buf(self.get_mut()))
+        }
+
+        fn consume(mut self: Pin<&mut Self>, amt: usize) {
+            capnp::io::BufRead::consume(&mut *self, amt)
+        }
+    }
+
+    impl<R: ?Sized + AsyncBufRead + Unpin> AsyncBufRead for &mut R {
+        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>> {
+            Pin::new(&mut **self.get_mut()).poll_fill_buf(cx)
+        }
+
+        fn consume(mut self: Pin<&mut Self>, amt: usize) {
+            Pin::new(&mut **self).consume(amt)
+        }
+    }
+
+    impl<'a> AsyncWrite for &'a mut [u8] {
+        fn poll_write(mut self: Pin<&mut Self>, _: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
+            Poll::Ready(capnp::io::Write::write_all(&mut *self, buf).map(|_| buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl<W: ?Sized + AsyncWrite + Unpin> AsyncWrite for &mut W {
+        fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
+            Pin::new(&mut **self).poll_write(cx, buf)
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+            Pin::new(&mut **self).poll_flush(cx)
+        }
+
+        fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+            Pin::new(&mut **self).poll_close(cx)
+        }
+    }
+}
+
+#[cfg(feature="std")]
+pub mod async_ext {
+    pub use futures::AsyncReadExt;
+    pub use futures::AsyncWriteExt;
+}
+
+#[cfg(not(feature="std"))]
+pub mod async_ext {
+    use core::pin::Pin;
+    use core::future::Future;
+    use core::task::{Context, Poll};
+    use alloc::string::ToString;
+    use super::{AsyncRead, AsyncWrite};
+
+    pub trait AsyncReadExt: AsyncRead {
+        fn read<'a>(&'a mut self, buf: &'a mut [u8]) -> Read<'a, Self>
+            where Self: Unpin,
+        {
+            Read::new(self, buf)
+        }
+
+        fn read_exact<'a>(
+            &'a mut self,
+            buf: &'a mut [u8],
+        ) -> ReadExact<'a, Self>
+            where Self: Unpin,
+        {
+            ReadExact::new(self, buf)
+        }
+    }
+
+    impl<R: AsyncRead + ?Sized> AsyncReadExt for R {}
+
+    pub trait AsyncWriteExt: AsyncWrite {
+        fn flush(&mut self) -> Flush<'_, Self>
+            where Self: Unpin,
+        {
+            Flush::new(self)
+        }
+
+        fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> WriteAll<'a, Self>
+            where Self: Unpin,
+        {
+            WriteAll::new(self, buf)
+        }
+    }
+
+    impl<W: AsyncWrite + ?Sized> AsyncWriteExt for W {}
+
+    /// Future for the [`read`](super::AsyncReadExt::read) method.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct Read<'a, R: ?Sized> {
+        reader: &'a mut R,
+        buf: &'a mut [u8],
+    }
+
+    impl<R: ?Sized + Unpin> Unpin for Read<'_, R> {}
+
+    impl<'a, R: AsyncRead + ?Sized + Unpin> Read<'a, R> {
+        pub(super) fn new(reader: &'a mut R, buf: &'a mut [u8]) -> Self {
+            Read { reader, buf }
+        }
+    }
+
+    impl<R: AsyncRead + ?Sized + Unpin> Future for Read<'_, R> {
+        type Output = capnp::Result<usize>;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let this = &mut *self;
+            match Pin::new(&mut this.reader).poll_read(cx, this.buf) {
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+                other => other,
+            }
+        }
+    }
+
+    /// Future for the [`read_exact`](super::AsyncReadExt::read_exact) method.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct ReadExact<'a, R: ?Sized> {
+        reader: &'a mut R,
+        buf: &'a mut [u8],
+    }
+
+    impl<R: ?Sized + Unpin> Unpin for ReadExact<'_, R> {}
+
+    impl<'a, R: AsyncRead + ?Sized + Unpin> ReadExact<'a, R> {
+        pub(super) fn new(reader: &'a mut R, buf: &'a mut [u8]) -> Self {
+            ReadExact { reader, buf }
+        }
+    }
+
+    impl<R: AsyncRead + ?Sized + Unpin> Future for ReadExact<'_, R> {
+        type Output = capnp::Result<()>;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let this = &mut *self;
+            while !this.buf.is_empty() {
+
+                let n = match Pin::new(&mut this.reader).poll_read(cx, this.buf) {
+                    Poll::Ready(Ok(n)) => n,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e.into())),
+                    Poll::Pending => return Poll::Pending,
+                };
+
+                // let n = ready!(Pin::new(&mut this.reader).poll_read(cx, this.buf))?;
+                {
+                    let (_, rest) = core::mem::replace(&mut this.buf, &mut []).split_at_mut(n);
+                    this.buf = rest;
+                }
+                if n == 0 {
+                    return Poll::Ready(Err(capnp::Error::failed("unexpected End of File".to_string())))
+                }
+            }
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    /// Future for the [`flush`](super::AsyncWriteExt::flush) method.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct Flush<'a, W: ?Sized> {
+        writer: &'a mut W,
+    }
+
+    impl<W: ?Sized + Unpin> Unpin for Flush<'_, W> {}
+
+    impl<'a, W: AsyncWrite + ?Sized + Unpin> Flush<'a, W> {
+        pub(super) fn new(writer: &'a mut W) -> Self {
+            Flush { writer }
+        }
+    }
+
+    impl<W> Future for Flush<'_, W>
+        where W: AsyncWrite + ?Sized + Unpin,
+    {
+        type Output = capnp::Result<()>;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            match Pin::new(&mut *self.writer).poll_flush(cx) {
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+                other => other,
+            }
+        }
+    }
+
+    /// Future for the [`write_all`](super::AsyncWriteExt::write_all) method.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct WriteAll<'a, W: ?Sized> {
+        writer: &'a mut W,
+        buf: &'a [u8],
+    }
+
+    impl<W: ?Sized + Unpin> Unpin for WriteAll<'_, W> {}
+
+    impl<'a, W: AsyncWrite + ?Sized + Unpin> WriteAll<'a, W> {
+        pub(super) fn new(writer: &'a mut W, buf: &'a [u8]) -> Self {
+            WriteAll { writer, buf }
+        }
+    }
+
+    impl<W: AsyncWrite + ?Sized + Unpin> Future for WriteAll<'_, W> {
+        type Output = capnp::Result<()>;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let this = &mut *self;
+            while !this.buf.is_empty() {
+
+                let n = match Pin::new(&mut this.writer).poll_write(cx, this.buf) {
+                    Poll::Ready(Ok(n)) => n,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e.into())),
+                    Poll::Pending => return Poll::Pending,
+                };
+
+                // let n = ready!(Pin::new(&mut this.writer).poll_write(cx, this.buf))?;
+                {
+                    let (_, rest) = core::mem::replace(&mut this.buf, &[]).split_at(n);
+                    this.buf = rest;
+                }
+                if n == 0 {
+                    return Poll::Ready(Err(capnp::Error::failed("Write Zero".to_string())));
+                }
+            }
+
+            Poll::Ready(Ok(()))
+        }
+    }
+}

--- a/capnp-futures/src/lib.rs
+++ b/capnp-futures/src/lib.rs
@@ -18,6 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[macro_use]
+extern crate alloc;
 extern crate futures;
 
 pub use read_stream::ReadStream;
@@ -26,3 +30,4 @@ pub use write_queue::{write_queue, Sender};
 pub mod serialize;
 mod read_stream;
 mod write_queue;
+pub mod async_io;

--- a/capnp-futures/src/read_stream.rs
+++ b/capnp-futures/src/read_stream.rs
@@ -18,11 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use alloc::boxed::Box;
+
 use futures::future::Future;
 use futures::stream::Stream;
-use futures::{AsyncRead};
+use crate::async_io::AsyncRead;
+// use futures::{AsyncRead};
 
 use capnp::{Error, message};
 

--- a/capnp-futures/src/serialize.rs
+++ b/capnp-futures/src/serialize.rs
@@ -21,12 +21,12 @@
 //! Asynchronous reading and writing of messages using the
 //! [standard stream framing](https://capnproto.org/encoding.html#serialization-over-a-stream).
 
-use std::convert::TryInto;
+use core::convert::TryInto;
 
 use capnp::{message, Error, Result, OutputSegments};
 use capnp::serialize::{OwnedSegments, SegmentLengthsBuilder};
 
-use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use crate::async_io::{AsyncRead, AsyncWrite, AsyncReadExt, AsyncWriteExt};
 
 /// Begins an asynchronous read of a message from `reader`.
 pub async fn read_message<R>(mut reader: R, options: message::ReaderOptions) -> Result<Option<message::Reader<OwnedSegments>>>
@@ -144,7 +144,7 @@ impl <A> AsOutputSegments for message::Builder<A> where A: message::Allocator {
     }
 }*/
 
-impl <A> AsOutputSegments for ::std::rc::Rc<message::Builder<A>> where A: message::Allocator {
+impl <A> AsOutputSegments for alloc::rc::Rc<message::Builder<A>> where A: message::Allocator {
     fn as_output_segments<'a>(&'a self) -> OutputSegments<'a> {
         self.get_segments_for_output()
     }
@@ -160,7 +160,7 @@ pub async fn write_message<W,M>(mut writer: W, message: M) -> Result<()>
     Ok(())
 }
 
-async fn write_segment_table<W>(mut write: W, segments: &[&[u8]]) -> ::std::io::Result<()>
+async fn write_segment_table<W>(mut write: W, segments: &[&[u8]]) -> capnp::Result<()>
     where W: AsyncWrite + Unpin
 {
     let mut buf: [u8; 8] = [0; 8];
@@ -215,7 +215,8 @@ pub mod test {
     use std::pin::Pin;
     use std::task::{Context, Poll};
 
-    use futures::{AsyncRead, AsyncWrite};
+    // use futures::{AsyncRead, AsyncWrite};
+    use crate::async_io::{AsyncRead, AsyncWrite};
     use futures::io::Cursor;
 
     use quickcheck::{quickcheck, TestResult};

--- a/capnp-futures/src/write_queue.rs
+++ b/capnp-futures/src/write_queue.rs
@@ -20,11 +20,12 @@
 
 use futures::future::Future;
 use futures::channel::oneshot;
-use futures::{AsyncWrite, AsyncWriteExt, StreamExt, TryFutureExt};
+use futures::{StreamExt, TryFutureExt};
+use crate::async_io::{AsyncWrite, AsyncWriteExt};
 
-use capnp::{Error};
+use capnp::Error;
 
-use crate::serialize::{AsOutputSegments};
+use crate::serialize::AsOutputSegments;
 
 enum Item<M> where M: AsOutputSegments {
     Message(M, oneshot::Sender<M>),

--- a/capnp-rpc/Cargo.toml
+++ b/capnp-rpc/Cargo.toml
@@ -21,8 +21,17 @@ path = "src/lib.rs"
 [dependencies.futures]
 version = "0.3.0"
 default-features = false
-features = ["std"]
 
-[dependencies]
-capnp-futures = { version = "0.13.0", path = "../capnp-futures" }
-capnp = {version = "0.13.0", path = "../capnp"}
+[dependencies.capnp]
+version = "0.13.0"
+path = "../capnp"
+default-features = false
+
+[dependencies.capnp-futures]
+version = "0.13.0"
+path = "../capnp-futures"
+default-features = false
+
+[features]
+default = ["std"]
+std = ["futures/std", "capnp/std", "capnp-futures/std"]

--- a/capnp-rpc/src/lib.rs
+++ b/capnp-rpc/src/lib.rs
@@ -58,20 +58,23 @@
 //!
 //! For a more complete example, see https://github.com/capnproto/capnproto-rust/tree/master/capnp-rpc/examples/calculator
 
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate capnp;
 extern crate capnp_futures;
 extern crate futures;
+extern crate alloc;
 
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::cell::{RefCell};
+use alloc::rc::Rc;
+
 use futures::{Future, FutureExt, TryFutureExt};
 use futures::channel::oneshot;
 use capnp::Error;
 use capnp::capability::Promise;
 use capnp::private::capability::{ClientHook};
-use std::cell::{RefCell};
-use std::rc::{Rc};
 
 use crate::task_set::TaskSet;
 pub use crate::rpc::Disconnector;
@@ -92,9 +95,9 @@ pub mod rpc_twoparty_capnp;
 macro_rules! pry {
     ($expr:expr) => (
         match $expr {
-            ::std::result::Result::Ok(val) => val,
-            ::std::result::Result::Err(err) => {
-                return ::capnp::capability::Promise::err(::std::convert::From::from(err))
+            ::core::result::Result::Ok(val) => val,
+            ::core::result::Result::Err(err) => {
+                return ::capnp::capability::Promise::err(::core::convert::From::from(err))
             }
         })
 }

--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -32,7 +32,8 @@ use futures::{future, Future, FutureExt, TryFutureExt};
 use futures::channel::oneshot;
 
 use std::vec::Vec;
-use std::collections::hash_map::HashMap;
+// use std::collections::hash_map::HashMap;
+use alloc::collections::BTreeMap as HashMap;
 use std::collections::binary_heap::BinaryHeap;
 use std::cell::{Cell, RefCell};
 use std::rc::{Rc, Weak};

--- a/capnp-rpc/src/twoparty.rs
+++ b/capnp-rpc/src/twoparty.rs
@@ -23,7 +23,8 @@
 
 use capnp::message::ReaderOptions;
 use capnp::capability::Promise;
-use futures::{AsyncRead, AsyncWrite, FutureExt, TryFutureExt};
+use futures::{FutureExt, TryFutureExt};
+use capnp_futures::async_io::{AsyncRead, AsyncWrite};
 use futures::channel::oneshot;
 
 use std::cell::RefCell;

--- a/capnp/Cargo.toml
+++ b/capnp/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 keywords = ["encoding", "protocol", "serialization"]
 
 [lib]
-
 name = "capnp"
 path = "src/lib.rs"
 


### PR DESCRIPTION
Hi there, I'm back! Thanks for adding the changes for `no_std` a while back. I only recently saw those changes land, so I figured I would try my hand again at putting together a sample program for my embedded project. It seemed that I was able to compile my project when I added `capnp` as a dependency and `capnpc` as a build dependency, but that `capnp-rpc` was still not compiling for `no_std`. I wanted to see if it'd be possible to get `capnp-rpc` compiling for `no_std` using just `alloc`, so I started playing around with things. I'll describe what I've discovered so far.

### A quick TLDR

Right now the biggest thing that seems to be blocking this from working is the fact that `capnp-futures/src/write_queue` depends on `futures::channel::mpsc::unbounded()`, which seems truly unavailable on `no_std`, even with `alloc` present. Any solution to making `capnp-rpc` `no_std` compatible would probably hinge on finding a different channel solution which uses `alloc` or less.

### Features all the way down

When I added `capnp-rpc` as a dependency to my blank `no_std` project, the first thing that I noticed is that something seemed to be depending on `std`, causing the build to fail. I looked at the dependencies of `capnp-rpc` itself and saw this:

```toml
[dependencies.futures]
version = "0.3.0"
default-features = false
features = ["std"]
```

So, `capnp-rpc` depends on the `std` feature of `capnp-futures`. So I decided to dig deeper and see if there was any way that we could disable the `std` feature in `capnp-futures` and still retain a minimal working base on which `capnp-rpc` could run using just `alloc`. In `capnp-futures`, I made a `std` feature and set it on by default. I also turned off default features for the `futures` crate to avoid the std dependency there, but made sure to add back `futures/std` and `futures/executor` as a dependency of the `capnp-futures` `std` feature. Basically, I was hoping to create a big chain of `std` features which would all turn off if the top-level dependency opted out of default-features.

### AsyncRead and AsyncWrite

At about this point, I realized that AsyncRead and AsyncWrite have a hard dependency on std again because of their functions returning `io::Result`. So I figured I'd take a shot at reproducing the solution you came up with last time for `no_std`, creating approximations of those traits which are `no_std` compatible and defining blanket impls for the canonical versions of the traits when `std` is enabled. I dug down this rabbit hole for awhile, eventually coming up with `capnp-futures/async_io`, which has the trait approximations as well as some watered-down versions of the `AsyncReadExt` and `AsyncWriteExt` traits from `futures-util`. It turns out that all of the futures you used in `capnp-futures` (e.g. `Read`, `ReadExact`, etc.) are all just basic structs that don't depend on std at all, even though they're not published in a `no_std` compatible module. So I reproduced just those helper Futures from `futures-util` that you were using.

### futures::channel::mpsc

At this point, my compiler errors basically watered down to just about one problem: that `futures::channel::mpsc` was not available without `std`, not even if `alloc` is present. I tried looking for alternative channel solutions which only required `alloc`, but I was unable to find any. This is pretty much the largest blocking point that I can see right now. I think it might require an `alloc`-only implementation of a `mpsc` channel, which would probably need to be made custom for this. I don't know if you're aware of any crates that would meet that need or whether there's an alternative solution where the dependency on `mpsc` could be gotten rid of, but that's where this is all stuck at right now.

---

So, I'm not sure where this leaves this issue. I haven't spent way too long thinking of other approaches yet, but I figured I'd share my findings so far in case others have any ideas for how to proceed. I've never worked with concurrency "primitives" before, so while I think the idea of creating an `alloc`-only `mpsc` channel is interesting, I'm not sure I would trust myself to come up with a correct or good enough implementation to be upstreamed to this project. I'd love to hear other thoughts on this though!