### PR TITLE
Reduced number of dependencies pulled from futures

### DIFF
--- a/capnp-futures/Cargo.toml
+++ b/capnp-futures/Cargo.toml
@@ -13,16 +13,22 @@ keywords = ["async"]
 
 [dependencies]
 capnp = { version = "0.13.0", path = "../capnp" }
+futures-core = { version = "0.3.0", default-features = false }
 
-[dependencies.futures]
+[dependencies.futures-io]
 version = "0.3.0"
 default-features = false
-features = ["std", "executor"]
+features = ["std"]
 
-[dev-dependencies.futures]
+[dependencies.futures-util]
 version = "0.3.0"
 default-features = false
-features = ["executor"]
+features = ["io"]
+
+[dependencies.futures-channel]
+version = "0.3.0"
+default-features = false
+features = ["std"]
 
 [dev-dependencies]
 capnp = { version = "0.13.0", path = "../capnp", features = ["quickcheck"] }

--- a/capnp-futures/src/lib.rs
+++ b/capnp-futures/src/lib.rs
@@ -18,11 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-extern crate futures;
+extern crate futures_channel;
+extern crate futures_core;
+extern crate futures_io;
+extern crate futures_util;
 
 pub use read_stream::ReadStream;
 pub use write_queue::{write_queue, Sender};
 
-pub mod serialize;
 mod read_stream;
+pub mod serialize;
 mod write_queue;

--- a/capnp-futures/src/serialize.rs
+++ b/capnp-futures/src/serialize.rs
@@ -23,32 +23,46 @@
 
 use std::convert::TryInto;
 
-use capnp::{message, Error, Result, OutputSegments};
 use capnp::serialize::{OwnedSegments, SegmentLengthsBuilder};
+use capnp::{message, Error, OutputSegments, Result};
 
-use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::{AsyncReadExt, AsyncWriteExt};
 
 /// Begins an asynchronous read of a message from `reader`.
-pub async fn read_message<R>(mut reader: R, options: message::ReaderOptions) -> Result<Option<message::Reader<OwnedSegments>>>
-    where R: AsyncRead + Unpin
+pub async fn read_message<R>(
+    mut reader: R,
+    options: message::ReaderOptions,
+) -> Result<Option<message::Reader<OwnedSegments>>>
+where
+    R: AsyncRead + Unpin,
 {
     let segment_lengths_builder = match read_segment_table(&mut reader, options).await? {
         Some(s) => s,
         None => return Ok(None),
     };
-    Ok(Some(read_segments(reader, segment_lengths_builder.into_owned_segments(), options).await?))
+    Ok(Some(
+        read_segments(
+            reader,
+            segment_lengths_builder.into_owned_segments(),
+            options,
+        )
+        .await?,
+    ))
 }
 
-async fn read_segment_table<R>(mut reader: R,
-                               options: message::ReaderOptions)
-                               -> Result<Option<SegmentLengthsBuilder>>
-    where R: AsyncRead + Unpin
+async fn read_segment_table<R>(
+    mut reader: R,
+    options: message::ReaderOptions,
+) -> Result<Option<SegmentLengthsBuilder>>
+where
+    R: AsyncRead + Unpin,
 {
     let mut buf: [u8; 8] = [0; 8];
     {
         let n = reader.read(&mut buf[..]).await?;
         if n == 0 {
-            return Ok(None)
+            return Ok(None);
         } else if n < 8 {
             reader.read_exact(&mut buf[n..]).await?;
         }
@@ -71,7 +85,8 @@ async fn read_segment_table<R>(mut reader: R,
             reader.read_exact(&mut segment_sizes[..]).await?;
             for idx in 0..(segment_count - 1) {
                 let segment_len =
-                    u32::from_le_bytes(segment_sizes[(idx * 4)..(idx + 1) * 4].try_into().unwrap()) as usize;
+                    u32::from_le_bytes(segment_sizes[(idx * 4)..(idx + 1) * 4].try_into().unwrap())
+                        as usize;
                 segment_lengths_builder.push_segment(segment_len);
             }
         }
@@ -80,21 +95,25 @@ async fn read_segment_table<R>(mut reader: R,
     // Don't accept a message which the receiver couldn't possibly traverse without hitting the
     // traversal limit. Without this check, a malicious client could transmit a very large segment
     // size to make the receiver allocate excessive space and possibly crash.
-    if segment_lengths_builder.total_words() as u64 > options.traversal_limit_in_words  {
-        return Err(Error::failed(
-            format!("Message has {} words, which is too large. To increase the limit on the \
-             receiving end, see capnp::message::ReaderOptions.", segment_lengths_builder.total_words())))
+    if segment_lengths_builder.total_words() as u64 > options.traversal_limit_in_words {
+        return Err(Error::failed(format!(
+            "Message has {} words, which is too large. To increase the limit on the \
+             receiving end, see capnp::message::ReaderOptions.",
+            segment_lengths_builder.total_words()
+        )));
     }
 
     Ok(Some(segment_lengths_builder))
 }
 
 /// Reads segments from `read`.
-async fn read_segments<R>(mut read: R,
-                          mut owned_segments: OwnedSegments,
-                          options: message::ReaderOptions)
-                    -> Result<message::Reader<OwnedSegments>>
-    where R: AsyncRead + Unpin
+async fn read_segments<R>(
+    mut read: R,
+    mut owned_segments: OwnedSegments,
+    options: message::ReaderOptions,
+) -> Result<message::Reader<OwnedSegments>>
+where
+    R: AsyncRead + Unpin,
 {
     read.read_exact(&mut owned_segments[..]).await?;
     Ok(message::Reader::new(owned_segments, options))
@@ -107,13 +126,18 @@ async fn read_segments<R>(mut read: R,
 ///
 /// Returns the segment count and first segment length, or a state if the
 /// read would block.
-fn parse_segment_table_first(buf: &[u8]) -> Result<(usize, usize)>
-{
+fn parse_segment_table_first(buf: &[u8]) -> Result<(usize, usize)> {
     let segment_count = u32::from_le_bytes(buf[0..4].try_into().unwrap()).wrapping_add(1);
     if segment_count >= 512 {
-        return Err(Error::failed(format!("Too many segments: {}", segment_count)))
+        return Err(Error::failed(format!(
+            "Too many segments: {}",
+            segment_count
+        )));
     } else if segment_count == 0 {
-        return Err(Error::failed(format!("Too few segments: {}", segment_count)))
+        return Err(Error::failed(format!(
+            "Too few segments: {}",
+            segment_count
+        )));
     }
 
     let first_segment_len = u32::from_le_bytes(buf[4..8].try_into().unwrap());
@@ -125,14 +149,19 @@ pub trait AsOutputSegments {
     fn as_output_segments<'a>(&'a self) -> OutputSegments<'a>;
 }
 
-
-impl <'a, M> AsOutputSegments for &'a M where M: AsOutputSegments {
+impl<'a, M> AsOutputSegments for &'a M
+where
+    M: AsOutputSegments,
+{
     fn as_output_segments<'b>(&'b self) -> OutputSegments<'b> {
         (*self).as_output_segments()
     }
 }
 
-impl <A> AsOutputSegments for message::Builder<A> where A: message::Allocator {
+impl<A> AsOutputSegments for message::Builder<A>
+where
+    A: message::Allocator,
+{
     fn as_output_segments<'a>(&'a self) -> OutputSegments<'a> {
         self.get_segments_for_output()
     }
@@ -144,15 +173,20 @@ impl <A> AsOutputSegments for message::Builder<A> where A: message::Allocator {
     }
 }*/
 
-impl <A> AsOutputSegments for ::std::rc::Rc<message::Builder<A>> where A: message::Allocator {
+impl<A> AsOutputSegments for ::std::rc::Rc<message::Builder<A>>
+where
+    A: message::Allocator,
+{
     fn as_output_segments<'a>(&'a self) -> OutputSegments<'a> {
         self.get_segments_for_output()
     }
 }
 
 /// Writes the provided message to `writer`. Does not call `flush()`.
-pub async fn write_message<W,M>(mut writer: W, message: M) -> Result<()>
-    where W: AsyncWrite + Unpin, M: AsOutputSegments
+pub async fn write_message<W, M>(mut writer: W, message: M) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+    M: AsOutputSegments,
 {
     let segments = message.as_output_segments();
     write_segment_table(&mut writer, &segments[..]).await?;
@@ -161,7 +195,8 @@ pub async fn write_message<W,M>(mut writer: W, message: M) -> Result<()>
 }
 
 async fn write_segment_table<W>(mut write: W, segments: &[&[u8]]) -> ::std::io::Result<()>
-    where W: AsyncWrite + Unpin
+where
+    W: AsyncWrite + Unpin,
 {
     let mut buf: [u8; 8] = [0; 8];
     let segment_count = segments.len();
@@ -174,21 +209,25 @@ async fn write_segment_table<W>(mut write: W, segments: &[&[u8]]) -> ::std::io::
     if segment_count > 1 {
         if segment_count < 4 {
             for idx in 1..segment_count {
-                buf[(idx - 1) * 4..idx * 4].copy_from_slice(
-                    &((segments[idx].len() / 8) as u32).to_le_bytes());
+                buf[(idx - 1) * 4..idx * 4]
+                    .copy_from_slice(&((segments[idx].len() / 8) as u32).to_le_bytes());
             }
             if segment_count == 2 {
-                for idx in 4..8 { buf[idx] = 0 }
+                for idx in 4..8 {
+                    buf[idx] = 0
+                }
             }
             write.write_all(&buf).await?;
         } else {
             let mut buf = vec![0; (segment_count & !1) * 4];
             for idx in 1..segment_count {
-                buf[(idx - 1) * 4..idx * 4].copy_from_slice(
-                    &((segments[idx].len() / 8) as u32).to_le_bytes());
+                buf[(idx - 1) * 4..idx * 4]
+                    .copy_from_slice(&((segments[idx].len() / 8) as u32).to_le_bytes());
             }
             if segment_count % 2 == 0 {
-                for idx in (buf.len() - 4)..(buf.len()) { buf[idx] = 0 }
+                for idx in (buf.len() - 4)..(buf.len()) {
+                    buf[idx] = 0
+                }
             }
             write.write_all(&buf).await?;
         }
@@ -198,15 +237,14 @@ async fn write_segment_table<W>(mut write: W, segments: &[&[u8]]) -> ::std::io::
 
 /// Writes segments to `write`.
 async fn write_segments<W>(mut write: W, segments: &[&[u8]]) -> Result<()>
-    where W: AsyncWrite + Unpin
+where
+    W: AsyncWrite + Unpin,
 {
     for i in 0..segments.len() {
         write.write_all(segments[i]).await?;
     }
     Ok(())
 }
-
-
 
 #[cfg(test)]
 pub mod test {
@@ -215,78 +253,129 @@ pub mod test {
     use std::pin::Pin;
     use std::task::{Context, Poll};
 
-    use futures::{AsyncRead, AsyncWrite};
     use futures::io::Cursor;
+    use futures::{AsyncRead, AsyncWrite};
 
     use quickcheck::{quickcheck, TestResult};
 
-    use capnp::{message, OutputSegments};
     use capnp::message::ReaderSegments;
+    use capnp::{message, OutputSegments};
 
-    use super::{
-        AsOutputSegments,
-        read_message,
-        read_segment_table,
-        write_message,
-    };
+    use super::{read_message, read_segment_table, write_message, AsOutputSegments};
 
     #[test]
     fn test_read_segment_table() {
         let mut exec = futures::executor::LocalPool::new();
         let mut buf = vec![];
 
-        buf.extend([0,0,0,0, // 1 segments
-                    0,0,0,0] // 0 length
-                    .iter().cloned());
-        let segment_lengths = exec.run_until(read_segment_table(Cursor::new(&buf[..]),
-                                                                message::ReaderOptions::new())).unwrap().unwrap();
+        buf.extend(
+            [
+                0, 0, 0, 0, // 1 segments
+                0, 0, 0, 0,
+            ] // 0 length
+            .iter()
+            .cloned(),
+        );
+        let segment_lengths = exec
+            .run_until(read_segment_table(
+                Cursor::new(&buf[..]),
+                message::ReaderOptions::new(),
+            ))
+            .unwrap()
+            .unwrap();
         assert_eq!(0, segment_lengths.total_words());
-        assert_eq!(vec![(0,0)], segment_lengths.to_segment_indices());
+        assert_eq!(vec![(0, 0)], segment_lengths.to_segment_indices());
         buf.clear();
 
-        buf.extend([0,0,0,0, // 1 segments
-                    1,0,0,0] // 1 length
-                   .iter().cloned());
+        buf.extend(
+            [
+                0, 0, 0, 0, // 1 segments
+                1, 0, 0, 0,
+            ] // 1 length
+            .iter()
+            .cloned(),
+        );
 
-        let segment_lengths = exec.run_until(read_segment_table(&mut Cursor::new(&buf[..]),
-                                                                message::ReaderOptions::new())).unwrap().unwrap();
+        let segment_lengths = exec
+            .run_until(read_segment_table(
+                &mut Cursor::new(&buf[..]),
+                message::ReaderOptions::new(),
+            ))
+            .unwrap()
+            .unwrap();
         assert_eq!(1, segment_lengths.total_words());
-        assert_eq!(vec![(0,1)], segment_lengths.to_segment_indices());
+        assert_eq!(vec![(0, 1)], segment_lengths.to_segment_indices());
         buf.clear();
 
-        buf.extend([1,0,0,0, // 2 segments
-                    1,0,0,0, // 1 length
-                    1,0,0,0, // 1 length
-                    0,0,0,0] // padding
-                    .iter().cloned());
-        let segment_lengths = exec.run_until(read_segment_table(&mut Cursor::new(&buf[..]),
-                                                                message::ReaderOptions::new())).unwrap().unwrap();
+        buf.extend(
+            [
+                1, 0, 0, 0, // 2 segments
+                1, 0, 0, 0, // 1 length
+                1, 0, 0, 0, // 1 length
+                0, 0, 0, 0,
+            ] // padding
+            .iter()
+            .cloned(),
+        );
+        let segment_lengths = exec
+            .run_until(read_segment_table(
+                &mut Cursor::new(&buf[..]),
+                message::ReaderOptions::new(),
+            ))
+            .unwrap()
+            .unwrap();
         assert_eq!(2, segment_lengths.total_words());
-        assert_eq!(vec![(0,1), (1, 2)], segment_lengths.to_segment_indices());
+        assert_eq!(vec![(0, 1), (1, 2)], segment_lengths.to_segment_indices());
         buf.clear();
 
-        buf.extend([2,0,0,0, // 3 segments
-                    1,0,0,0, // 1 length
-                    1,0,0,0, // 1 length
-                    0,1,0,0] // 256 length
-                    .iter().cloned());
-        let segment_lengths = exec.run_until(read_segment_table(&mut Cursor::new(&buf[..]),
-                                                                message::ReaderOptions::new())).unwrap().unwrap();
+        buf.extend(
+            [
+                2, 0, 0, 0, // 3 segments
+                1, 0, 0, 0, // 1 length
+                1, 0, 0, 0, // 1 length
+                0, 1, 0, 0,
+            ] // 256 length
+            .iter()
+            .cloned(),
+        );
+        let segment_lengths = exec
+            .run_until(read_segment_table(
+                &mut Cursor::new(&buf[..]),
+                message::ReaderOptions::new(),
+            ))
+            .unwrap()
+            .unwrap();
         assert_eq!(258, segment_lengths.total_words());
-        assert_eq!(vec![(0,1), (1, 2), (2, 258)], segment_lengths.to_segment_indices());
+        assert_eq!(
+            vec![(0, 1), (1, 2), (2, 258)],
+            segment_lengths.to_segment_indices()
+        );
         buf.clear();
 
-        buf.extend([3,0,0,0,  // 4 segments
-                    77,0,0,0, // 77 length
-                    23,0,0,0, // 23 length
-                    1,0,0,0,  // 1 length
-                    99,0,0,0, // 99 length
-                    0,0,0,0]  // padding
-                    .iter().cloned());
-        let segment_lengths = exec.run_until(read_segment_table(&mut Cursor::new(&buf[..]),
-                                                                message::ReaderOptions::new())).unwrap().unwrap();
+        buf.extend(
+            [
+                3, 0, 0, 0, // 4 segments
+                77, 0, 0, 0, // 77 length
+                23, 0, 0, 0, // 23 length
+                1, 0, 0, 0, // 1 length
+                99, 0, 0, 0, // 99 length
+                0, 0, 0, 0,
+            ] // padding
+            .iter()
+            .cloned(),
+        );
+        let segment_lengths = exec
+            .run_until(read_segment_table(
+                &mut Cursor::new(&buf[..]),
+                message::ReaderOptions::new(),
+            ))
+            .unwrap()
+            .unwrap();
         assert_eq!(200, segment_lengths.total_words());
-        assert_eq!(vec![(0,77), (77, 100), (100, 101), (101, 200)], segment_lengths.to_segment_indices());
+        assert_eq!(
+            vec![(0, 77), (77, 100), (100, 101), (101, 200)],
+            segment_lengths.to_segment_indices()
+        );
         buf.clear();
     }
 
@@ -295,84 +384,129 @@ pub mod test {
         let mut exec = futures::executor::LocalPool::new();
         let mut buf = vec![];
 
-        buf.extend([0,2,0,0].iter().cloned()); // 513 segments
+        buf.extend([0, 2, 0, 0].iter().cloned()); // 513 segments
         buf.extend([0; 513 * 4].iter().cloned());
-        assert!(exec.run_until(read_segment_table(Cursor::new(&buf[..]),
-                                                  message::ReaderOptions::new())).is_err());
+        assert!(exec
+            .run_until(read_segment_table(
+                Cursor::new(&buf[..]),
+                message::ReaderOptions::new()
+            ))
+            .is_err());
         buf.clear();
 
-        buf.extend([0,0,0,0].iter().cloned()); // 1 segments
-        assert!(exec.run_until(read_segment_table(Cursor::new(&buf[..]),
-                                                  message::ReaderOptions::new())).is_err());
+        buf.extend([0, 0, 0, 0].iter().cloned()); // 1 segments
+        assert!(exec
+            .run_until(read_segment_table(
+                Cursor::new(&buf[..]),
+                message::ReaderOptions::new()
+            ))
+            .is_err());
 
         buf.clear();
 
-        buf.extend([0,0,0,0].iter().cloned()); // 1 segments
+        buf.extend([0, 0, 0, 0].iter().cloned()); // 1 segments
         buf.extend([0; 3].iter().cloned());
-        assert!(exec.run_until(read_segment_table(Cursor::new(&buf[..]),
-                                                  message::ReaderOptions::new())).is_err());
+        assert!(exec
+            .run_until(read_segment_table(
+                Cursor::new(&buf[..]),
+                message::ReaderOptions::new()
+            ))
+            .is_err());
         buf.clear();
 
-        buf.extend([255,255,255,255].iter().cloned()); // 0 segments
-        assert!(exec.run_until(read_segment_table(Cursor::new(&buf[..]),
-                                                  message::ReaderOptions::new())).is_err());
+        buf.extend([255, 255, 255, 255].iter().cloned()); // 0 segments
+        assert!(exec
+            .run_until(read_segment_table(
+                Cursor::new(&buf[..]),
+                message::ReaderOptions::new()
+            ))
+            .is_err());
         buf.clear();
     }
 
     fn construct_segment_table(segments: &[&[u8]]) -> Vec<u8> {
         let mut exec = futures::executor::LocalPool::new();
         let mut buf = vec![];
-        exec.run_until(super::write_segment_table(&mut buf, segments)).unwrap();
+        exec.run_until(super::write_segment_table(&mut buf, segments))
+            .unwrap();
         buf
     }
 
     #[test]
     fn test_construct_segment_table() {
-
         let segment_0: [u8; 0] = [];
-        let segment_1 = [1,0,0,0,0,0,0,0];
+        let segment_1 = [1, 0, 0, 0, 0, 0, 0, 0];
         let segment_199 = [197; 199 * 8];
 
         let buf = construct_segment_table(&[&segment_0]);
-        assert_eq!(&[0,0,0,0,  // 1 segments
-                     0,0,0,0], // 0 length
-                   &buf[..]);
+        assert_eq!(
+            &[
+                0, 0, 0, 0, // 1 segments
+                0, 0, 0, 0
+            ], // 0 length
+            &buf[..]
+        );
 
         let buf = construct_segment_table(&[&segment_1]);
-        assert_eq!(&[0,0,0,0,  // 1 segments
-                     1,0,0,0], // 1 length
-                   &buf[..]);
+        assert_eq!(
+            &[
+                0, 0, 0, 0, // 1 segments
+                1, 0, 0, 0
+            ], // 1 length
+            &buf[..]
+        );
 
         let buf = construct_segment_table(&[&segment_199]);
-        assert_eq!(&[0,0,0,0,    // 1 segments
-                     199,0,0,0], // 199 length
-                   &buf[..]);
+        assert_eq!(
+            &[
+                0, 0, 0, 0, // 1 segments
+                199, 0, 0, 0
+            ], // 199 length
+            &buf[..]
+        );
 
         let buf = construct_segment_table(&[&segment_0, &segment_1]);
-        assert_eq!(&[1,0,0,0,  // 2 segments
-                     0,0,0,0,  // 0 length
-                     1,0,0,0,  // 1 length
-                     0,0,0,0], // padding
-                   &buf[..]);
+        assert_eq!(
+            &[
+                1, 0, 0, 0, // 2 segments
+                0, 0, 0, 0, // 0 length
+                1, 0, 0, 0, // 1 length
+                0, 0, 0, 0
+            ], // padding
+            &buf[..]
+        );
 
         let buf = construct_segment_table(&[&segment_199, &segment_1, &segment_199, &segment_0]);
-        assert_eq!(&[3,0,0,0,   // 4 segments
-                     199,0,0,0, // 199 length
-                     1,0,0,0,   // 1 length
-                     199,0,0,0, // 199 length
-                     0,0,0,0,   // 0 length
-                     0,0,0,0],  // padding
-                   &buf[..]);
+        assert_eq!(
+            &[
+                3, 0, 0, 0, // 4 segments
+                199, 0, 0, 0, // 199 length
+                1, 0, 0, 0, // 1 length
+                199, 0, 0, 0, // 199 length
+                0, 0, 0, 0, // 0 length
+                0, 0, 0, 0
+            ], // padding
+            &buf[..]
+        );
 
-        let buf = construct_segment_table(
-            &[&segment_199, &segment_1, &segment_199, &segment_0, &segment_1]);
-        assert_eq!(&[4,0,0,0,   // 5 segments
-                     199,0,0,0, // 199 length
-                     1,0,0,0,   // 1 length
-                     199,0,0,0, // 199 length
-                     0,0,0,0,   // 0 length
-                     1,0,0,0],  // 1 length
-                   &buf[..]);
+        let buf = construct_segment_table(&[
+            &segment_199,
+            &segment_1,
+            &segment_199,
+            &segment_0,
+            &segment_1,
+        ]);
+        assert_eq!(
+            &[
+                4, 0, 0, 0, // 5 segments
+                199, 0, 0, 0, // 199 length
+                1, 0, 0, 0, // 1 length
+                199, 0, 0, 0, // 199 length
+                0, 0, 0, 0, // 0 length
+                1, 0, 0, 0
+            ], // 1 length
+            &buf[..]
+        );
     }
 
     impl AsOutputSegments for Vec<Vec<capnp::Word>> {
@@ -382,15 +516,20 @@ pub mod test {
             } else if self.len() == 1 {
                 OutputSegments::SingleSegment([capnp::Word::words_to_bytes(&self[0][..])])
             } else {
-                OutputSegments::MultiSegment(self.iter()
-                                             .map(|segment| capnp::Word::words_to_bytes(&segment[..]))
-                                             .collect::<Vec<_>>())
+                OutputSegments::MultiSegment(
+                    self.iter()
+                        .map(|segment| capnp::Word::words_to_bytes(&segment[..]))
+                        .collect::<Vec<_>>(),
+                )
             }
         }
     }
 
     /// Wraps a `Read` instance and introduces blocking.
-    struct BlockingRead<R> where R: Read {
+    struct BlockingRead<R>
+    where
+        R: Read,
+    {
         /// The wrapped reader
         read: R,
 
@@ -401,14 +540,28 @@ pub mod test {
         idx: usize,
     }
 
-    impl <R> BlockingRead<R> where R: Read {
+    impl<R> BlockingRead<R>
+    where
+        R: Read,
+    {
         fn new(read: R, frequency: usize) -> BlockingRead<R> {
-            BlockingRead { read: read, frequency: frequency, idx: 0 }
+            BlockingRead {
+                read: read,
+                frequency: frequency,
+                idx: 0,
+            }
         }
     }
 
-    impl <R> AsyncRead for BlockingRead<R> where R: Read + Unpin {
-        fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context, buf: &mut [u8]) -> Poll<io::Result<usize>> {
+    impl<R> AsyncRead for BlockingRead<R>
+    where
+        R: Read + Unpin,
+    {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context,
+            buf: &mut [u8],
+        ) -> Poll<io::Result<usize>> {
             if self.idx == 0 {
                 self.idx = self.frequency;
                 cx.waker().clone().wake();
@@ -426,7 +579,10 @@ pub mod test {
     }
 
     /// Wraps a `Write` instance and introduces blocking.
-    struct BlockingWrite<W> where W: Write {
+    struct BlockingWrite<W>
+    where
+        W: Write,
+    {
         /// The wrapped writer
         writer: W,
 
@@ -437,17 +593,31 @@ pub mod test {
         idx: usize,
     }
 
-    impl <W> BlockingWrite<W> where W: Write {
+    impl<W> BlockingWrite<W>
+    where
+        W: Write,
+    {
         fn new(writer: W, frequency: usize) -> BlockingWrite<W> {
-            BlockingWrite { writer: writer, frequency: frequency, idx: 0 }
+            BlockingWrite {
+                writer: writer,
+                frequency: frequency,
+                idx: 0,
+            }
         }
         fn into_writer(self) -> W {
             self.writer
         }
     }
 
-    impl <W> AsyncWrite for BlockingWrite<W> where W: Write + Unpin {
-        fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {
+    impl<W> AsyncWrite for BlockingWrite<W>
+    where
+        W: Write + Unpin,
+    {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
             if self.idx == 0 {
                 self.idx = self.frequency;
                 cx.waker().clone().wake();
@@ -473,17 +643,19 @@ pub mod test {
 
     #[test]
     fn check_round_trip_async() {
-        fn round_trip(read_block_frequency: usize,
-                      write_block_frequency: usize,
-                      segments: Vec<Vec<capnp::Word>>) -> TestResult
-        {
+        fn round_trip(
+            read_block_frequency: usize,
+            write_block_frequency: usize,
+            segments: Vec<Vec<capnp::Word>>,
+        ) -> TestResult {
             if segments.len() == 0 || read_block_frequency == 0 || write_block_frequency == 0 {
                 return TestResult::discard();
             }
             let (mut read, segments) = {
                 let cursor = std::io::Cursor::new(Vec::new());
                 let mut writer = BlockingWrite::new(cursor, write_block_frequency);
-                futures::executor::block_on(Box::pin(write_message(&mut writer, &segments))).expect("writing");
+                futures::executor::block_on(Box::pin(write_message(&mut writer, &segments)))
+                    .expect("writing");
 
                 let mut cursor = writer.into_writer();
                 cursor.set_position(0);
@@ -491,15 +663,17 @@ pub mod test {
             };
 
             let message =
-                futures::executor::block_on(Box::pin(read_message(&mut read, Default::default()))).expect("reading").unwrap();
+                futures::executor::block_on(Box::pin(read_message(&mut read, Default::default())))
+                    .expect("reading")
+                    .unwrap();
             let message_segments = message.into_segments();
 
             TestResult::from_bool(segments.iter().enumerate().all(|(i, segment)| {
-                capnp::Word::words_to_bytes(&segment[..]) == message_segments.get_segment(i as u32).unwrap()
+                capnp::Word::words_to_bytes(&segment[..])
+                    == message_segments.get_segment(i as u32).unwrap()
             }))
         }
 
         quickcheck(round_trip as fn(usize, usize, Vec<Vec<capnp::Word>>) -> TestResult);
     }
 }
-

--- a/capnp-futures/src/write_queue.rs
+++ b/capnp-futures/src/write_queue.rs
@@ -18,34 +18,48 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use futures::future::Future;
-use futures::channel::oneshot;
-use futures::{AsyncWrite, AsyncWriteExt, StreamExt, TryFutureExt};
+use futures_channel::oneshot;
+use futures_core::future::Future;
+use futures_io::AsyncWrite;
+use futures_util::{AsyncWriteExt, StreamExt, TryFutureExt};
 
-use capnp::{Error};
+use capnp::Error;
 
-use crate::serialize::{AsOutputSegments};
+use crate::serialize::AsOutputSegments;
 
-enum Item<M> where M: AsOutputSegments {
+enum Item<M>
+where
+    M: AsOutputSegments,
+{
     Message(M, oneshot::Sender<M>),
-    Done(Result<(), Error>, oneshot::Sender<()>)
+    Done(Result<(), Error>, oneshot::Sender<()>),
 }
 /// A handle that allows message to be sent to a write queue`.
-pub struct Sender<M> where M: AsOutputSegments {
-    sender: futures::channel::mpsc::UnboundedSender<Item<M>>,
+pub struct Sender<M>
+where
+    M: AsOutputSegments,
+{
+    sender: futures_channel::mpsc::UnboundedSender<Item<M>>,
 }
 
-impl <M> Clone for Sender<M> where M: AsOutputSegments {
+impl<M> Clone for Sender<M>
+where
+    M: AsOutputSegments,
+{
     fn clone(&self) -> Sender<M> {
-        Sender { sender: self.sender.clone() }
+        Sender {
+            sender: self.sender.clone(),
+        }
     }
 }
 
 /// Creates a new WriteQueue that wraps the given writer.
-pub fn write_queue<W, M>(mut writer: W) -> (Sender<M>, impl Future<Output=Result<(),Error>> )
-    where W: AsyncWrite + Unpin , M: AsOutputSegments
+pub fn write_queue<W, M>(mut writer: W) -> (Sender<M>, impl Future<Output = Result<(), Error>>)
+where
+    W: AsyncWrite + Unpin,
+    M: AsOutputSegments,
 {
-    let (tx, mut rx) = futures::channel::mpsc::unbounded();
+    let (tx, mut rx) = futures_channel::mpsc::unbounded();
 
     let sender = Sender { sender: tx };
 
@@ -69,16 +83,18 @@ pub fn write_queue<W, M>(mut writer: W) -> (Sender<M>, impl Future<Output=Result
     (sender, queue)
 }
 
-impl <M> Sender<M> where M: AsOutputSegments  {
+impl<M> Sender<M>
+where
+    M: AsOutputSegments,
+{
     /// Enqueues a message to be written. The returned future resolves once the write
     /// has completed.
-    pub fn send(&mut self, message: M) -> impl Future<Output=Result<M,Error>> + Unpin  {
+    pub fn send(&mut self, message: M) -> impl Future<Output = Result<M, Error>> + Unpin {
         let (complete, oneshot) = oneshot::channel();
 
         let _ = self.sender.unbounded_send(Item::Message(message, complete));
 
-        oneshot.map_err(
-            |oneshot::Canceled| Error::disconnected("WriteQueue has terminated".into()))
+        oneshot.map_err(|oneshot::Canceled| Error::disconnected("WriteQueue has terminated".into()))
     }
 
     /// Returns the number of messages queued to be written, not including any in-progress write.
@@ -89,12 +105,15 @@ impl <M> Sender<M> where M: AsOutputSegments  {
     /// Commands the queue to stop writing messages once it is empty. After this method has been called,
     /// any new calls to `send()` will return a future that immediately resolves to an error.
     /// If the passed-in `result` is an error, then the `WriteQueue` will resolve to that error.
-    pub fn terminate(&mut self, result: Result<(), Error>) -> impl Future<Output=Result<(),Error>> + Unpin  {
+    pub fn terminate(
+        &mut self,
+        result: Result<(), Error>,
+    ) -> impl Future<Output = Result<(), Error>> + Unpin {
         let (complete, receiver) = oneshot::channel();
 
         let _ = self.sender.unbounded_send(Item::Done(result, complete));
 
-        receiver.map_err(
-            |oneshot::Canceled| Error::disconnected("WriteQueue has terminated".into()))
+        receiver
+            .map_err(|oneshot::Canceled| Error::disconnected("WriteQueue has terminated".into()))
     }
 }

--- a/capnp-rpc/Cargo.toml
+++ b/capnp-rpc/Cargo.toml
@@ -18,11 +18,23 @@ readme = "README.md"
 name = "capnp_rpc"
 path = "src/lib.rs"
 
-[dependencies.futures]
-version = "0.3.0"
-default-features = false
-features = ["std"]
 
 [dependencies]
 capnp-futures = { version = "0.13.0", path = "../capnp-futures" }
 capnp = {version = "0.13.0", path = "../capnp"}
+futures-core = { version = "0.3.0", default-features = false }
+
+[dependencies.futures-io]
+version = "0.3.0"
+default-features = false
+features = ["std"]
+
+[dependencies.futures-util]
+version = "0.3.0"
+default-features = false
+features = ["io"]
+
+[dependencies.futures-channel]
+version = "0.3.0"
+default-features = false
+features = ["std"]

--- a/capnp-rpc/src/attach.rs
+++ b/capnp-rpc/src/attach.rs
@@ -18,19 +18,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+use futures_core::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use futures::{Future};
 
-pub struct AttachFuture<F, T> where F: Future + Unpin {
+pub struct AttachFuture<F, T>
+where
+    F: Future + Unpin,
+{
     original_future: F,
     value: Option<T>,
 }
 
-impl <F,T> Unpin for AttachFuture<F, T> where F: Future + Unpin {}
+impl<F, T> Unpin for AttachFuture<F, T> where F: Future + Unpin {}
 
-impl <F, T> Future for AttachFuture<F, T>
-    where F: Future + Unpin,
+impl<F, T> Future for AttachFuture<F, T>
+where
+    F: Future + Unpin,
 {
     type Output = F::Output;
 
@@ -43,9 +47,13 @@ impl <F, T> Future for AttachFuture<F, T>
     }
 }
 
-pub trait Attach: Future where Self: Unpin {
+pub trait Attach: Future
+where
+    Self: Unpin,
+{
     fn attach<T>(self, value: T) -> AttachFuture<Self, T>
-        where Self: Sized
+    where
+        Self: Sized,
     {
         AttachFuture {
             original_future: self,
@@ -54,4 +62,4 @@ pub trait Attach: Future where Self: Unpin {
     }
 }
 
-impl <F> Attach for F where F: Future + Unpin {}
+impl<F> Attach for F where F: Future + Unpin {}

--- a/capnp-rpc/src/local.rs
+++ b/capnp-rpc/src/local.rs
@@ -18,19 +18,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use capnp::{any_pointer, message};
-use capnp::Error;
-use capnp::traits::{Imbue, ImbueMut};
 use capnp::capability::{self, Promise};
-use capnp::private::capability::{ClientHook, ParamsHook, PipelineHook, PipelineOp,
-                                 RequestHook, ResponseHook, ResultsHook};
+use capnp::private::capability::{
+    ClientHook, ParamsHook, PipelineHook, PipelineOp, RequestHook, ResponseHook, ResultsHook,
+};
+use capnp::traits::{Imbue, ImbueMut};
+use capnp::Error;
+use capnp::{any_pointer, message};
 
-use futures::{TryFutureExt};
-use futures::channel::oneshot;
+use futures_channel::oneshot;
+use futures_util::TryFutureExt;
 
 use std::cell::RefCell;
-use std::rc::{Rc};
 use std::mem;
+use std::rc::Rc;
 
 pub trait ResultsDoneHook {
     fn add_ref(&self) -> Box<dyn ResultsDoneHook>;
@@ -44,14 +45,12 @@ impl Clone for Box<dyn ResultsDoneHook> {
 }
 
 pub struct Response {
-    results: Box<dyn ResultsDoneHook>
+    results: Box<dyn ResultsDoneHook>,
 }
 
 impl Response {
     fn new(results: Box<dyn ResultsDoneHook>) -> Response {
-        Response {
-            results: results
-        }
+        Response { results: results }
     }
 }
 
@@ -67,10 +66,10 @@ struct Params {
 }
 
 impl Params {
-    fn new(request: message::Builder<message::HeapAllocator>,
-           cap_table: Vec<Option<Box<dyn ClientHook>>>)
-           -> Params
-    {
+    fn new(
+        request: message::Builder<message::HeapAllocator>,
+        cap_table: Vec<Option<Box<dyn ClientHook>>>,
+    ) -> Params {
         Params {
             request: request,
             cap_table: cap_table,
@@ -104,7 +103,9 @@ impl Results {
 
 impl Drop for Results {
     fn drop(&mut self) {
-        if let (Some(message), Some(fulfiller)) = (self.message.take(), self.results_done_fulfiller.take()) {
+        if let (Some(message), Some(fulfiller)) =
+            (self.message.take(), self.results_done_fulfiller.take())
+        {
             let cap_table = mem::replace(&mut self.cap_table, Vec::new());
             let _ = fulfiller.send(Box::new(ResultsDone::new(message, cap_table)));
         } else {
@@ -116,7 +117,11 @@ impl Drop for Results {
 impl ResultsHook for Results {
     fn get<'a>(&'a mut self) -> ::capnp::Result<any_pointer::Builder<'a>> {
         match *self {
-            Results { message: Some(ref mut message), ref mut cap_table, .. } => {
+            Results {
+                message: Some(ref mut message),
+                ref mut cap_table,
+                ..
+            } => {
                 let mut result: any_pointer::Builder = message.get_root()?;
                 result.imbue_mut(cap_table);
                 Ok(result)
@@ -129,9 +134,10 @@ impl ResultsHook for Results {
         unimplemented!()
     }
 
-    fn direct_tail_call(self: Box<Self>, _request: Box<dyn RequestHook>)
-                        -> (Promise<(), Error>, Box<dyn PipelineHook>)
-    {
+    fn direct_tail_call(
+        self: Box<Self>,
+        _request: Box<dyn RequestHook>,
+    ) -> (Promise<(), Error>, Box<dyn PipelineHook>) {
         unimplemented!()
     }
 
@@ -150,11 +156,10 @@ struct ResultsDone {
 }
 
 impl ResultsDone {
-    fn new(message: message::Builder<message::HeapAllocator>,
-           cap_table: Vec<Option<Box<dyn ClientHook>>>,
-    )
-        -> ResultsDone
-    {
+    fn new(
+        message: message::Builder<message::HeapAllocator>,
+        cap_table: Vec<Option<Box<dyn ClientHook>>>,
+    ) -> ResultsDone {
         ResultsDone {
             inner: Rc::new(ResultsDoneInner {
                 message: message,
@@ -166,7 +171,9 @@ impl ResultsDone {
 
 impl ResultsDoneHook for ResultsDone {
     fn add_ref(&self) -> Box<dyn ResultsDoneHook> {
-        Box::new(ResultsDone { inner: self.inner.clone() })
+        Box::new(ResultsDone {
+            inner: self.inner.clone(),
+        })
     }
     fn get<'a>(&'a self) -> ::capnp::Result<any_pointer::Reader<'a>> {
         let mut result: any_pointer::Reader = self.inner.message.get_root_as_reader()?;
@@ -174,7 +181,6 @@ impl ResultsDoneHook for ResultsDone {
         Ok(result)
     }
 }
-
 
 pub struct Request {
     message: message::Builder<::capnp::message::HeapAllocator>,
@@ -185,11 +191,12 @@ pub struct Request {
 }
 
 impl Request {
-    pub fn new(interface_id: u64, method_id: u16,
-           _size_hint: Option<::capnp::MessageSize>,
-           client: Box<dyn ClientHook>)
-           -> Request
-    {
+    pub fn new(
+        interface_id: u64,
+        method_id: u16,
+        _size_hint: Option<::capnp::MessageSize>,
+        client: Box<dyn ClientHook>,
+    ) -> Request {
         Request {
             message: message::Builder::new_default(),
             cap_table: Vec::new(),
@@ -211,21 +218,34 @@ impl RequestHook for Request {
     }
     fn send(self: Box<Self>) -> capability::RemotePromise<any_pointer::Owned> {
         let tmp = *self;
-        let Request { message, cap_table, interface_id, method_id, client } = tmp;
+        let Request {
+            message,
+            cap_table,
+            interface_id,
+            method_id,
+            client,
+        } = tmp;
         let params = Params::new(message, cap_table);
 
-        let (results_done_fulfiller, results_done_promise) = oneshot::channel::<Box<dyn ResultsDoneHook>>();
+        let (results_done_fulfiller, results_done_promise) =
+            oneshot::channel::<Box<dyn ResultsDoneHook>>();
         let results_done_promise = results_done_promise.map_err(crate::canceled_to_error);
         let results = Results::new(results_done_fulfiller);
         let promise = client.call(interface_id, method_id, Box::new(params), Box::new(results));
 
-
         let (pipeline_sender, mut pipeline) = crate::queued::Pipeline::new();
 
-        let p = futures::future::try_join(promise, results_done_promise).and_then(move |((), results_done_hook)| {
-            pipeline_sender.complete(Box::new(Pipeline::new(results_done_hook.add_ref())) as Box<dyn PipelineHook>);
-            Promise::ok((capability::Response::new(Box::new(Response::new(results_done_hook))), ()))
-        });
+        let p = futures_util::future::try_join(promise, results_done_promise).and_then(
+            move |((), results_done_hook)| {
+                pipeline_sender
+                    .complete(Box::new(Pipeline::new(results_done_hook.add_ref()))
+                        as Box<dyn PipelineHook>);
+                Promise::ok((
+                    capability::Response::new(Box::new(Response::new(results_done_hook))),
+                    (),
+                ))
+            },
+        );
 
         let (left, right) = crate::split::split(p);
 
@@ -237,9 +257,7 @@ impl RequestHook for Request {
             pipeline: pipeline,
         }
     }
-    fn tail_send(self: Box<Self>)
-                 -> Option<(u32, Promise<(), Error>, Box<dyn PipelineHook>)>
-    {
+    fn tail_send(self: Box<Self>) -> Option<(u32, Promise<(), Error>, Box<dyn PipelineHook>)> {
         unimplemented!()
     }
 }
@@ -255,14 +273,16 @@ pub struct Pipeline {
 impl Pipeline {
     pub fn new(results: Box<dyn ResultsDoneHook>) -> Pipeline {
         Pipeline {
-            inner: Rc::new(RefCell::new(PipelineInner { results: results }))
+            inner: Rc::new(RefCell::new(PipelineInner { results: results })),
         }
     }
 }
 
 impl Clone for Pipeline {
     fn clone(&self) -> Pipeline {
-        Pipeline { inner: self.inner.clone() }
+        Pipeline {
+            inner: self.inner.clone(),
+        }
     }
 }
 
@@ -271,7 +291,14 @@ impl PipelineHook for Pipeline {
         Box::new(self.clone())
     }
     fn get_pipelined_cap(&self, ops: &[PipelineOp]) -> Box<dyn ClientHook> {
-        match self.inner.borrow_mut().results.get().unwrap().get_pipelined_cap(ops) {
+        match self
+            .inner
+            .borrow_mut()
+            .results
+            .get()
+            .unwrap()
+            .get_pipelined_cap(ops)
+        {
             Ok(v) => v,
             Err(e) => Box::new(crate::broken::Client::new(e, true, 0)) as Box<dyn ClientHook>,
         }
@@ -289,14 +316,16 @@ pub struct Client {
 impl Client {
     pub fn new(server: Box<dyn capability::Server>) -> Client {
         Client {
-            inner: Rc::new(RefCell::new(ClientInner { server: server }))
+            inner: Rc::new(RefCell::new(ClientInner { server: server })),
         }
     }
 }
 
 impl Clone for Client {
     fn clone(&self) -> Client {
-        Client { inner: self.inner.clone() }
+        Client {
+            inner: self.inner.clone(),
+        }
     }
 }
 
@@ -304,17 +333,27 @@ impl ClientHook for Client {
     fn add_ref(&self) -> Box<dyn ClientHook> {
         Box::new(self.clone())
     }
-    fn new_call(&self, interface_id: u64, method_id: u16,
-                size_hint: Option<::capnp::MessageSize>)
-                -> capability::Request<any_pointer::Owned, any_pointer::Owned>
-    {
-        capability::Request::new(
-            Box::new(Request::new(interface_id, method_id, size_hint, self.add_ref())))
+    fn new_call(
+        &self,
+        interface_id: u64,
+        method_id: u16,
+        size_hint: Option<::capnp::MessageSize>,
+    ) -> capability::Request<any_pointer::Owned, any_pointer::Owned> {
+        capability::Request::new(Box::new(Request::new(
+            interface_id,
+            method_id,
+            size_hint,
+            self.add_ref(),
+        )))
     }
 
-    fn call(&self, interface_id: u64, method_id: u16, params: Box<dyn ParamsHook>, results: Box<dyn ResultsHook>)
-        -> Promise<(), Error>
-    {
+    fn call(
+        &self,
+        interface_id: u64,
+        method_id: u16,
+        params: Box<dyn ParamsHook>,
+        results: Box<dyn ResultsHook>,
+    ) -> Promise<(), Error> {
         // We don't want to actually dispatch the call synchronously, because we don't want the callee
         // to have any side effects before the promise is returned to the caller.  This helps avoid
         // race conditions.
@@ -327,16 +366,19 @@ impl ClientHook for Client {
                 // We put this borrow_mut() inside a block to avoid a potential
                 // double borrow during f.await
                 let server = &mut inner.borrow_mut().server;
-                server.dispatch_call(interface_id, method_id,
-                                     ::capnp::capability::Params::new(params),
-                                     ::capnp::capability::Results::new(results))
+                server.dispatch_call(
+                    interface_id,
+                    method_id,
+                    ::capnp::capability::Params::new(params),
+                    ::capnp::capability::Results::new(results),
+                )
             };
             f.await
         })
     }
 
     fn get_ptr(&self) -> usize {
-        (&*self.inner.borrow()) as * const _ as usize
+        (&*self.inner.borrow()) as *const _ as usize
     }
 
     fn get_brand(&self) -> usize {

--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -22,28 +22,32 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use capnp::{any_pointer};
-use capnp::Error;
+use capnp::any_pointer;
 use capnp::capability::Promise;
-use capnp::private::capability::{ClientHook, ParamsHook, PipelineHook, PipelineOp,
-                                 RequestHook, ResponseHook, ResultsHook};
+use capnp::private::capability::{
+    ClientHook, ParamsHook, PipelineHook, PipelineOp, RequestHook, ResponseHook, ResultsHook,
+};
+use capnp::Error;
 
-use futures::{future, Future, FutureExt, TryFutureExt};
-use futures::channel::oneshot;
+use futures_channel::oneshot;
+use futures_core::Future;
+use futures_util::{future, FutureExt, TryFutureExt};
 
-use std::vec::Vec;
-use std::collections::hash_map::HashMap;
-use std::collections::binary_heap::BinaryHeap;
 use std::cell::{Cell, RefCell};
+use std::collections::binary_heap::BinaryHeap;
+use std::collections::hash_map::HashMap;
 use std::rc::{Rc, Weak};
+use std::vec::Vec;
 use std::{cmp, mem};
 
-use crate::rpc_capnp::{call, cap_descriptor, disembargo, exception,
-                message, message_target, payload, resolve, return_, promised_answer};
 use crate::attach::Attach;
-use crate::{broken, local, queued};
 use crate::local::ResultsDoneHook;
+use crate::rpc_capnp::{
+    call, cap_descriptor, disembargo, exception, message, message_target, payload, promised_answer,
+    resolve, return_,
+};
 use crate::task_set::TaskSet;
+use crate::{broken, local, queued};
 
 pub type QuestionId = u32;
 pub type AnswerId = QuestionId;
@@ -54,20 +58,28 @@ pub struct ImportTable<T> {
     slots: HashMap<u32, T>,
 }
 
-impl <T> ImportTable<T> {
+impl<T> ImportTable<T> {
     pub fn new() -> ImportTable<T> {
-        ImportTable { slots : HashMap::new() }
+        ImportTable {
+            slots: HashMap::new(),
+        }
     }
 }
 
 #[derive(PartialEq, Eq)]
-struct ReverseU32 { val: u32 }
+struct ReverseU32 {
+    val: u32,
+}
 
 impl cmp::Ord for ReverseU32 {
     fn cmp(&self, other: &ReverseU32) -> cmp::Ordering {
-        if self.val > other.val { cmp::Ordering::Less }
-        else if self.val < other.val { cmp::Ordering::Greater }
-        else { cmp::Ordering::Equal }
+        if self.val > other.val {
+            cmp::Ordering::Less
+        } else if self.val < other.val {
+            cmp::Ordering::Greater
+        } else {
+            cmp::Ordering::Equal
+        }
     }
 }
 
@@ -84,34 +96,42 @@ struct ExportTable<T> {
     free_ids: BinaryHeap<ReverseU32>,
 }
 
-struct ExportTableIter<'a, T> where T: 'a {
+struct ExportTableIter<'a, T>
+where
+    T: 'a,
+{
     table: &'a ExportTable<T>,
     idx: usize,
 }
 
-impl <'a, T> ::std::iter::Iterator for ExportTableIter<'a, T> where T: 'a{
+impl<'a, T> ::std::iter::Iterator for ExportTableIter<'a, T>
+where
+    T: 'a,
+{
     type Item = &'a T;
     fn next(&mut self) -> Option<&'a T> {
         while self.idx < self.table.slots.len() {
             let idx = self.idx;
             self.idx += 1;
             if let Some(ref v) = self.table.slots[idx] {
-                return Some(v)
+                return Some(v);
             }
         }
         None
     }
 }
 
-impl <T> ExportTable<T> {
+impl<T> ExportTable<T> {
     pub fn new() -> ExportTable<T> {
-        ExportTable { slots: Vec::new(),
-                      free_ids: BinaryHeap::new() }
+        ExportTable {
+            slots: Vec::new(),
+            free_ids: BinaryHeap::new(),
+        }
     }
 
     pub fn erase(&mut self, id: u32) {
         self.slots[id as usize] = None;
-        self.free_ids.push(ReverseU32 { val: id } );
+        self.free_ids.push(ReverseU32 { val: id });
     }
 
     pub fn push(&mut self, val: T) -> u32 {
@@ -142,41 +162,56 @@ impl <T> ExportTable<T> {
     pub fn iter<'a>(&'a self) -> ExportTableIter<'a, T> {
         ExportTableIter {
             table: self,
-            idx: 0
+            idx: 0,
         }
     }
 }
 
-struct Question<VatId> where VatId: 'static {
+struct Question<VatId>
+where
+    VatId: 'static,
+{
     is_awaiting_return: bool,
     param_exports: Vec<ExportId>,
     is_tail_call: bool,
 
     /// The local QuestionRef, set to None when it is destroyed.
-    self_ref: Option<Weak<RefCell<QuestionRef<VatId>>>>
+    self_ref: Option<Weak<RefCell<QuestionRef<VatId>>>>,
 }
 
-impl <VatId> Question<VatId> {
+impl<VatId> Question<VatId> {
     fn new() -> Question<VatId> {
-        Question { is_awaiting_return: true, param_exports: Vec::new(),
-                   is_tail_call: false, self_ref: None }
+        Question {
+            is_awaiting_return: true,
+            param_exports: Vec::new(),
+            is_tail_call: false,
+            self_ref: None,
+        }
     }
 }
 
 /// A reference to an entry on the question table.  Used to detect when the `Finish` message
 /// can be sent.
-struct QuestionRef<VatId> where VatId: 'static {
+struct QuestionRef<VatId>
+where
+    VatId: 'static,
+{
     connection_state: Rc<ConnectionState<VatId>>,
     id: QuestionId,
     fulfiller: Option<oneshot::Sender<Promise<Response<VatId>, Error>>>,
 }
 
-impl <VatId> QuestionRef<VatId> {
-    fn new(state: Rc<ConnectionState<VatId>>, id: QuestionId,
-           fulfiller: oneshot::Sender<Promise<Response<VatId>, Error>>)
-           -> QuestionRef<VatId>
-    {
-        QuestionRef { connection_state: state, id: id, fulfiller: Some(fulfiller) }
+impl<VatId> QuestionRef<VatId> {
+    fn new(
+        state: Rc<ConnectionState<VatId>>,
+        id: QuestionId,
+        fulfiller: oneshot::Sender<Promise<Response<VatId>, Error>>,
+    ) -> QuestionRef<VatId> {
+        QuestionRef {
+            connection_state: state,
+            id: id,
+            fulfiller: Some(fulfiller),
+        }
     }
     fn fulfill(&mut self, response: Promise<Response<VatId>, Error>) {
         if let Some(fulfiller) = self.fulfiller.take() {
@@ -191,7 +226,7 @@ impl <VatId> QuestionRef<VatId> {
     }
 }
 
-impl <VatId> Drop for QuestionRef<VatId> {
+impl<VatId> Drop for QuestionRef<VatId> {
     fn drop(&mut self) {
         let mut questions = self.connection_state.questions.borrow_mut();
         match questions.slots[self.id as usize] {
@@ -221,14 +256,15 @@ impl <VatId> Drop for QuestionRef<VatId> {
                     questions.erase(self.id)
                 }
             }
-            None => {
-                unreachable!()
-            }
+            None => unreachable!(),
         }
     }
 }
 
-struct Answer<VatId> where VatId: 'static {
+struct Answer<VatId>
+where
+    VatId: 'static,
+{
     // True from the point when the Call message is received to the point when both the `Finish`
     // message has been received and the `Return` has been sent.
     active: bool,
@@ -250,7 +286,7 @@ struct Answer<VatId> where VatId: 'static {
     result_exports: Vec<ExportId>,
 }
 
-impl <VatId> Answer<VatId> {
+impl<VatId> Answer<VatId> {
     fn new() -> Answer<VatId> {
         Answer {
             active: false,
@@ -283,7 +319,10 @@ impl Export {
     }
 }
 
-pub struct Import<VatId> where VatId: 'static {
+pub struct Import<VatId>
+where
+    VatId: 'static,
+{
     // Becomes null when the import is destroyed.
     import_client: Option<(Weak<RefCell<ImportClient<VatId>>>, usize)>,
 
@@ -296,7 +335,7 @@ pub struct Import<VatId> where VatId: 'static {
     promise_client_to_resolve: Option<Weak<RefCell<PromiseClient<VatId>>>>,
 }
 
-impl <VatId> Import<VatId> {
+impl<VatId> Import<VatId> {
     fn new() -> Import<VatId> {
         Import {
             import_client: None,
@@ -312,13 +351,15 @@ struct Embargo {
 
 impl Embargo {
     fn new(fulfiller: oneshot::Sender<Result<(), Error>>) -> Embargo {
-        Embargo { fulfiller: Some(fulfiller) }
+        Embargo {
+            fulfiller: Some(fulfiller),
+        }
     }
 }
 
-fn to_pipeline_ops(ops: ::capnp::struct_list::Reader<promised_answer::op::Owned>)
-                   -> ::capnp::Result<Vec<PipelineOp>>
-{
+fn to_pipeline_ops(
+    ops: ::capnp::struct_list::Reader<promised_answer::op::Owned>,
+) -> ::capnp::Result<Vec<PipelineOp>> {
     let mut result = Vec::new();
     for op in ops.iter() {
         match op.which()? {
@@ -346,30 +387,38 @@ fn from_error(error: &Error, mut builder: exception::Builder) {
 
 fn remote_exception_to_error(exception: exception::Reader) -> Error {
     let (kind, reason) = match (exception.get_type(), exception.get_reason()) {
-        (Ok(exception::Type::Failed), Ok(reason)) =>
-            (::capnp::ErrorKind::Failed, reason),
-        (Ok(exception::Type::Overloaded), Ok(reason)) =>
-            (::capnp::ErrorKind::Overloaded, reason),
-        (Ok(exception::Type::Disconnected), Ok(reason)) =>
-            (::capnp::ErrorKind::Disconnected, reason),
-        (Ok(exception::Type::Unimplemented), Ok(reason)) =>
-            (::capnp::ErrorKind::Unimplemented, reason),
+        (Ok(exception::Type::Failed), Ok(reason)) => (::capnp::ErrorKind::Failed, reason),
+        (Ok(exception::Type::Overloaded), Ok(reason)) => (::capnp::ErrorKind::Overloaded, reason),
+        (Ok(exception::Type::Disconnected), Ok(reason)) => {
+            (::capnp::ErrorKind::Disconnected, reason)
+        }
+        (Ok(exception::Type::Unimplemented), Ok(reason)) => {
+            (::capnp::ErrorKind::Unimplemented, reason)
+        }
         _ => (::capnp::ErrorKind::Failed, "(malformed error)"),
     };
-    Error { description: format!("remote exception: {}", reason), kind: kind }
-}
-
-pub struct ConnectionErrorHandler<VatId> where VatId: 'static {
-    weak_state: Weak<ConnectionState<VatId>>,
-}
-
-impl <VatId> ConnectionErrorHandler<VatId> {
-    fn new(weak_state: Weak<ConnectionState<VatId>>) -> ConnectionErrorHandler<VatId> {
-        ConnectionErrorHandler { weak_state: weak_state }
+    Error {
+        description: format!("remote exception: {}", reason),
+        kind: kind,
     }
 }
 
-impl <VatId> crate::task_set::TaskReaper<capnp::Error> for ConnectionErrorHandler<VatId> {
+pub struct ConnectionErrorHandler<VatId>
+where
+    VatId: 'static,
+{
+    weak_state: Weak<ConnectionState<VatId>>,
+}
+
+impl<VatId> ConnectionErrorHandler<VatId> {
+    fn new(weak_state: Weak<ConnectionState<VatId>>) -> ConnectionErrorHandler<VatId> {
+        ConnectionErrorHandler {
+            weak_state: weak_state,
+        }
+    }
+}
+
+impl<VatId> crate::task_set::TaskReaper<capnp::Error> for ConnectionErrorHandler<VatId> {
     fn task_failed(&mut self, error: ::capnp::Error) {
         if let Some(state) = self.weak_state.upgrade() {
             state.disconnect(error)
@@ -377,7 +426,10 @@ impl <VatId> crate::task_set::TaskReaper<capnp::Error> for ConnectionErrorHandle
     }
 }
 
-pub struct ConnectionState<VatId> where VatId: 'static {
+pub struct ConnectionState<VatId>
+where
+    VatId: 'static,
+{
     bootstrap_cap: Box<dyn ClientHook>,
     exports: RefCell<ExportTable<Export>>,
     questions: RefCell<ExportTable<Question<VatId>>>,
@@ -395,13 +447,12 @@ pub struct ConnectionState<VatId> where VatId: 'static {
     client_downcast_map: RefCell<HashMap<usize, WeakClient<VatId>>>,
 }
 
-impl <VatId> ConnectionState<VatId> {
+impl<VatId> ConnectionState<VatId> {
     pub fn new(
         bootstrap_cap: Box<dyn ClientHook>,
         connection: Box<dyn crate::Connection<VatId>>,
-        disconnect_fulfiller: oneshot::Sender<Promise<(), Error>>)
-        -> (TaskSet<Error>, Rc<ConnectionState<VatId>>)
-    {
+        disconnect_fulfiller: oneshot::Sender<Promise<(), Error>>,
+    ) -> (TaskSet<Error>, Rc<ConnectionState<VatId>>) {
         let state = Rc::new(ConnectionState {
             bootstrap_cap: bootstrap_cap,
             exports: RefCell::new(ExportTable::new()),
@@ -415,14 +466,18 @@ impl <VatId> ConnectionState<VatId> {
             disconnect_fulfiller: RefCell::new(Some(disconnect_fulfiller)),
             client_downcast_map: RefCell::new(HashMap::new()),
         });
-        let (mut handle, tasks) = TaskSet::new(Box::new(ConnectionErrorHandler::new(Rc::downgrade(&state))));
+        let (mut handle, tasks) =
+            TaskSet::new(Box::new(ConnectionErrorHandler::new(Rc::downgrade(&state))));
 
         handle.add(ConnectionState::message_loop(Rc::downgrade(&state)));
         *state.tasks.borrow_mut() = Some(handle);
         (tasks, state)
     }
 
-    fn new_outgoing_message(&self, first_segment_words: u32) -> capnp::Result<Box<dyn crate::OutgoingMessage>> {
+    fn new_outgoing_message(
+        &self,
+        first_segment_words: u32,
+    ) -> capnp::Result<Box<dyn crate::OutgoingMessage>> {
         match self.connection.borrow_mut().as_mut() {
             Err(e) => Err(e.clone()),
             Ok(c) => Ok(c.new_outgoing_message(first_segment_words)),
@@ -459,9 +514,13 @@ impl <VatId> ConnectionState<VatId> {
         }
 
         let len = self.exports.borrow().slots.len();
-        for idx in 0..len  {
+        for idx in 0..len {
             if let Some(exp) = self.exports.borrow_mut().slots[idx].take() {
-                let Export { client_hook, resolve_op, .. } = exp;
+                let Export {
+                    client_hook,
+                    resolve_op,
+                    ..
+                } = exp;
                 clients_to_release.push(client_hook);
                 resolve_ops_to_release.push(resolve_op);
             }
@@ -498,7 +557,11 @@ impl <VatId> ConnectionState<VatId> {
             Ok(ref mut c) => {
                 let mut message = c.new_outgoing_message(100); // TODO estimate size
                 {
-                    let builder = message.get_body().unwrap().init_as::<message::Builder>().init_abort();
+                    let builder = message
+                        .get_body()
+                        .unwrap()
+                        .init_as::<message::Builder>()
+                        .init_abort();
                     from_error(&error, builder);
                 }
                 let _ = message.send();
@@ -521,7 +584,8 @@ impl <VatId> ConnectionState<VatId> {
                         }
                     }
                 });
-                let maybe_fulfiller = mem::replace(&mut *self.disconnect_fulfiller.borrow_mut(), None);
+                let maybe_fulfiller =
+                    mem::replace(&mut *self.disconnect_fulfiller.borrow_mut(), None);
                 match maybe_fulfiller {
                     None => unreachable!(),
                     Some(fulfiller) => {
@@ -536,22 +600,27 @@ impl <VatId> ConnectionState<VatId> {
     // Transform a future into a promise that gets executed even if it is never polled.
     // Dropping the returned promise cancels the computation.
     fn eagerly_evaluate<T, F>(&self, task: F) -> Promise<T, Error>
-        where F: Future<Output=Result<T,Error>> + 'static + Unpin,
-              T: 'static
+    where
+        F: Future<Output = Result<T, Error>> + 'static + Unpin,
+        T: 'static,
     {
-        let (tx, rx) = oneshot::channel::<Result<T,Error>>();
+        let (tx, rx) = oneshot::channel::<Result<T, Error>>();
         let (tx2, rx2) = oneshot::channel::<()>();
-        let f1 = Box::pin(task.map(move |r| { let _ = tx.send(r);}))
-            as Pin<Box<dyn Future<Output = ()> + Unpin>>;
-        let f2 = Box::pin(rx2.map(drop))
-            as Pin<Box<dyn Future<Output = ()> + Unpin>>;
+        let f1 = Box::pin(task.map(move |r| {
+            let _ = tx.send(r);
+        })) as Pin<Box<dyn Future<Output = ()> + Unpin>>;
+        let f2 = Box::pin(rx2.map(drop)) as Pin<Box<dyn Future<Output = ()> + Unpin>>;
 
         self.add_task(future::select(f1, f2).map(|_| Ok(())));
-        Promise::from_future(rx.map_err(crate::canceled_to_error).map(|r| {drop(tx2); r?}))
+        Promise::from_future(rx.map_err(crate::canceled_to_error).map(|r| {
+            drop(tx2);
+            r?
+        }))
     }
 
     fn add_task<F>(&self, task: F)
-        where F: Future<Output=Result<(),Error>> + 'static
+    where
+        F: Future<Output = Result<(), Error>> + 'static,
     {
         if let Some(ref mut tasks) = *self.tasks.borrow_mut() {
             tasks.add(task);
@@ -563,8 +632,12 @@ impl <VatId> ConnectionState<VatId> {
 
         let (fulfiller, promise) = oneshot::channel();
         let promise = promise.map_err(crate::canceled_to_error);
-        let promise = promise.and_then(|response_promise| response_promise );
-        let question_ref = Rc::new(RefCell::new(QuestionRef::new(state.clone(), question_id, fulfiller)));
+        let promise = promise.and_then(|response_promise| response_promise);
+        let question_ref = Rc::new(RefCell::new(QuestionRef::new(
+            state.clone(),
+            question_id,
+            fulfiller,
+        )));
         let promise = promise.attach(question_ref.clone());
         match state.questions.borrow_mut().slots[question_id as usize] {
             Some(ref mut q) => {
@@ -576,7 +649,11 @@ impl <VatId> ConnectionState<VatId> {
             Ok(ref mut c) => {
                 let mut message = c.new_outgoing_message(100); // TODO estimate size
                 {
-                    let mut builder = message.get_body().unwrap().init_as::<message::Builder>().init_bootstrap();
+                    let mut builder = message
+                        .get_body()
+                        .unwrap()
+                        .init_as::<message::Builder>()
+                        .init_bootstrap();
                     builder.set_question_id(question_id);
                 }
                 let _ = message.send();
@@ -590,8 +667,11 @@ impl <VatId> ConnectionState<VatId> {
 
     fn message_loop(weak_state: Weak<ConnectionState<VatId>>) -> Promise<(), capnp::Error> {
         let state = match weak_state.upgrade() {
-            None => return Promise::err(
-                Error::disconnected("message loop cannot continue without a connection".into())),
+            None => {
+                return Promise::err(Error::disconnected(
+                    "message loop cannot continue without a connection".into(),
+                ))
+            }
             Some(c) => c,
         };
 
@@ -604,11 +684,15 @@ impl <VatId> ConnectionState<VatId> {
             match promise.await? {
                 Some(m) => {
                     ConnectionState::handle_message(weak_state.clone(), m)?;
-                    weak_state.upgrade().expect("message loop outlived connection state?")
+                    weak_state
+                        .upgrade()
+                        .expect("message loop outlived connection state?")
                         .add_task(ConnectionState::message_loop(weak_state));
                 }
                 None => {
-                    weak_state.upgrade().expect("message loop outlived connection state?")
+                    weak_state
+                        .upgrade()
+                        .expect("message loop outlived connection state?")
                         .disconnect(Error::disconnected("Peer disconnected.".to_string()));
                 }
             }
@@ -616,8 +700,10 @@ impl <VatId> ConnectionState<VatId> {
         })
     }
 
-    fn send_unimplemented(connection_state: Rc<ConnectionState<VatId>>,
-                          message: Box<dyn crate::IncomingMessage>) -> capnp::Result<()> {
+    fn send_unimplemented(
+        connection_state: Rc<ConnectionState<VatId>>,
+        message: Box<dyn crate::IncomingMessage>,
+    ) -> capnp::Result<()> {
         let mut out_message = connection_state.new_outgoing_message(50)?; // XXX size hint
         {
             let mut root: message::Builder = out_message.get_body()?.get_as()?;
@@ -627,12 +713,16 @@ impl <VatId> ConnectionState<VatId> {
         Ok(())
     }
 
-    fn handle_message(weak_state: Weak<ConnectionState<VatId>>,
-                      message: Box<dyn crate::IncomingMessage>) -> ::capnp::Result<()> {
-
+    fn handle_message(
+        weak_state: Weak<ConnectionState<VatId>>,
+        message: Box<dyn crate::IncomingMessage>,
+    ) -> ::capnp::Result<()> {
         let connection_state = match weak_state.upgrade() {
-            None => return Err(
-                Error::disconnected("handle_message() cannot continue without a connection".into())),
+            None => {
+                return Err(Error::disconnected(
+                    "handle_message() cannot continue without a connection".into(),
+                ))
+            }
             Some(c) => c,
         };
 
@@ -644,35 +734,34 @@ impl <VatId> ConnectionState<VatId> {
                     message::Resolve(resolve) => {
                         let resolve = resolve?;
                         match resolve.which()? {
-                            resolve::Cap(c) => {
-                                match c?.which()? {
-                                    cap_descriptor::None(()) => (),
-                                    cap_descriptor::SenderHosted(export_id) => {
-                                        connection_state.release_export(export_id, 1)?;
-                                    }
-                                    cap_descriptor::SenderPromise(export_id) => {
-                                        connection_state.release_export(export_id, 1)?;
-                                    }
-                                    cap_descriptor::ReceiverAnswer(_) |
-                                    cap_descriptor::ReceiverHosted(_) => (),
-                                    cap_descriptor::ThirdPartyHosted(_) => {
-                                        return Err(Error::failed(
-                                            "Peer claims we resolved a ThirdPartyHosted cap.".to_string()));
-                                    },
+                            resolve::Cap(c) => match c?.which()? {
+                                cap_descriptor::None(()) => (),
+                                cap_descriptor::SenderHosted(export_id) => {
+                                    connection_state.release_export(export_id, 1)?;
                                 }
-                            }
+                                cap_descriptor::SenderPromise(export_id) => {
+                                    connection_state.release_export(export_id, 1)?;
+                                }
+                                cap_descriptor::ReceiverAnswer(_)
+                                | cap_descriptor::ReceiverHosted(_) => (),
+                                cap_descriptor::ThirdPartyHosted(_) => {
+                                    return Err(Error::failed(
+                                        "Peer claims we resolved a ThirdPartyHosted cap."
+                                            .to_string(),
+                                    ));
+                                }
+                            },
                             resolve::Exception(_) => (),
                         }
                     }
                     _ => {
                         return Err(Error::failed(
-                            "Peer did not implement required RPC message type.".to_string()));
+                            "Peer did not implement required RPC message type.".to_string(),
+                        ));
                     }
                 }
             }
-            Ok(message::Abort(abort)) => {
-                return Err(remote_exception_to_error(abort?))
-            }
+            Ok(message::Abort(abort)) => return Err(remote_exception_to_error(abort?)),
             Ok(message::Bootstrap(bootstrap)) => {
                 use ::capnp::traits::ImbueMut;
 
@@ -687,7 +776,10 @@ impl <VatId> ConnectionState<VatId> {
                 let mut response = connection_state.new_outgoing_message(50)?; // XXX size hint
 
                 let result_exports = {
-                    let mut ret = response.get_body()?.init_as::<message::Builder>().init_return();
+                    let mut ret = response
+                        .get_body()?
+                        .init_as::<message::Builder>()
+                        .init_return();
                     ret.set_answer_id(answer_id);
 
                     let cap = connection_state.bootstrap_cap.clone();
@@ -700,8 +792,7 @@ impl <VatId> ConnectionState<VatId> {
                     }
                     assert_eq!(cap_table.len(), 1);
 
-                    ConnectionState::write_descriptors(&connection_state, &cap_table,
-                                                       payload)
+                    ConnectionState::write_descriptors(&connection_state, &cap_table, payload)
                 };
 
                 let slots = &mut connection_state.answers.borrow_mut().slots;
@@ -714,7 +805,8 @@ impl <VatId> ConnectionState<VatId> {
                 answer.return_has_been_sent = true;
                 answer.result_exports = result_exports;
                 answer.pipeline = Some(Box::new(SingleCapPipeline::new(
-                    connection_state.bootstrap_cap.clone())));
+                    connection_state.bootstrap_cap.clone(),
+                )));
 
                 let _ = response.send();
             }
@@ -731,20 +823,36 @@ impl <VatId> ConnectionState<VatId> {
                     let redirect_results = match call.get_send_results_to().which()? {
                         call::send_results_to::Caller(()) => false,
                         call::send_results_to::Yourself(()) => true,
-                        call::send_results_to::ThirdParty(_) =>
-                            return Err(Error::failed("Unsupported `Call.sendResultsTo`.".to_string())),
+                        call::send_results_to::ThirdParty(_) => {
+                            return Err(Error::failed(
+                                "Unsupported `Call.sendResultsTo`.".to_string(),
+                            ))
+                        }
                     };
                     let payload = call.get_params()?;
 
-                    (call.get_interface_id(), call.get_method_id(), call.get_question_id(),
-                     ConnectionState::receive_caps(connection_state.clone(),
-                                                   payload.get_cap_table()?)?,
-                     redirect_results)
+                    (
+                        call.get_interface_id(),
+                        call.get_method_id(),
+                        call.get_question_id(),
+                        ConnectionState::receive_caps(
+                            connection_state.clone(),
+                            payload.get_cap_table()?,
+                        )?,
+                        redirect_results,
+                    )
                 };
 
-                if connection_state.answers.borrow().slots.contains_key(&question_id) {
-                    return Err(Error::failed(
-                        format!("Received a new call on in-use question id {}", question_id)));
+                if connection_state
+                    .answers
+                    .borrow()
+                    .slots
+                    .contains_key(&question_id)
+                {
+                    return Err(Error::failed(format!(
+                        "Received a new call on in-use question id {}",
+                        question_id
+                    )));
                 }
 
                 let params = Params::new(message, cap_table_array);
@@ -753,13 +861,20 @@ impl <VatId> ConnectionState<VatId> {
 
                 let (results_inner_fulfiller, results_inner_promise) = oneshot::channel();
                 let results_inner_promise = results_inner_promise.map_err(crate::canceled_to_error);
-                let results = Results::new(&connection_state, question_id, redirect_results,
-                                           results_inner_fulfiller, answer.received_finish.clone());
+                let results = Results::new(
+                    &connection_state,
+                    question_id,
+                    redirect_results,
+                    results_inner_fulfiller,
+                    answer.received_finish.clone(),
+                );
 
                 let (redirected_results_done_promise, redirected_results_done_fulfiller) =
                     if redirect_results {
                         let (f, p) = oneshot::channel::<Result<Response<VatId>, Error>>();
-                        let p = p.map_err(crate::canceled_to_error).and_then(|x| future::ready(x));
+                        let p = p
+                            .map_err(crate::canceled_to_error)
+                            .and_then(|x| future::ready(x));
                         (Some(Promise::from_future(p)), Some(f))
                     } else {
                         (None, None)
@@ -774,27 +889,30 @@ impl <VatId> ConnectionState<VatId> {
                     answer.active = true;
                 }
 
-                let call_promise = capability.call(interface_id, method_id, Box::new(params), Box::new(results));
+                let call_promise =
+                    capability.call(interface_id, method_id, Box::new(params), Box::new(results));
                 let (pipeline_sender, mut pipeline) = queued::Pipeline::new();
 
-                let promise = call_promise.then(move |call_result| {
-                    results_inner_promise.then(move |result| {
-                        future::ready(ResultsDone::from_results_inner(result, call_result, pipeline_sender))
+                let promise = call_promise
+                    .then(move |call_result| {
+                        results_inner_promise.then(move |result| {
+                            future::ready(ResultsDone::from_results_inner(
+                                result,
+                                call_result,
+                                pipeline_sender,
+                            ))
+                        })
                     })
-                }).then(move |v| {
-                    match redirected_results_done_fulfiller {
-                        Some(f) => {
-                            match v {
-                                Ok(ref r) =>
-                                    drop(f.send(Ok(Response::redirected(r.clone())))),
-                                Err(ref e) =>
-                                    drop(f.send(Err(e.clone()))),
-                            }
+                    .then(move |v| {
+                        match redirected_results_done_fulfiller {
+                            Some(f) => match v {
+                                Ok(ref r) => drop(f.send(Ok(Response::redirected(r.clone())))),
+                                Err(ref e) => drop(f.send(Err(e.clone()))),
+                            },
+                            None => (),
                         }
-                        None => (),
-                    }
-                    Promise::ok(())
-                });
+                        Promise::ok(())
+                    });
 
                 let fork = promise.shared();
                 pipeline.drive(fork.clone());
@@ -806,13 +924,13 @@ impl <VatId> ConnectionState<VatId> {
                             answer.pipeline = Some(Box::new(pipeline));
                             if redirect_results {
                                 answer.redirected_results = redirected_results_done_promise;
-                                // More to do here?
+                            // More to do here?
                             } else {
-                                answer.call_completion_promise = Some(
-                                    connection_state.eagerly_evaluate(fork));
+                                answer.call_completion_promise =
+                                    Some(connection_state.eagerly_evaluate(fork));
                             }
                         }
-                        None => unreachable!()
+                        None => unreachable!(),
                     }
                 }
             }
@@ -825,59 +943,58 @@ impl <VatId> ConnectionState<VatId> {
                     Some(ref mut question) => {
                         question.is_awaiting_return = false;
                         match question.self_ref {
-                            Some(ref question_ref) => {
-                                match ret.which()? {
-                                    return_::Results(results) => {
-                                        let cap_table =
-                                            ConnectionState::receive_caps(connection_state.clone(),
-                                                                          results?.get_cap_table()?)?;
+                            Some(ref question_ref) => match ret.which()? {
+                                return_::Results(results) => {
+                                    let cap_table = ConnectionState::receive_caps(
+                                        connection_state.clone(),
+                                        results?.get_cap_table()?,
+                                    )?;
 
-                                        let question_ref = question_ref.upgrade()
-                                            .expect("dangling question ref?");
-                                        let response = Response::new(connection_state.clone(),
-                                                                     question_ref.clone(),
-                                                                     message, cap_table);
-                                        question_ref.borrow_mut().fulfill(Promise::ok(response));
-                                    }
-                                    return_::Exception(e) => {
-                                        let tmp = question_ref.upgrade().expect("dangling question ref?");
-                                        tmp.borrow_mut().reject(remote_exception_to_error(e?));
-                                    }
-                                    return_::Canceled(_) => {
-                                        unimplemented!()
-                                    }
-                                    return_::ResultsSentElsewhere(_) => {
-                                        unimplemented!()
-                                    }
-                                    return_::TakeFromOtherQuestion(id) => {
-                                        if let Some(ref mut answer) =
-                                            connection_state.answers.borrow_mut().slots.get_mut(&id)
-                                        {
-                                            if let Some(res) = answer.redirected_results.take() {
-                                                let tmp = question_ref.upgrade()
-                                                    .expect("dangling question ref?");
-                                                tmp.borrow_mut().fulfill(res);
-                                            } else {
-                                                return Err(Error::failed(format!(
-                                                    "return.takeFromOtherQuestion referenced a call that \
-                                                     did not use sendResultsTo.yourself.")));
-                                            }
+                                    let question_ref =
+                                        question_ref.upgrade().expect("dangling question ref?");
+                                    let response = Response::new(
+                                        connection_state.clone(),
+                                        question_ref.clone(),
+                                        message,
+                                        cap_table,
+                                    );
+                                    question_ref.borrow_mut().fulfill(Promise::ok(response));
+                                }
+                                return_::Exception(e) => {
+                                    let tmp =
+                                        question_ref.upgrade().expect("dangling question ref?");
+                                    tmp.borrow_mut().reject(remote_exception_to_error(e?));
+                                }
+                                return_::Canceled(_) => unimplemented!(),
+                                return_::ResultsSentElsewhere(_) => unimplemented!(),
+                                return_::TakeFromOtherQuestion(id) => {
+                                    if let Some(ref mut answer) =
+                                        connection_state.answers.borrow_mut().slots.get_mut(&id)
+                                    {
+                                        if let Some(res) = answer.redirected_results.take() {
+                                            let tmp = question_ref
+                                                .upgrade()
+                                                .expect("dangling question ref?");
+                                            tmp.borrow_mut().fulfill(res);
                                         } else {
                                             return Err(Error::failed(format!(
-                                                "return.takeFromOtherQuestion had invalid answer ID.")));
+                                                    "return.takeFromOtherQuestion referenced a call that \
+                                                     did not use sendResultsTo.yourself.")));
                                         }
-                                    }
-                                    return_::AcceptFromThirdParty(_) => {
-                                        drop(questions);
-                                        ConnectionState::send_unimplemented(connection_state, message)?;
+                                    } else {
+                                        return Err(Error::failed(format!(
+                                            "return.takeFromOtherQuestion had invalid answer ID."
+                                        )));
                                     }
                                 }
-                            }
+                                return_::AcceptFromThirdParty(_) => {
+                                    drop(questions);
+                                    ConnectionState::send_unimplemented(connection_state, message)?;
+                                }
+                            },
                             None => {
                                 match ret.which()? {
-                                    return_::TakeFromOtherQuestion(_) => {
-                                        unimplemented!()
-                                    }
+                                    return_::TakeFromOtherQuestion(_) => unimplemented!(),
                                     _ => {}
                                 }
                                 // Looks like this question was canceled earlier, so `Finish`
@@ -889,8 +1006,10 @@ impl <VatId> ConnectionState<VatId> {
                         }
                     }
                     None => {
-                        return Err(Error::failed(
-                            format!("Invalid question ID in Return message: {}", question_id)));
+                        return Err(Error::failed(format!(
+                            "Invalid question ID in Return message: {}",
+                            question_id
+                        )));
                     }
                 }
             }
@@ -904,18 +1023,23 @@ impl <VatId> ConnectionState<VatId> {
                 let answers_slots = &mut connection_state.answers.borrow_mut().slots;
                 match answers_slots.get_mut(&answer_id) {
                     None => {
-                        return Err(Error::failed(
-                            format!("Invalid question ID {} in Finish message.", answer_id)));
+                        return Err(Error::failed(format!(
+                            "Invalid question ID {} in Finish message.",
+                            answer_id
+                        )));
                     }
                     Some(ref mut answer) => {
                         if !answer.active {
-                            return Err(Error::failed(
-                                format!("'Finish' for invalid question ID {}.", answer_id)));
+                            return Err(Error::failed(format!(
+                                "'Finish' for invalid question ID {}.",
+                                answer_id
+                            )));
                         }
                         answer.received_finish.set(true);
 
                         if finish.get_release_result_caps() {
-                            exports_to_release = mem::replace(&mut answer.result_exports, Vec::new());
+                            exports_to_release =
+                                mem::replace(&mut answer.result_exports, Vec::new());
                         }
 
                         // If the pipeline has not been cloned, the following two lines cancel the call.
@@ -941,8 +1065,9 @@ impl <VatId> ConnectionState<VatId> {
                         match ConnectionState::receive_cap(connection_state.clone(), c?)? {
                             Some(cap) => Ok(cap),
                             None => {
-                                return Err(Error::failed(
-                                    format!("'Resolve' contained 'CapDescriptor.none'.")));
+                                return Err(Error::failed(format!(
+                                    "'Resolve' contained 'CapDescriptor.none'."
+                                )));
                             }
                         }
                     }
@@ -970,8 +1095,9 @@ impl <VatId> ConnectionState<VatId> {
                             }
                         }
                         None => {
-                            return Err(Error::failed(
-                                format!("Got 'Resolve' for a non-promise import.")));
+                            return Err(Error::failed(format!(
+                                "Got 'Resolve' for a non-promise import."
+                            )));
                         }
                     }
                 }
@@ -1005,10 +1131,15 @@ impl <VatId> ConnectionState<VatId> {
                                 {
                                     let root: message::Builder = message.get_body()?.init_as();
                                     let mut disembargo = root.init_disembargo();
-                                    disembargo.reborrow().init_context().set_receiver_loopback(embargo_id);
+                                    disembargo
+                                        .reborrow()
+                                        .init_context()
+                                        .set_receiver_loopback(embargo_id);
 
-                                    let redirect = match Client::from_ptr(target.get_ptr(),
-                                                                          &connection_state_ref1) {
+                                    let redirect = match Client::from_ptr(
+                                        target.get_ptr(),
+                                        &connection_state_ref1,
+                                    ) {
                                         Some(c) => c.write_target(disembargo.init_target()),
                                         None => unreachable!(),
                                     };
@@ -1032,23 +1163,26 @@ impl <VatId> ConnectionState<VatId> {
                             let fulfiller = embargo.fulfiller.take().unwrap();
                             let _ = fulfiller.send(Ok(()));
                         } else {
-                            return Err(
-                                Error::failed(
-                                    "Invalid embargo ID in `Disembargo.context.receiverLoopback".to_string()));
+                            return Err(Error::failed(
+                                "Invalid embargo ID in `Disembargo.context.receiverLoopback"
+                                    .to_string(),
+                            ));
                         }
                         connection_state.embargoes.borrow_mut().erase(embargo_id);
                     }
-                    disembargo::context::Accept(_) |
-                    disembargo::context::Provide(_) => {
-                        return Err(
-                            Error::unimplemented(
-                                "Disembargo::Context::Provide/Accept not implemented".to_string()));
+                    disembargo::context::Accept(_) | disembargo::context::Provide(_) => {
+                        return Err(Error::unimplemented(
+                            "Disembargo::Context::Provide/Accept not implemented".to_string(),
+                        ));
                     }
                 }
             }
-            Ok(message::Provide(_)) | Ok(message::Accept(_)) |
-            Ok(message::Join(_)) | Ok(message::ObsoleteSave(_)) | Ok(message::ObsoleteDelete(_)) |
-            Err(::capnp::NotInSchema(_)) => {
+            Ok(message::Provide(_))
+            | Ok(message::Accept(_))
+            | Ok(message::Join(_))
+            | Ok(message::ObsoleteSave(_))
+            | Ok(message::ObsoleteDelete(_))
+            | Err(::capnp::NotInSchema(_)) => {
                 ConnectionState::send_unimplemented(connection_state, message)?;
             }
         }
@@ -1080,7 +1214,9 @@ impl <VatId> ConnectionState<VatId> {
         match self.exports.borrow_mut().find(id) {
             Some(e) => {
                 if refcount > e.refcount {
-                    return Err(Error::failed("Tried to drop export's refcount below zero.".to_string()));
+                    return Err(Error::failed(
+                        "Tried to drop export's refcount below zero.".to_string(),
+                    ));
                 } else {
                     e.refcount -= refcount;
                     if e.refcount == 0 {
@@ -1090,7 +1226,9 @@ impl <VatId> ConnectionState<VatId> {
                 }
             }
             None => {
-                return Err(Error::failed("Tried to release invalid export ID.".to_string()));
+                return Err(Error::failed(
+                    "Tried to release invalid export ID.".to_string(),
+                ));
             }
         }
         if erase_export {
@@ -1108,21 +1246,20 @@ impl <VatId> ConnectionState<VatId> {
     }
 
     fn get_brand(&self) -> usize {
-        self as * const _ as usize
+        self as *const _ as usize
     }
 
-    fn get_message_target(&self, target: message_target::Reader)
-                          -> ::capnp::Result<Box<dyn ClientHook>>
-    {
+    fn get_message_target(
+        &self,
+        target: message_target::Reader,
+    ) -> ::capnp::Result<Box<dyn ClientHook>> {
         match target.which()? {
             message_target::ImportedCap(export_id) => {
                 match self.exports.borrow().slots.get(export_id as usize) {
-                    Some(&Some(ref exp)) => {
-                        Ok(exp.client_hook.clone())
-                    }
-                    _ => {
-                        Err(Error::failed("Message target is not a current export ID.".to_string()))
-                    }
+                    Some(&Some(ref exp)) => Ok(exp.client_hook.clone()),
+                    _ => Err(Error::failed(
+                        "Message target is not a current export ID.".to_string(),
+                    )),
                 }
             }
             message_target::PromisedAnswer(promised_answer) => {
@@ -1130,15 +1267,17 @@ impl <VatId> ConnectionState<VatId> {
                 let question_id = promised_answer.get_question_id();
 
                 match self.answers.borrow().slots.get(&question_id) {
-                    None => {
-                        Err(Error::failed("PromisedAnswer.questionId is not a current question.".to_string()))
-                    }
+                    None => Err(Error::failed(
+                        "PromisedAnswer.questionId is not a current question.".to_string(),
+                    )),
                     Some(base) => {
                         let pipeline = match base.pipeline {
                             Some(ref pipeline) => pipeline.add_ref(),
                             None => Box::new(broken::Pipeline::new(Error::failed(
                                 "Pipeline call on a request that returned not capabilities or was \
-                                 already closed.".to_string()))) as Box<dyn PipelineHook>,
+                                 already closed."
+                                    .to_string(),
+                            ))) as Box<dyn PipelineHook>,
                         };
                         let ops = to_pipeline_ops(promised_answer.get_transform()?)?;
                         Ok(pipeline.get_pipelined_cap(&ops))
@@ -1157,9 +1296,11 @@ impl <VatId> ConnectionState<VatId> {
     /// resolved, and so the request may have been built on the assumption that it would be sent over
     /// this network connection, but then the promise resolved to point somewhere else before the
     /// request was sent.  Now the request has to be redirected to the new target instead.
-    fn write_target(&self, cap: &dyn ClientHook, target: message_target::Builder)
-        -> Option<Box<dyn ClientHook>>
-    {
+    fn write_target(
+        &self,
+        cap: &dyn ClientHook,
+        target: message_target::Builder,
+    ) -> Option<Box<dyn ClientHook>> {
         if cap.get_brand() == self.get_brand() {
             match Client::from_ptr(cap.get_ptr(), self) {
                 Some(c) => c.write_target(target),
@@ -1177,9 +1318,7 @@ impl <VatId> ConnectionState<VatId> {
         }
         if client.get_brand() == self.get_brand() {
             match self.client_downcast_map.borrow().get(&client.get_ptr()) {
-                Some(c) => {
-                    Box::new(c.upgrade().expect("dangling client?"))
-                }
+                Some(c) => Box::new(c.upgrade().expect("dangling client?")),
                 None => unreachable!(),
             }
         } else {
@@ -1190,13 +1329,16 @@ impl <VatId> ConnectionState<VatId> {
     /// Implements exporting of a promise.  The promise has been exported under the given ID, and is
     /// to eventually resolve to the ClientHook produced by `promise`.  This method waits for that
     /// resolve to happen and then sends the appropriate `Resolve` message to the peer.
-    fn resolve_exported_promise(state: &Rc<ConnectionState<VatId>>, export_id: ExportId,
-                                promise: Promise<Box<dyn ClientHook>, Error>)
-                                -> Promise<(), Error>
-    {
+    fn resolve_exported_promise(
+        state: &Rc<ConnectionState<VatId>>,
+        export_id: ExportId,
+        promise: Promise<Box<dyn ClientHook>, Error>,
+    ) -> Promise<(), Error> {
         let weak_connection_state = Rc::downgrade(state);
         state.eagerly_evaluate(promise.map(move |resolution_result| {
-            let connection_state = weak_connection_state.upgrade().expect("dangling connection state?");
+            let connection_state = weak_connection_state
+                .upgrade()
+                .expect("dangling connection state?");
 
             match resolution_result {
                 Ok(resolution) => {
@@ -1207,8 +1349,12 @@ impl <VatId> ConnectionState<VatId> {
                     // Update the export table to point at this object instead. We know that our
                     // entry in the export table is still live because when it is destroyed the
                     // asynchronous resolution task (i.e. this code) is canceled.
-                    if let Some(ref mut exp) = connection_state.exports.borrow_mut().find(export_id) {
-                        connection_state.exports_by_cap.borrow_mut().remove(&exp.client_hook.get_ptr());
+                    if let Some(ref mut exp) = connection_state.exports.borrow_mut().find(export_id)
+                    {
+                        connection_state
+                            .exports_by_cap
+                            .borrow_mut()
+                            .remove(&exp.client_hook.get_ptr());
                         exp.client_hook = resolution.clone();
                     } else {
                         return Err(Error::failed("export table entry not found".to_string()));
@@ -1234,8 +1380,11 @@ impl <VatId> ConnectionState<VatId> {
                         let root: message::Builder = message.get_body()?.get_as()?;
                         let mut resolve = root.init_resolve();
                         resolve.set_promise_id(export_id);
-                        let _export = ConnectionState::write_descriptor(&connection_state, &resolution,
-                                                                        resolve.init_cap())?;
+                        let _export = ConnectionState::write_descriptor(
+                            &connection_state,
+                            &resolution,
+                            resolve.init_cap(),
+                        )?;
                     }
                     let _ = message.send();
                     Ok(())
@@ -1256,10 +1405,11 @@ impl <VatId> ConnectionState<VatId> {
         }))
     }
 
-    fn write_descriptor(state: &Rc<ConnectionState<VatId>>,
-                        cap: &Box<dyn ClientHook>,
-                        mut descriptor: cap_descriptor::Builder) -> ::capnp::Result<Option<ExportId>> {
-
+    fn write_descriptor(
+        state: &Rc<ConnectionState<VatId>>,
+        cap: &Box<dyn ClientHook>,
+        mut descriptor: cap_descriptor::Builder,
+    ) -> ::capnp::Result<Option<ExportId>> {
         // Find the innermost wrapped capability.
         let mut inner = cap.clone();
         while let Some(resolved) = inner.get_resolved() {
@@ -1295,8 +1445,9 @@ impl <VatId> ConnectionState<VatId> {
                     Some(wrapped) => {
                         // This is a promise.  Arrange for the `Resolve` message to be sent later.
                         if let Some(ref mut exp) = state.exports.borrow_mut().find(export_id) {
-                            exp.resolve_op =
-                                ConnectionState::resolve_exported_promise(state, export_id, wrapped);
+                            exp.resolve_op = ConnectionState::resolve_exported_promise(
+                                state, export_id, wrapped,
+                            );
                         }
                         descriptor.set_sender_promise(export_id);
                     }
@@ -1309,18 +1460,23 @@ impl <VatId> ConnectionState<VatId> {
         }
     }
 
-    fn write_descriptors(state: &Rc<ConnectionState<VatId>>,
-                         cap_table: &[Option<Box<dyn ClientHook>>],
-                         payload: payload::Builder)
-                         -> Vec<ExportId>
-    {
+    fn write_descriptors(
+        state: &Rc<ConnectionState<VatId>>,
+        cap_table: &[Option<Box<dyn ClientHook>>],
+        payload: payload::Builder,
+    ) -> Vec<ExportId> {
         let mut cap_table_builder = payload.init_cap_table(cap_table.len() as u32);
         let mut exports = Vec::new();
-        for idx in 0 .. cap_table.len() {
+        for idx in 0..cap_table.len() {
             match cap_table[idx] {
                 Some(ref cap) => {
-                    match ConnectionState::write_descriptor(state, cap,
-                                                            cap_table_builder.reborrow().get(idx as u32)).unwrap() {
+                    match ConnectionState::write_descriptor(
+                        state,
+                        cap,
+                        cap_table_builder.reborrow().get(idx as u32),
+                    )
+                    .unwrap()
+                    {
                         Some(export_id) => {
                             exports.push(export_id);
                         }
@@ -1335,19 +1491,30 @@ impl <VatId> ConnectionState<VatId> {
         exports
     }
 
-    fn import(state: Rc<ConnectionState<VatId>>,
-              import_id: ImportId, is_promise: bool) -> Box<dyn ClientHook> {
+    fn import(
+        state: Rc<ConnectionState<VatId>>,
+        import_id: ImportId,
+        is_promise: bool,
+    ) -> Box<dyn ClientHook> {
         let connection_state = state.clone();
 
         let import_client = {
             let slots = &mut state.imports.borrow_mut().slots;
             let v = slots.entry(import_id).or_insert_with(Import::new);
             if v.import_client.is_some() {
-                v.import_client.as_ref().unwrap().0.upgrade().expect("dangling ref to import client?").clone()
+                v.import_client
+                    .as_ref()
+                    .unwrap()
+                    .0
+                    .upgrade()
+                    .expect("dangling ref to import client?")
+                    .clone()
             } else {
                 let import_client = ImportClient::new(&connection_state, import_id);
-                v.import_client = Some((Rc::downgrade(&import_client),
-                                        (&*import_client.borrow())as *const _ as usize ));
+                v.import_client = Some((
+                    Rc::downgrade(&import_client),
+                    (&*import_client.borrow()) as *const _ as usize,
+                ));
                 import_client
             }
         };
@@ -1372,10 +1539,10 @@ impl <VatId> ConnectionState<VatId> {
 
                             // XXX do I need something like this?
                             // Make sure the import is not destroyed while this promise exists.
-//                            let promise = promise.attach(client.add_ref());
+                            //                            let promise = promise.attach(client.add_ref());
 
-                            let client = PromiseClient::new(&connection_state, client,
-                                                            Some(import_id));
+                            let client =
+                                PromiseClient::new(&connection_state, client, Some(import_id));
 
                             import.promise_client_to_resolve = Some(Rc::downgrade(&client));
                             let client: Box<Client<VatId>> = Box::new(client.into());
@@ -1384,7 +1551,7 @@ impl <VatId> ConnectionState<VatId> {
                         }
                     }
                 }
-                None => { unreachable!() }
+                None => unreachable!(),
             }
         } else {
             let client: Box<Client<VatId>> = Box::new(import_client.into());
@@ -1392,20 +1559,19 @@ impl <VatId> ConnectionState<VatId> {
                 Some(ref mut v) => {
                     v.app_client = Some(client.downgrade());
                 }
-                None => { unreachable!() }
+                None => unreachable!(),
             };
 
             client
         }
     }
 
-    fn receive_cap(state: Rc<ConnectionState<VatId>>, descriptor: cap_descriptor::Reader)
-                   -> ::capnp::Result<Option<Box<dyn ClientHook>>>
-    {
+    fn receive_cap(
+        state: Rc<ConnectionState<VatId>>,
+        descriptor: cap_descriptor::Reader,
+    ) -> ::capnp::Result<Option<Box<dyn ClientHook>>> {
         match descriptor.which()? {
-            cap_descriptor::None(()) => {
-                Ok(None)
-            }
+            cap_descriptor::None(()) => Ok(None),
             cap_descriptor::SenderHosted(sender_hosted) => {
                 Ok(Some(ConnectionState::import(state, sender_hosted, false)))
             }
@@ -1416,7 +1582,9 @@ impl <VatId> ConnectionState<VatId> {
                 if let Some(ref mut exp) = state.exports.borrow_mut().find(receiver_hosted) {
                     Ok(Some(exp.client_hook.add_ref()))
                 } else {
-                    Ok(Some(broken::new_cap(Error::failed("invalid 'receivedHosted' export ID".to_string()))))
+                    Ok(Some(broken::new_cap(Error::failed(
+                        "invalid 'receivedHosted' export ID".to_string(),
+                    ))))
                 }
             }
             cap_descriptor::ReceiverAnswer(receiver_answer) => {
@@ -1436,48 +1604,53 @@ impl <VatId> ConnectionState<VatId> {
                     }
                     None => (),
                 }
-                Ok(Some(broken::new_cap(Error::failed("invalid 'receiver answer'".to_string()))))
+                Ok(Some(broken::new_cap(Error::failed(
+                    "invalid 'receiver answer'".to_string(),
+                ))))
             }
-            cap_descriptor::ThirdPartyHosted(_third_party_hosted) => {
-                Err(Error::unimplemented("ThirdPartyHosted caps are not supported.".to_string()))
-            }
+            cap_descriptor::ThirdPartyHosted(_third_party_hosted) => Err(Error::unimplemented(
+                "ThirdPartyHosted caps are not supported.".to_string(),
+            )),
         }
     }
 
-    fn receive_caps(state: Rc<ConnectionState<VatId>>,
-                    cap_table: ::capnp::struct_list::Reader<cap_descriptor::Owned>)
-        -> ::capnp::Result<Vec<Option<Box<dyn ClientHook>>>>
-    {
+    fn receive_caps(
+        state: Rc<ConnectionState<VatId>>,
+        cap_table: ::capnp::struct_list::Reader<cap_descriptor::Owned>,
+    ) -> ::capnp::Result<Vec<Option<Box<dyn ClientHook>>>> {
         let mut result = Vec::new();
         for idx in 0..cap_table.len() {
-            result.push(ConnectionState::receive_cap(state.clone(), cap_table.get(idx))?);
+            result.push(ConnectionState::receive_cap(
+                state.clone(),
+                cap_table.get(idx),
+            )?);
         }
         Ok(result)
     }
 }
 
-enum DisconnectorState
-{
+enum DisconnectorState {
     Connected,
     Disconnecting,
-    Disconnected
+    Disconnected,
 }
 
 /// A `Future` that can be run to disconnect an `RpcSystem`'s ConnectionState and wait for it to be closed.
-pub struct Disconnector<VatId> where VatId: 'static {
+pub struct Disconnector<VatId>
+where
+    VatId: 'static,
+{
     connection_state: Rc<RefCell<Option<Rc<ConnectionState<VatId>>>>>,
-    state:  DisconnectorState,
+    state: DisconnectorState,
 }
 
-impl <VatId> Disconnector<VatId> {
-    pub fn new(connection_state: Rc<RefCell<Option<Rc<ConnectionState<VatId>>>>>) -> Disconnector<VatId> {
+impl<VatId> Disconnector<VatId> {
+    pub fn new(
+        connection_state: Rc<RefCell<Option<Rc<ConnectionState<VatId>>>>>,
+    ) -> Disconnector<VatId> {
         let state = match *(connection_state.borrow()) {
-            Some(_) => {
-                DisconnectorState::Connected
-            },
-            None => {
-                DisconnectorState::Disconnected
-            }
+            Some(_) => DisconnectorState::Connected,
+            None => DisconnectorState::Disconnected,
         };
         Disconnector {
             connection_state: connection_state,
@@ -1486,12 +1659,14 @@ impl <VatId> Disconnector<VatId> {
     }
     fn disconnect(&self) {
         if let Some(ref state) = *(self.connection_state.borrow()) {
-            state.disconnect(::capnp::Error::disconnected("client requested disconnect".to_owned()));
+            state.disconnect(::capnp::Error::disconnected(
+                "client requested disconnect".to_owned(),
+            ));
         }
     }
 }
 
-impl <VatId> Future for Disconnector<VatId>
+impl<VatId> Future for Disconnector<VatId>
 where
     VatId: 'static,
 {
@@ -1502,50 +1677,59 @@ where
             DisconnectorState::Connected => {
                 self.disconnect();
                 DisconnectorState::Disconnecting
-            },
+            }
             DisconnectorState::Disconnecting => {
                 if let Some(_) = *(self.connection_state.borrow()) {
                     DisconnectorState::Disconnecting
                 } else {
                     DisconnectorState::Disconnected
                 }
-            },
-            DisconnectorState::Disconnected => {
-                DisconnectorState::Disconnected
             }
+            DisconnectorState::Disconnected => DisconnectorState::Disconnected,
         };
         match self.state {
             DisconnectorState::Connected => unreachable!(),
             DisconnectorState::Disconnecting => {
                 cx.waker().clone().wake();
                 Poll::Pending
-            },
+            }
             DisconnectorState::Disconnected => Poll::Ready(Ok(())),
         }
     }
 }
 
-struct ResponseState<VatId> where VatId: 'static {
+struct ResponseState<VatId>
+where
+    VatId: 'static,
+{
     _connection_state: Rc<ConnectionState<VatId>>,
     message: Box<dyn crate::IncomingMessage>,
     cap_table: Vec<Option<Box<dyn ClientHook>>>,
     _question_ref: Rc<RefCell<QuestionRef<VatId>>>,
 }
 
-enum ResponseVariant<VatId> where VatId: 'static {
+enum ResponseVariant<VatId>
+where
+    VatId: 'static,
+{
     Rpc(ResponseState<VatId>),
     LocallyRedirected(Box<dyn ResultsDoneHook>),
 }
 
-struct Response<VatId> where VatId: 'static {
+struct Response<VatId>
+where
+    VatId: 'static,
+{
     variant: Rc<ResponseVariant<VatId>>,
 }
 
-impl <VatId> Response<VatId> {
-    fn new(connection_state: Rc<ConnectionState<VatId>>,
-           question_ref: Rc<RefCell<QuestionRef<VatId>>>,
-           message: Box<dyn crate::IncomingMessage>,
-           cap_table_array: Vec<Option<Box<dyn ClientHook>>>) -> Response<VatId> {
+impl<VatId> Response<VatId> {
+    fn new(
+        connection_state: Rc<ConnectionState<VatId>>,
+        question_ref: Rc<RefCell<QuestionRef<VatId>>>,
+        message: Box<dyn crate::IncomingMessage>,
+        cap_table_array: Vec<Option<Box<dyn ClientHook>>>,
+    ) -> Response<VatId> {
         Response {
             variant: Rc::new(ResponseVariant::Rpc(ResponseState {
                 _connection_state: connection_state,
@@ -1555,72 +1739,76 @@ impl <VatId> Response<VatId> {
             })),
         }
     }
-    fn redirected(results_done: Box<dyn ResultsDoneHook>)
-        -> Response<VatId>
-    {
+    fn redirected(results_done: Box<dyn ResultsDoneHook>) -> Response<VatId> {
         Response {
-            variant: Rc::new(ResponseVariant::LocallyRedirected(results_done))
+            variant: Rc::new(ResponseVariant::LocallyRedirected(results_done)),
         }
     }
 }
 
-impl <VatId> Clone for Response<VatId> {
+impl<VatId> Clone for Response<VatId> {
     fn clone(&self) -> Response<VatId> {
-        Response { variant: self.variant.clone() }
+        Response {
+            variant: self.variant.clone(),
+        }
     }
 }
 
-impl <VatId> ResponseHook for Response<VatId> {
+impl<VatId> ResponseHook for Response<VatId> {
     fn get<'a>(&'a self) -> ::capnp::Result<any_pointer::Reader<'a>> {
         match *self.variant {
             ResponseVariant::Rpc(ref state) => {
-                match state.message.get_body()?.get_as::<message::Reader>()?.which()? {
-                    message::Return(Ok(ret)) => {
-                        match ret.which()? {
-                            return_::Results(Ok(mut payload)) => {
-                                use ::capnp::traits::Imbue;
-                                payload.imbue(&state.cap_table);
-                                Ok(payload.get_content())
-                            }
-                            _ => unreachable!(),
+                match state
+                    .message
+                    .get_body()?
+                    .get_as::<message::Reader>()?
+                    .which()?
+                {
+                    message::Return(Ok(ret)) => match ret.which()? {
+                        return_::Results(Ok(mut payload)) => {
+                            use ::capnp::traits::Imbue;
+                            payload.imbue(&state.cap_table);
+                            Ok(payload.get_content())
                         }
-                    }
+                        _ => unreachable!(),
+                    },
                     _ => unreachable!(),
                 }
             }
-            ResponseVariant::LocallyRedirected(ref results_done) => {
-                results_done.get()
-            }
+            ResponseVariant::LocallyRedirected(ref results_done) => results_done.get(),
         }
     }
 }
 
-struct Request<VatId> where VatId: 'static {
+struct Request<VatId>
+where
+    VatId: 'static,
+{
     connection_state: Rc<ConnectionState<VatId>>,
     target: Client<VatId>,
     message: Box<dyn crate::OutgoingMessage>,
     cap_table: Vec<Option<Box<dyn ClientHook>>>,
 }
 
-fn get_call<'a>(message: &'a mut Box<dyn crate::OutgoingMessage>)
-                -> ::capnp::Result<call::Builder<'a>>
-{
+fn get_call<'a>(
+    message: &'a mut Box<dyn crate::OutgoingMessage>,
+) -> ::capnp::Result<call::Builder<'a>> {
     let message_root: message::Builder = message.get_body()?.get_as()?;
     match message_root.which()? {
-        message::Call(call) => {
-            call
-        }
-        _ => {
-            unimplemented!()
-        }
+        message::Call(call) => call,
+        _ => unimplemented!(),
     }
 }
 
-impl <VatId> Request<VatId> where VatId: 'static {
-    fn new(connection_state: Rc<ConnectionState<VatId>>,
-           _size_hint: Option<::capnp::MessageSize>,
-           target: Client<VatId>) -> ::capnp::Result<Request<VatId>> {
-
+impl<VatId> Request<VatId>
+where
+    VatId: 'static,
+{
+    fn new(
+        connection_state: Rc<ConnectionState<VatId>>,
+        _size_hint: Option<::capnp::MessageSize>,
+        target: Client<VatId>,
+    ) -> ::capnp::Result<Request<VatId>> {
         let message = connection_state.new_outgoing_message(100)?;
         Ok(Request {
             connection_state: connection_state,
@@ -1635,15 +1823,21 @@ impl <VatId> Request<VatId> where VatId: 'static {
         message_root.init_call()
     }
 
-    fn send_internal(connection_state: Rc<ConnectionState<VatId>>,
-                     mut message: Box<dyn crate::OutgoingMessage>,
-                     cap_table: Vec<Option<Box<dyn ClientHook>>>,
-                     is_tail_call: bool)
-                     -> (Rc<RefCell<QuestionRef<VatId>>>, Promise<Response<VatId>, Error>)
-    {
+    fn send_internal(
+        connection_state: Rc<ConnectionState<VatId>>,
+        mut message: Box<dyn crate::OutgoingMessage>,
+        cap_table: Vec<Option<Box<dyn ClientHook>>>,
+        is_tail_call: bool,
+    ) -> (
+        Rc<RefCell<QuestionRef<VatId>>>,
+        Promise<Response<VatId>, Error>,
+    ) {
         // Build the cap table.
-        let exports = ConnectionState::write_descriptors(&connection_state, &cap_table,
-                                                         get_call(&mut message).unwrap().get_params().unwrap());
+        let exports = ConnectionState::write_descriptors(
+            &connection_state,
+            &cap_table,
+            get_call(&mut message).unwrap().get_params().unwrap(),
+        );
 
         // Init the question table.  Do this after writing descriptors to avoid interference.
         let mut question = Question::<VatId>::new();
@@ -1664,8 +1858,11 @@ impl <VatId> Request<VatId> where VatId: 'static {
         // Make the result promise.
         let (fulfiller, promise) = oneshot::channel::<Promise<Response<VatId>, Error>>();
         let promise = promise.map_err(crate::canceled_to_error).and_then(|x| x);
-        let question_ref = Rc::new(RefCell::new(
-            QuestionRef::new(connection_state.clone(), question_id, fulfiller)));
+        let question_ref = Rc::new(RefCell::new(QuestionRef::new(
+            connection_state.clone(),
+            question_id,
+            fulfiller,
+        )));
 
         match connection_state.questions.borrow_mut().slots[question_id as usize] {
             Some(ref mut q) => {
@@ -1681,10 +1878,14 @@ impl <VatId> Request<VatId> where VatId: 'static {
     }
 }
 
-impl <VatId> RequestHook for Request<VatId> {
+impl<VatId> RequestHook for Request<VatId> {
     fn get<'a>(&'a mut self) -> any_pointer::Builder<'a> {
         use ::capnp::traits::ImbueMut;
-        let mut builder = get_call(&mut self.message).unwrap().get_params().unwrap().get_content();
+        let mut builder = get_call(&mut self.message)
+            .unwrap()
+            .get_params()
+            .unwrap()
+            .get_content();
         builder.imbue_mut(&mut self.cap_table);
         builder
     }
@@ -1693,7 +1894,12 @@ impl <VatId> RequestHook for Request<VatId> {
     }
     fn send(self: Box<Self>) -> ::capnp::capability::RemotePromise<any_pointer::Owned> {
         let tmp = *self;
-        let Request { connection_state, target, mut message, cap_table } = tmp;
+        let Request {
+            connection_state,
+            target,
+            mut message,
+            cap_table,
+        } = tmp;
         let write_target_result = {
             let call_builder: call::Builder = get_call(&mut message).unwrap();
             target.write_target(call_builder.get_target().unwrap())
@@ -1703,10 +1909,21 @@ impl <VatId> RequestHook for Request<VatId> {
                 // Whoops, this capability has been redirected while we were building the request!
                 // We'll have to make a new request and do a copy.  Ick.
                 let mut call_builder: call::Builder = get_call(&mut message).unwrap();
-                let mut replacement = redirect.new_call(call_builder.reborrow().get_interface_id(),
-                                                        call_builder.reborrow().get_method_id(), None);
+                let mut replacement = redirect.new_call(
+                    call_builder.reborrow().get_interface_id(),
+                    call_builder.reborrow().get_method_id(),
+                    None,
+                );
 
-                replacement.set(call_builder.get_params().unwrap().get_content().into_reader()).unwrap();
+                replacement
+                    .set(
+                        call_builder
+                            .get_params()
+                            .unwrap()
+                            .get_content()
+                            .into_reader(),
+                    )
+                    .unwrap();
                 replacement.send()
             }
             None => {
@@ -1716,29 +1933,36 @@ impl <VatId> RequestHook for Request<VatId> {
                 let forked_promise2 = forked_promise1.clone();
 
                 // The pipeline must get notified of resolution before the app does to maintain ordering.
-                let pipeline = Pipeline::new(connection_state, question_ref.clone(),
-                                             Some(Promise::from_future(forked_promise1)));
+                let pipeline = Pipeline::new(
+                    connection_state,
+                    question_ref.clone(),
+                    Some(Promise::from_future(forked_promise1)),
+                );
 
                 let resolved = pipeline.when_resolved();
 
                 let forked_promise2 = resolved.map(|_| Ok(())).and_then(|()| forked_promise2);
 
-                let app_promise = Promise::from_future(forked_promise2.map_ok(|response| {
-                    ::capnp::capability::Response::new(Box::new(response))
-                }));
+                let app_promise = Promise::from_future(
+                    forked_promise2
+                        .map_ok(|response| ::capnp::capability::Response::new(Box::new(response))),
+                );
 
                 ::capnp::capability::RemotePromise {
                     promise: app_promise,
-                    pipeline: any_pointer::Pipeline::new(Box::new(pipeline))
+                    pipeline: any_pointer::Pipeline::new(Box::new(pipeline)),
                 }
             }
         }
     }
-    fn tail_send(self: Box<Self>)
-                 -> Option<(u32, Promise<(), Error>, Box<dyn PipelineHook>)>
-    {
+    fn tail_send(self: Box<Self>) -> Option<(u32, Promise<(), Error>, Box<dyn PipelineHook>)> {
         let tmp = *self;
-        let Request { connection_state, target, mut message, cap_table } = tmp;
+        let Request {
+            connection_state,
+            target,
+            mut message,
+            cap_table,
+        } = tmp;
 
         if connection_state.connection.borrow().is_err() {
             // Disconnected; fall back to a regular send() which will fail appropriately.
@@ -1754,9 +1978,7 @@ impl <VatId> RequestHook for Request<VatId> {
             Some(_redirect) => {
                 return None;
             }
-            None => {
-                Request::send_internal(connection_state.clone(), message, cap_table, true)
-            }
+            None => Request::send_internal(connection_state.clone(), message, cap_table, true),
         };
 
         let promise = promise.map_ok(|_response| {
@@ -1768,29 +1990,50 @@ impl <VatId> RequestHook for Request<VatId> {
         let question_id = question_ref.borrow().id;
         let pipeline = Pipeline::never_done(connection_state, question_ref);
 
-        Some((question_id, Promise::from_future(promise), Box::new(pipeline)))
+        Some((
+            question_id,
+            Promise::from_future(promise),
+            Box::new(pipeline),
+        ))
     }
 }
 
-enum PipelineVariant<VatId> where VatId: 'static {
+enum PipelineVariant<VatId>
+where
+    VatId: 'static,
+{
     Waiting(Rc<RefCell<QuestionRef<VatId>>>),
     Resolved(Response<VatId>),
     Broken(Error),
 }
 
-struct PipelineState<VatId> where VatId: 'static {
+struct PipelineState<VatId>
+where
+    VatId: 'static,
+{
     variant: PipelineVariant<VatId>,
-    redirect_later: Option<RefCell<futures::future::Shared<Promise<Response<VatId>, ::capnp::Error>>>>,
+    redirect_later:
+        Option<RefCell<futures_util::future::Shared<Promise<Response<VatId>, ::capnp::Error>>>>,
     connection_state: Rc<ConnectionState<VatId>>,
 
     resolve_self_promise: Promise<(), Error>,
-    promise_clients_to_resolve:
-         RefCell<crate::sender_queue::SenderQueue<(Weak<RefCell<PromiseClient<VatId>>>, Vec<PipelineOp>), ()>>,
+    promise_clients_to_resolve: RefCell<
+        crate::sender_queue::SenderQueue<
+            (Weak<RefCell<PromiseClient<VatId>>>, Vec<PipelineOp>),
+            (),
+        >,
+    >,
     resolution_waiters: crate::sender_queue::SenderQueue<(), ()>,
 }
 
-impl <VatId> PipelineState<VatId> where VatId: 'static {
-    fn resolve(state: &Rc<RefCell<PipelineState<VatId>>>, response: Result<Response<VatId>, Error>) {
+impl<VatId> PipelineState<VatId>
+where
+    VatId: 'static,
+{
+    fn resolve(
+        state: &Rc<RefCell<PipelineState<VatId>>>,
+        response: Result<Response<VatId>, Error>,
+    ) {
         let to_resolve = {
             let tmp = state.borrow();
             let r = tmp.promise_clients_to_resolve.borrow_mut().drain();
@@ -1798,14 +2041,10 @@ impl <VatId> PipelineState<VatId> where VatId: 'static {
         };
         for ((c, ops), _) in to_resolve {
             let resolved = match response.clone() {
-                Ok(v) => {
-                    match v.get() {
-                        Ok(x) => {
-                            x.get_pipelined_cap(&ops)
-                        }
-                        Err(e) => Err(e),
-                    }
-                }
+                Ok(v) => match v.get() {
+                    Ok(x) => x.get_pipelined_cap(&ops),
+                    Err(e) => Err(e),
+                },
                 Err(e) => Err(e),
             };
             if let Some(c) = c.upgrade() {
@@ -1814,7 +2053,7 @@ impl <VatId> PipelineState<VatId> where VatId: 'static {
         }
 
         let new_variant = match response {
-            Ok(r) =>  PipelineVariant::Resolved(r),
+            Ok(r) => PipelineVariant::Resolved(r),
             Err(e) => PipelineVariant::Broken(e),
         };
         let _old_variant = mem::replace(&mut state.borrow_mut().variant, new_variant);
@@ -1826,16 +2065,19 @@ impl <VatId> PipelineState<VatId> where VatId: 'static {
     }
 }
 
-struct Pipeline<VatId> where VatId: 'static {
+struct Pipeline<VatId>
+where
+    VatId: 'static,
+{
     state: Rc<RefCell<PipelineState<VatId>>>,
 }
 
-impl <VatId> Pipeline<VatId> {
-    fn new(connection_state: Rc<ConnectionState<VatId>>,
-           question_ref: Rc<RefCell<QuestionRef<VatId>>>,
-           redirect_later: Option<Promise<Response<VatId>, ::capnp::Error>>)
-           -> Pipeline<VatId>
-    {
+impl<VatId> Pipeline<VatId> {
+    fn new(
+        connection_state: Rc<ConnectionState<VatId>>,
+        question_ref: Rc<RefCell<QuestionRef<VatId>>>,
+        redirect_later: Option<Promise<Response<VatId>, ::capnp::Error>>,
+    ) -> Pipeline<VatId> {
         let state = Rc::new(RefCell::new(PipelineState {
             variant: PipelineVariant::Waiting(question_ref),
             connection_state: connection_state.clone(),
@@ -1848,14 +2090,19 @@ impl <VatId> Pipeline<VatId> {
             Some(redirect_later_promise) => {
                 let fork = redirect_later_promise.shared();
                 let this = Rc::downgrade(&state);
-                let resolve_self_promise = connection_state.eagerly_evaluate(fork.clone().then(move |response| {
-                    let state = match this.upgrade() {
-                        Some(s) => s,
-                        None => return Promise::err(Error::failed("dangling reference to this".into())),
-                    };
-                    PipelineState::resolve(&state, response);
-                    Promise::ok(())
-                }));
+                let resolve_self_promise =
+                    connection_state.eagerly_evaluate(fork.clone().then(move |response| {
+                        let state = match this.upgrade() {
+                            Some(s) => s,
+                            None => {
+                                return Promise::err(Error::failed(
+                                    "dangling reference to this".into(),
+                                ))
+                            }
+                        };
+                        PipelineState::resolve(&state, response);
+                        Promise::ok(())
+                    }));
 
                 state.borrow_mut().resolve_self_promise = resolve_self_promise;
                 state.borrow_mut().redirect_later = Some(RefCell::new(fork.clone()));
@@ -1869,10 +2116,10 @@ impl <VatId> Pipeline<VatId> {
         self.state.borrow_mut().resolution_waiters.push(())
     }
 
-    fn never_done(connection_state: Rc<ConnectionState<VatId>>,
-                  question_ref: Rc<RefCell<QuestionRef<VatId>>>)
-           -> Pipeline<VatId>
-    {
+    fn never_done(
+        connection_state: Rc<ConnectionState<VatId>>,
+        question_ref: Rc<RefCell<QuestionRef<VatId>>>,
+    ) -> Pipeline<VatId> {
         let state = Rc::new(RefCell::new(PipelineState {
             variant: PipelineVariant::Waiting(question_ref),
             connection_state: connection_state,
@@ -1886,17 +2133,24 @@ impl <VatId> Pipeline<VatId> {
     }
 }
 
-impl <VatId> PipelineHook for Pipeline<VatId> {
+impl<VatId> PipelineHook for Pipeline<VatId> {
     fn add_ref(&self) -> Box<dyn PipelineHook> {
-        Box::new(Pipeline { state: self.state.clone() })
+        Box::new(Pipeline {
+            state: self.state.clone(),
+        })
     }
     fn get_pipelined_cap(&self, ops: &[PipelineOp]) -> Box<dyn ClientHook> {
         self.get_pipelined_cap_move(ops.into())
     }
     fn get_pipelined_cap_move(&self, ops: Vec<PipelineOp>) -> Box<dyn ClientHook> {
         match *self.state.borrow() {
-            PipelineState {variant: PipelineVariant::Waiting(ref question_ref),
-                            ref connection_state, ref redirect_later, ref promise_clients_to_resolve, ..} => {
+            PipelineState {
+                variant: PipelineVariant::Waiting(ref question_ref),
+                ref connection_state,
+                ref redirect_later,
+                ref promise_clients_to_resolve,
+                ..
+            } => {
                 // Wrap a PipelineClient in a PromiseClient.
                 let pipeline_client =
                     PipelineClient::new(connection_state, question_ref.clone(), ops.clone());
@@ -1904,11 +2158,11 @@ impl <VatId> PipelineHook for Pipeline<VatId> {
                 match *redirect_later {
                     Some(ref _r) => {
                         let client: Client<VatId> = pipeline_client.into();
-                        let promise_client = PromiseClient::new(
-                            connection_state,
-                            Box::new(client),
-                            None);
-                        promise_clients_to_resolve.borrow_mut().push_detach((Rc::downgrade(&promise_client), ops));
+                        let promise_client =
+                            PromiseClient::new(connection_state, Box::new(client), None);
+                        promise_clients_to_resolve
+                            .borrow_mut()
+                            .push_detach((Rc::downgrade(&promise_client), ops));
                         let result: Client<VatId> = promise_client.into();
                         Box::new(result)
                     }
@@ -1919,12 +2173,14 @@ impl <VatId> PipelineHook for Pipeline<VatId> {
                     }
                 }
             }
-            PipelineState {variant: PipelineVariant::Resolved(ref response), ..} => {
-                response.get().unwrap().get_pipelined_cap(&ops[..]).unwrap()
-            }
-            PipelineState {variant: PipelineVariant::Broken(ref e), ..} => {
-                broken::new_cap(e.clone())
-            }
+            PipelineState {
+                variant: PipelineVariant::Resolved(ref response),
+                ..
+            } => response.get().unwrap().get_pipelined_cap(&ops[..]).unwrap(),
+            PipelineState {
+                variant: PipelineVariant::Broken(ref e),
+                ..
+            } => broken::new_cap(e.clone()),
         }
     }
 }
@@ -1935,10 +2191,10 @@ pub struct Params {
 }
 
 impl Params {
-    fn new(request: Box<dyn crate::IncomingMessage>,
-           cap_table: Vec<Option<Box<dyn ClientHook>>>)
-           -> Params
-    {
+    fn new(
+        request: Box<dyn crate::IncomingMessage>,
+        cap_table: Vec<Option<Box<dyn ClientHook>>>,
+    ) -> Params {
         Params {
             request: request,
             cap_table: cap_table,
@@ -1956,19 +2212,26 @@ impl ParamsHook for Params {
                 content.imbue(&self.cap_table);
                 Ok(content)
             }
-            _ =>  {
-                unreachable!()
-            }
+            _ => unreachable!(),
         }
     }
 }
 
 enum ResultsVariant {
-    Rpc(Box<dyn crate::OutgoingMessage>, Vec<Option<Box<dyn ClientHook>>>),
-    LocallyRedirected(::capnp::message::Builder<::capnp::message::HeapAllocator>, Vec<Option<Box<dyn ClientHook>>>),
+    Rpc(
+        Box<dyn crate::OutgoingMessage>,
+        Vec<Option<Box<dyn ClientHook>>>,
+    ),
+    LocallyRedirected(
+        ::capnp::message::Builder<::capnp::message::HeapAllocator>,
+        Vec<Option<Box<dyn ClientHook>>>,
+    ),
 }
 
-struct ResultsInner<VatId> where VatId: 'static {
+struct ResultsInner<VatId>
+where
+    VatId: 'static,
+{
     connection_state: Rc<ConnectionState<VatId>>,
     variant: Option<ResultsVariant>,
     redirect_results: bool,
@@ -1976,11 +2239,17 @@ struct ResultsInner<VatId> where VatId: 'static {
     finish_received: Rc<Cell<bool>>,
 }
 
-impl <VatId> ResultsInner<VatId> where VatId: 'static {
+impl<VatId> ResultsInner<VatId>
+where
+    VatId: 'static,
+{
     fn ensure_initialized(&mut self) {
         let answer_id = self.answer_id;
         if self.variant.is_none() {
-            match (self.redirect_results, self.connection_state.connection.borrow_mut().as_mut()) {
+            match (
+                self.redirect_results,
+                self.connection_state.connection.borrow_mut().as_mut(),
+            ) {
                 (false, Ok(c)) => {
                     let mut message = c.new_outgoing_message(100); // size hint?
 
@@ -1993,10 +2262,10 @@ impl <VatId> ResultsInner<VatId> where VatId: 'static {
                     self.variant = Some(ResultsVariant::Rpc(message, Vec::new()));
                 }
                 _ => {
-                    self.variant =
-                        Some(ResultsVariant::LocallyRedirected(
-                            ::capnp::message::Builder::new_default(),
-                            Vec::new()));
+                    self.variant = Some(ResultsVariant::LocallyRedirected(
+                        ::capnp::message::Builder::new_default(),
+                        Vec::new(),
+                    ));
                 }
             }
         }
@@ -2004,21 +2273,25 @@ impl <VatId> ResultsInner<VatId> where VatId: 'static {
 }
 
 // This takes the place of both RpcCallContext and RpcServerResponse in capnproto-c++.
-pub struct Results<VatId> where VatId: 'static {
+pub struct Results<VatId>
+where
+    VatId: 'static,
+{
     inner: Option<ResultsInner<VatId>>,
     results_done_fulfiller: Option<oneshot::Sender<ResultsInner<VatId>>>,
 }
 
-
-impl <VatId> Results<VatId> where VatId: 'static {
-    fn new(connection_state: &Rc<ConnectionState<VatId>>,
-           answer_id: AnswerId,
-           redirect_results: bool,
-           fulfiller: oneshot::Sender<ResultsInner<VatId>>,
-           finish_received: Rc<Cell<bool>>,
-           )
-           -> Results<VatId>
-    {
+impl<VatId> Results<VatId>
+where
+    VatId: 'static,
+{
+    fn new(
+        connection_state: &Rc<ConnectionState<VatId>>,
+        answer_id: AnswerId,
+        redirect_results: bool,
+        fulfiller: oneshot::Sender<ResultsInner<VatId>>,
+        finish_received: Rc<Cell<bool>>,
+    ) -> Results<VatId> {
         Results {
             inner: Some(ResultsInner {
                 variant: None,
@@ -2032,7 +2305,7 @@ impl <VatId> Results<VatId> where VatId: 'static {
     }
 }
 
-impl <VatId> Drop for Results<VatId> {
+impl<VatId> Drop for Results<VatId> {
     fn drop(&mut self) {
         match (self.inner.take(), self.results_done_fulfiller.take()) {
             (Some(inner), Some(fulfiller)) => {
@@ -2044,7 +2317,7 @@ impl <VatId> Drop for Results<VatId> {
     }
 }
 
-impl <VatId> ResultsHook for Results<VatId> {
+impl<VatId> ResultsHook for Results<VatId> {
     fn get<'a>(&'a mut self) -> ::capnp::Result<any_pointer::Builder<'a>> {
         use ::capnp::traits::ImbueMut;
         if let Some(ref mut inner) = self.inner {
@@ -2054,21 +2327,15 @@ impl <VatId> ResultsHook for Results<VatId> {
                 Some(ResultsVariant::Rpc(ref mut message, ref mut cap_table)) => {
                     let root: message::Builder = message.get_body()?.get_as()?;
                     match root.which()? {
-                        message::Return(ret) => {
-                            match ret?.which()? {
-                                return_::Results(payload) => {
-                                    let mut content = payload?.get_content();
-                                    content.imbue_mut(cap_table);
-                                    Ok(content)
-                                }
-                                _ => {
-                                    unreachable!()
-                                }
+                        message::Return(ret) => match ret?.which()? {
+                            return_::Results(payload) => {
+                                let mut content = payload?.get_content();
+                                content.imbue_mut(cap_table);
+                                Ok(content)
                             }
-                        }
-                        _ =>  {
-                            unreachable!()
-                        }
+                            _ => unreachable!(),
+                        },
+                        _ => unreachable!(),
                     }
                 }
                 Some(ResultsVariant::LocallyRedirected(ref mut message, ref mut cap_table)) => {
@@ -2086,16 +2353,18 @@ impl <VatId> ResultsHook for Results<VatId> {
         unimplemented!()
     }
 
-    fn direct_tail_call(mut self: Box<Self>, request: Box<dyn RequestHook>)
-                        -> (Promise<(), Error>, Box<dyn PipelineHook>)
-    {
-        if let (Some(inner), Some(fulfiller)) = (self.inner.take(), self.results_done_fulfiller.take()) {
+    fn direct_tail_call(
+        mut self: Box<Self>,
+        request: Box<dyn RequestHook>,
+    ) -> (Promise<(), Error>, Box<dyn PipelineHook>) {
+        if let (Some(inner), Some(fulfiller)) =
+            (self.inner.take(), self.results_done_fulfiller.take())
+        {
             let state = inner.connection_state.clone();
             if request.get_brand() == state.get_brand() && !inner.redirect_results {
                 // The tail call is headed towards the peer that called us in the first place, so we can
                 // optimize out the return trip.
                 if let Some((question_id, promise, pipeline)) = request.tail_send() {
-
                     let mut message = state.new_outgoing_message(100).expect("no connection?"); // size hint?
 
                     {
@@ -2116,7 +2385,6 @@ impl <VatId> ResultsHook for Results<VatId> {
             } else {
                 unimplemented!()
             }
-
         } else {
             unreachable!();
         }
@@ -2128,20 +2396,28 @@ impl <VatId> ResultsHook for Results<VatId> {
 }
 
 enum ResultsDoneVariant {
-    Rpc(Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>, Vec<Option<Box<dyn ClientHook>>>),
-    LocallyRedirected(::capnp::message::Builder<::capnp::message::HeapAllocator>, Vec<Option<Box<dyn ClientHook>>>),
+    Rpc(
+        Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>,
+        Vec<Option<Box<dyn ClientHook>>>,
+    ),
+    LocallyRedirected(
+        ::capnp::message::Builder<::capnp::message::HeapAllocator>,
+        Vec<Option<Box<dyn ClientHook>>>,
+    ),
 }
 
 struct ResultsDone {
-    inner: Rc<ResultsDoneVariant>
+    inner: Rc<ResultsDoneVariant>,
 }
 
 impl ResultsDone {
-    fn from_results_inner<VatId>(results_inner: Result<ResultsInner<VatId>, Error>,
-                                 call_status: Result<(), Error>,
-                                 pipeline_sender: queued::PipelineInnerSender)
-                                 -> Result<Box<dyn ResultsDoneHook>, Error>
-        where VatId: 'static
+    fn from_results_inner<VatId>(
+        results_inner: Result<ResultsInner<VatId>, Error>,
+        call_status: Result<(), Error>,
+        pipeline_sender: queued::PipelineInnerSender,
+    ) -> Result<Box<dyn ResultsDoneHook>, Error>
+    where
+        VatId: 'static,
     {
         match results_inner {
             Err(e) => {
@@ -2150,24 +2426,31 @@ impl ResultsDone {
             }
             Ok(mut results_inner) => {
                 results_inner.ensure_initialized();
-                let ResultsInner { connection_state, variant,
-                                   answer_id, finish_received, .. } = results_inner;
+                let ResultsInner {
+                    connection_state,
+                    variant,
+                    answer_id,
+                    finish_received,
+                    ..
+                } = results_inner;
                 match variant {
                     None => unreachable!(),
                     Some(ResultsVariant::Rpc(mut message, cap_table)) => {
                         match (finish_received.get(), call_status) {
                             (true, _) => {
-                                let hook = Box::new(ResultsDone::rpc(Rc::new(message.take()), cap_table))
-                                    as Box<dyn ResultsDoneHook>;
-                                pipeline_sender.complete(Box::new(
-                                    local::Pipeline::new(hook.clone())));
+                                let hook =
+                                    Box::new(ResultsDone::rpc(Rc::new(message.take()), cap_table))
+                                        as Box<dyn ResultsDoneHook>;
+                                pipeline_sender
+                                    .complete(Box::new(local::Pipeline::new(hook.clone())));
 
                                 // Send a Canceled return.
                                 match connection_state.connection.borrow_mut().as_mut() {
                                     Ok(ref mut connection) => {
                                         let mut message = connection.new_outgoing_message(50); // XXX size hint
                                         {
-                                            let root: message::Builder = message.get_body()?.get_as()?;
+                                            let root: message::Builder =
+                                                message.get_body()?.get_as()?;
                                             let mut ret = root.init_return();
                                             ret.set_answer_id(answer_id);
                                             ret.set_release_param_caps(false);
@@ -2185,29 +2468,26 @@ impl ResultsDone {
                                 let exports = {
                                     let root: message::Builder = message.get_body()?.get_as()?;
                                     match root.which()? {
-                                        message::Return(ret) => {
-                                            match ret?.which()? {
-                                                crate::rpc_capnp::return_::Results(Ok(payload)) => {
-                                                    ConnectionState::write_descriptors(&connection_state,
-                                                                                       &cap_table,
-                                                                                       payload)
-                                                }
-                                                _ => {
-                                                    unreachable!()
-                                                }
+                                        message::Return(ret) => match ret?.which()? {
+                                            crate::rpc_capnp::return_::Results(Ok(payload)) => {
+                                                ConnectionState::write_descriptors(
+                                                    &connection_state,
+                                                    &cap_table,
+                                                    payload,
+                                                )
                                             }
-                                        }
-                                        _ =>  {
-                                            unreachable!()
-                                        }
+                                            _ => unreachable!(),
+                                        },
+                                        _ => unreachable!(),
                                     }
                                 };
 
                                 let (_promise, m) = message.send();
                                 connection_state.answer_has_sent_return(answer_id, exports);
-                                let hook = Box::new(ResultsDone::rpc(m, cap_table)) as Box<dyn ResultsDoneHook>;
-                                pipeline_sender.complete(Box::new(
-                                    local::Pipeline::new(hook.clone())));
+                                let hook = Box::new(ResultsDone::rpc(m, cap_table))
+                                    as Box<dyn ResultsDoneHook>;
+                                pipeline_sender
+                                    .complete(Box::new(local::Pipeline::new(hook.clone())));
                                 Ok(hook)
                             }
                             (false, Err(e)) => {
@@ -2216,7 +2496,8 @@ impl ResultsDone {
                                     Ok(ref mut connection) => {
                                         let mut message = connection.new_outgoing_message(50); // XXX size hint
                                         {
-                                            let root: message::Builder = message.get_body()?.get_as()?;
+                                            let root: message::Builder =
+                                                message.get_body()?.get_as()?;
                                             let mut ret = root.init_return();
                                             ret.set_answer_id(answer_id);
                                             ret.set_release_param_caps(false);
@@ -2229,8 +2510,8 @@ impl ResultsDone {
                                 }
                                 connection_state.answer_has_sent_return(answer_id, Vec::new());
 
-                                pipeline_sender.complete(Box::new(
-                                    crate::broken::Pipeline::new(e.clone())));
+                                pipeline_sender
+                                    .complete(Box::new(crate::broken::Pipeline::new(e.clone())));
 
                                 Err(e)
                             }
@@ -2239,7 +2520,8 @@ impl ResultsDone {
                     Some(ResultsVariant::LocallyRedirected(results_done, cap_table)) => {
                         let hook = Box::new(ResultsDone::redirected(results_done, cap_table))
                             as Box<dyn ResultsDoneHook>;
-                        pipeline_sender.complete(Box::new(crate::local::Pipeline::new(hook.clone())));
+                        pipeline_sender
+                            .complete(Box::new(crate::local::Pipeline::new(hook.clone())));
                         Ok(hook)
                     }
                 }
@@ -2247,19 +2529,19 @@ impl ResultsDone {
         }
     }
 
-    fn rpc(message: Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>,
-           cap_table: Vec<Option<Box<dyn ClientHook>>>)
-           -> ResultsDone
-    {
+    fn rpc(
+        message: Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>,
+        cap_table: Vec<Option<Box<dyn ClientHook>>>,
+    ) -> ResultsDone {
         ResultsDone {
             inner: Rc::new(ResultsDoneVariant::Rpc(message, cap_table)),
         }
     }
 
-    fn redirected(message: ::capnp::message::Builder<::capnp::message::HeapAllocator>,
-                  cap_table: Vec<Option<Box<dyn ClientHook>>>)
-                  -> ResultsDone
-    {
+    fn redirected(
+        message: ::capnp::message::Builder<::capnp::message::HeapAllocator>,
+        cap_table: Vec<Option<Box<dyn ClientHook>>>,
+    ) -> ResultsDone {
         ResultsDone {
             inner: Rc::new(ResultsDoneVariant::LocallyRedirected(message, cap_table)),
         }
@@ -2268,7 +2550,9 @@ impl ResultsDone {
 
 impl ResultsDoneHook for ResultsDone {
     fn add_ref(&self) -> Box<dyn ResultsDoneHook> {
-        Box::new(ResultsDone { inner: self.inner.clone() })
+        Box::new(ResultsDone {
+            inner: self.inner.clone(),
+        })
     }
     fn get<'a>(&'a self) -> ::capnp::Result<any_pointer::Reader<'a>> {
         use ::capnp::traits::Imbue;
@@ -2276,21 +2560,15 @@ impl ResultsDoneHook for ResultsDone {
             ResultsDoneVariant::Rpc(ref message, ref cap_table) => {
                 let root: message::Reader = message.get_root_as_reader()?;
                 match root.which()? {
-                    message::Return(ret) => {
-                        match ret?.which()? {
-                            crate::rpc_capnp::return_::Results(payload) => {
-                                let mut content = payload?.get_content();
-                                content.imbue(cap_table);
-                                Ok(content)
-                            }
-                            _ => {
-                                unreachable!()
-                            }
+                    message::Return(ret) => match ret?.which()? {
+                        crate::rpc_capnp::return_::Results(payload) => {
+                            let mut content = payload?.get_content();
+                            content.imbue(cap_table);
+                            Ok(content)
                         }
-                    }
-                    _ =>  {
-                        unreachable!()
-                    }
+                        _ => unreachable!(),
+                    },
+                    _ => unreachable!(),
                 }
             }
             ResultsDoneVariant::LocallyRedirected(ref message, ref cap_table) => {
@@ -2302,54 +2580,61 @@ impl ResultsDoneHook for ResultsDone {
     }
 }
 
-enum ClientVariant<VatId> where VatId: 'static {
+enum ClientVariant<VatId>
+where
+    VatId: 'static,
+{
     Import(Rc<RefCell<ImportClient<VatId>>>),
     Pipeline(Rc<RefCell<PipelineClient<VatId>>>),
     Promise(Rc<RefCell<PromiseClient<VatId>>>),
     __NoIntercept(()),
 }
 
-struct Client<VatId> where VatId: 'static {
+struct Client<VatId>
+where
+    VatId: 'static,
+{
     connection_state: Rc<ConnectionState<VatId>>,
     variant: ClientVariant<VatId>,
 }
 
-enum WeakClientVariant<VatId> where VatId: 'static {
+enum WeakClientVariant<VatId>
+where
+    VatId: 'static,
+{
     Import(Weak<RefCell<ImportClient<VatId>>>),
     Pipeline(Weak<RefCell<PipelineClient<VatId>>>),
     Promise(Weak<RefCell<PromiseClient<VatId>>>),
     __NoIntercept(()),
 }
 
-struct WeakClient<VatId> where VatId: 'static {
+struct WeakClient<VatId>
+where
+    VatId: 'static,
+{
     connection_state: Weak<ConnectionState<VatId>>,
     variant: WeakClientVariant<VatId>,
 }
 
-impl <VatId> WeakClient<VatId> where VatId: 'static {
+impl<VatId> WeakClient<VatId>
+where
+    VatId: 'static,
+{
     fn upgrade(&self) -> Option<Client<VatId>> {
         let variant = match self.variant {
-            WeakClientVariant::Import(ref ic) => {
-                match ic.upgrade() {
-                    Some(ic) => ClientVariant::Import(ic),
-                    None => return None,
-                }
-            }
-            WeakClientVariant::Pipeline(ref pc) => {
-                match pc.upgrade() {
-                    Some(pc) => ClientVariant::Pipeline(pc),
-                    None => return None,
-                }
-            }
-            WeakClientVariant::Promise(ref pc) => {
-                match pc.upgrade() {
-                    Some(pc) => ClientVariant::Promise(pc),
-                    None => return None,
-                }
-            }
-            WeakClientVariant::__NoIntercept(()) => {
-                ClientVariant::__NoIntercept(())
-            }
+            WeakClientVariant::Import(ref ic) => match ic.upgrade() {
+                Some(ic) => ClientVariant::Import(ic),
+                None => return None,
+            },
+            WeakClientVariant::Pipeline(ref pc) => match pc.upgrade() {
+                Some(pc) => ClientVariant::Pipeline(pc),
+                None => return None,
+            },
+            WeakClientVariant::Promise(ref pc) => match pc.upgrade() {
+                Some(pc) => ClientVariant::Promise(pc),
+                None => return None,
+            },
+            WeakClientVariant::__NoIntercept(()) => ClientVariant::__NoIntercept(()),
         };
         let state = match self.connection_state.upgrade() {
             Some(s) => s,
@@ -2362,7 +2647,10 @@ impl <VatId> WeakClient<VatId> where VatId: 'static {
     }
 }
 
-struct ImportClient<VatId> where VatId: 'static {
+struct ImportClient<VatId>
+where
+    VatId: 'static,
+{
     connection_state: Rc<ConnectionState<VatId>>,
     import_id: ImportId,
 
@@ -2370,12 +2658,15 @@ struct ImportClient<VatId> where VatId: 'static {
     remote_ref_count: u32,
 }
 
-impl <VatId> Drop for ImportClient<VatId> {
+impl<VatId> Drop for ImportClient<VatId> {
     fn drop(&mut self) {
         let connection_state = self.connection_state.clone();
 
-        assert!(connection_state.client_downcast_map.borrow_mut()
-                .remove(&((self) as *const _ as usize)).is_some());
+        assert!(connection_state
+            .client_downcast_map
+            .borrow_mut()
+            .remove(&((self) as *const _ as usize))
+            .is_some());
 
         // Remove self from the import table, if the table is still pointing at us.
         let mut remove = false;
@@ -2388,7 +2679,11 @@ impl <VatId> Drop for ImportClient<VatId> {
         }
 
         if remove {
-            connection_state.imports.borrow_mut().slots.remove(&self.import_id);
+            connection_state
+                .imports
+                .borrow_mut()
+                .slots
+                .remove(&self.import_id);
         }
 
         // Send a message releasing our remote references.
@@ -2409,9 +2704,14 @@ impl <VatId> Drop for ImportClient<VatId> {
     }
 }
 
-impl <VatId> ImportClient<VatId> where VatId: 'static {
-    fn new(connection_state: &Rc<ConnectionState<VatId>>, import_id: ImportId)
-           -> Rc<RefCell<ImportClient<VatId>>> {
+impl<VatId> ImportClient<VatId>
+where
+    VatId: 'static,
+{
+    fn new(
+        connection_state: &Rc<ConnectionState<VatId>>,
+        import_id: ImportId,
+    ) -> Rc<RefCell<ImportClient<VatId>>> {
         Rc::new(RefCell::new(ImportClient {
             connection_state: connection_state.clone(),
             import_id: import_id,
@@ -2424,7 +2724,7 @@ impl <VatId> ImportClient<VatId> where VatId: 'static {
     }
 }
 
-impl <VatId> From<Rc<RefCell<ImportClient<VatId>>>> for Client<VatId> {
+impl<VatId> From<Rc<RefCell<ImportClient<VatId>>>> for Client<VatId> {
     fn from(client: Rc<RefCell<ImportClient<VatId>>>) -> Client<VatId> {
         let connection_state = client.borrow().connection_state.clone();
         Client::new(&connection_state, ClientVariant::Import(client))
@@ -2432,16 +2732,24 @@ impl <VatId> From<Rc<RefCell<ImportClient<VatId>>>> for Client<VatId> {
 }
 
 /// A `ClientHook` representing a pipelined promise.  Always wrapped in `PromiseClient`.
-struct PipelineClient<VatId> where VatId: 'static {
+struct PipelineClient<VatId>
+where
+    VatId: 'static,
+{
     connection_state: Rc<ConnectionState<VatId>>,
     question_ref: Rc<RefCell<QuestionRef<VatId>>>,
     ops: Vec<PipelineOp>,
 }
 
-impl <VatId> PipelineClient<VatId> where VatId: 'static {
-    fn new(connection_state: &Rc<ConnectionState<VatId>>,
-           question_ref: Rc<RefCell<QuestionRef<VatId>>>,
-           ops: Vec<PipelineOp>) -> Rc<RefCell<PipelineClient<VatId>>> {
+impl<VatId> PipelineClient<VatId>
+where
+    VatId: 'static,
+{
+    fn new(
+        connection_state: &Rc<ConnectionState<VatId>>,
+        question_ref: Rc<RefCell<QuestionRef<VatId>>>,
+        ops: Vec<PipelineOp>,
+    ) -> Rc<RefCell<PipelineClient<VatId>>> {
         Rc::new(RefCell::new(PipelineClient {
             connection_state: connection_state.clone(),
             question_ref: question_ref,
@@ -2450,24 +2758,30 @@ impl <VatId> PipelineClient<VatId> where VatId: 'static {
     }
 }
 
-impl <VatId> From<Rc<RefCell<PipelineClient<VatId>>>> for Client<VatId> {
+impl<VatId> From<Rc<RefCell<PipelineClient<VatId>>>> for Client<VatId> {
     fn from(client: Rc<RefCell<PipelineClient<VatId>>>) -> Client<VatId> {
         let connection_state = client.borrow().connection_state.clone();
         Client::new(&connection_state, ClientVariant::Pipeline(client))
     }
 }
 
-impl <VatId> Drop for PipelineClient<VatId> {
+impl<VatId> Drop for PipelineClient<VatId> {
     fn drop(&mut self) {
-        assert!(self.connection_state.client_downcast_map.borrow_mut()
-                .remove(&((self) as *const _ as usize)).is_some());
+        assert!(self
+            .connection_state
+            .client_downcast_map
+            .borrow_mut()
+            .remove(&((self) as *const _ as usize))
+            .is_some());
     }
 }
 
-
 /// A `ClientHook` that initially wraps one client and then, later on, redirects
 /// to some other client.
-struct PromiseClient<VatId> where VatId: 'static {
+struct PromiseClient<VatId>
+where
+    VatId: 'static,
+{
     connection_state: Rc<ConnectionState<VatId>>,
     is_resolved: bool,
     cap: Box<dyn ClientHook>,
@@ -2476,10 +2790,12 @@ struct PromiseClient<VatId> where VatId: 'static {
     resolution_waiters: crate::sender_queue::SenderQueue<(), Box<dyn ClientHook>>,
 }
 
-impl <VatId> PromiseClient<VatId> {
-    fn new(connection_state: &Rc<ConnectionState<VatId>>,
-           initial: Box<dyn ClientHook>,
-           import_id: Option<ImportId>) -> Rc<RefCell<PromiseClient<VatId>>> {
+impl<VatId> PromiseClient<VatId> {
+    fn new(
+        connection_state: &Rc<ConnectionState<VatId>>,
+        initial: Box<dyn ClientHook>,
+        import_id: Option<ImportId>,
+    ) -> Rc<RefCell<PromiseClient<VatId>>> {
         Rc::new(RefCell::new(PromiseClient {
             connection_state: connection_state.clone(),
             is_resolved: false,
@@ -2498,23 +2814,32 @@ impl <VatId> PromiseClient<VatId> {
         let connection_state = self.connection_state.clone();
         let is_connected = connection_state.connection.borrow().is_ok();
         let replacement_brand = replacement.get_brand();
-        if replacement_brand != connection_state.get_brand() &&
-            self.received_call && !is_error && is_connected
+        if replacement_brand != connection_state.get_brand()
+            && self.received_call
+            && !is_error
+            && is_connected
         {
             // The new capability is hosted locally, not on the remote machine.  And, we had made calls
             // to the promise.  We need to make sure those calls echo back to us before we allow new
             // calls to go directly to the local capability, so we need to set a local embargo and send
             // a `Disembargo` to echo through the peer.
-            let (fulfiller, promise) = oneshot::channel::<Result<(),Error>>();
-            let promise = promise.map_err(crate::canceled_to_error).and_then(|v| future::ready(v));
+            let (fulfiller, promise) = oneshot::channel::<Result<(), Error>>();
+            let promise = promise
+                .map_err(crate::canceled_to_error)
+                .and_then(|v| future::ready(v));
             let embargo = Embargo::new(fulfiller);
             let embargo_id = connection_state.embargoes.borrow_mut().push(embargo);
 
-            let mut message = connection_state.new_outgoing_message(50).expect("no connection?"); // XXX size hint
+            let mut message = connection_state
+                .new_outgoing_message(50)
+                .expect("no connection?"); // XXX size hint
             {
                 let root: message::Builder = message.get_body().unwrap().init_as();
                 let mut disembargo = root.init_disembargo();
-                disembargo.reborrow().init_context().set_sender_loopback(embargo_id);
+                disembargo
+                    .reborrow()
+                    .init_context()
+                    .set_sender_loopback(embargo_id);
                 let target = disembargo.init_target();
 
                 let redirect = connection_state.write_target(&*self.cap, target);
@@ -2557,7 +2882,7 @@ impl <VatId> PromiseClient<VatId> {
     }
 }
 
-impl <VatId> Drop for PromiseClient<VatId> {
+impl<VatId> Drop for PromiseClient<VatId> {
     fn drop(&mut self) {
         let self_ptr = (self) as *const _ as usize;
 
@@ -2582,21 +2907,27 @@ impl <VatId> Drop for PromiseClient<VatId> {
             }
         }
 
-        assert!(self.connection_state.client_downcast_map.borrow_mut().remove(&self_ptr).is_some());
+        assert!(self
+            .connection_state
+            .client_downcast_map
+            .borrow_mut()
+            .remove(&self_ptr)
+            .is_some());
     }
 }
 
-impl <VatId> From<Rc<RefCell<PromiseClient<VatId>>>> for Client<VatId> {
+impl<VatId> From<Rc<RefCell<PromiseClient<VatId>>>> for Client<VatId> {
     fn from(client: Rc<RefCell<PromiseClient<VatId>>>) -> Client<VatId> {
         let connection_state = client.borrow().connection_state.clone();
         Client::new(&connection_state, ClientVariant::Promise(client))
     }
 }
 
-impl <VatId> Client<VatId> {
-    fn new(connection_state: &Rc<ConnectionState<VatId>>, variant: ClientVariant<VatId>)
-           -> Client<VatId>
-    {
+impl<VatId> Client<VatId> {
+    fn new(
+        connection_state: &Rc<ConnectionState<VatId>>,
+        variant: ClientVariant<VatId>,
+    ) -> Client<VatId> {
         let client = Client {
             connection_state: connection_state.clone(),
             variant: variant,
@@ -2604,7 +2935,10 @@ impl <VatId> Client<VatId> {
         let weak = client.downgrade();
 
         // XXX arguably, this should go in each of the variant's constructors.
-        connection_state.client_downcast_map.borrow_mut().insert(client.get_ptr(), weak);
+        connection_state
+            .client_downcast_map
+            .borrow_mut()
+            .insert(client.get_ptr(), weak);
         client
     }
     fn downgrade(&self) -> WeakClient<VatId> {
@@ -2618,9 +2952,7 @@ impl <VatId> Client<VatId> {
             ClientVariant::Promise(ref promise_client) => {
                 WeakClientVariant::Promise(Rc::downgrade(promise_client))
             }
-            _ => {
-                unimplemented!()
-            }
+            _ => unimplemented!(),
         };
         WeakClient {
             connection_state: Rc::downgrade(&self.connection_state),
@@ -2628,18 +2960,17 @@ impl <VatId> Client<VatId> {
         }
     }
 
-    fn from_ptr(ptr: usize, connection_state: &ConnectionState<VatId>)
-                -> Option<Client<VatId>>
-    {
-        match connection_state.client_downcast_map.borrow().get(&ptr){
+    fn from_ptr(ptr: usize, connection_state: &ConnectionState<VatId>) -> Option<Client<VatId>> {
+        match connection_state.client_downcast_map.borrow().get(&ptr) {
             Some(c) => c.upgrade(),
             None => None,
         }
     }
 
-    fn write_target(&self, mut target: crate::rpc_capnp::message_target::Builder)
-                    -> Option<Box<dyn ClientHook>>
-    {
+    fn write_target(
+        &self,
+        mut target: crate::rpc_capnp::message_target::Builder,
+    ) -> Option<Box<dyn ClientHook>> {
         match self.variant {
             ClientVariant::Import(ref import_client) => {
                 target.set_imported_cap(import_client.borrow().import_id);
@@ -2649,11 +2980,15 @@ impl <VatId> Client<VatId> {
                 let mut builder = target.init_promised_answer();
                 let question_ref = &pipeline_client.borrow().question_ref;
                 builder.set_question_id(question_ref.borrow().id);
-                let mut transform = builder.init_transform(pipeline_client.borrow().ops.len() as u32);
-                for idx in 0 .. pipeline_client.borrow().ops.len() {
+                let mut transform =
+                    builder.init_transform(pipeline_client.borrow().ops.len() as u32);
+                for idx in 0..pipeline_client.borrow().ops.len() {
                     match pipeline_client.borrow().ops[idx] {
                         ::capnp::private::capability::PipelineOp::GetPointerField(ordinal) => {
-                            transform.reborrow().get(idx as u32).set_get_pointer_field(ordinal);
+                            transform
+                                .reborrow()
+                                .get(idx as u32)
+                                .set_get_pointer_field(ordinal);
                         }
                         _ => {}
                     }
@@ -2662,12 +2997,10 @@ impl <VatId> Client<VatId> {
             }
             ClientVariant::Promise(ref promise_client) => {
                 promise_client.borrow_mut().received_call = true;
-                self.connection_state.write_target(
-                    &*promise_client.borrow().cap, target)
+                self.connection_state
+                    .write_target(&*promise_client.borrow().cap, target)
             }
-            _ => {
-                unimplemented!()
-            }
+            _ => unimplemented!(),
         }
     }
 
@@ -2681,11 +3014,15 @@ impl <VatId> Client<VatId> {
                 let mut promised_answer = descriptor.init_receiver_answer();
                 let question_ref = &pipeline_client.borrow().question_ref;
                 promised_answer.set_question_id(question_ref.borrow().id);
-                let mut transform = promised_answer.init_transform(pipeline_client.borrow().ops.len() as u32);
-                for idx in 0 .. pipeline_client.borrow().ops.len() {
+                let mut transform =
+                    promised_answer.init_transform(pipeline_client.borrow().ops.len() as u32);
+                for idx in 0..pipeline_client.borrow().ops.len() {
                     match pipeline_client.borrow().ops[idx] {
                         ::capnp::private::capability::PipelineOp::GetPointerField(ordinal) => {
-                            transform.reborrow().get(idx as u32).set_get_pointer_field(ordinal);
+                            transform
+                                .reborrow()
+                                .get(idx as u32)
+                                .set_get_pointer_field(ordinal);
                         }
                         _ => {}
                     }
@@ -2696,18 +3033,19 @@ impl <VatId> Client<VatId> {
             ClientVariant::Promise(ref promise_client) => {
                 promise_client.borrow_mut().received_call = true;
 
-                ConnectionState::write_descriptor(&self.connection_state.clone(),
-                                                  &promise_client.borrow().cap.clone(),
-                                                  descriptor).unwrap()
+                ConnectionState::write_descriptor(
+                    &self.connection_state.clone(),
+                    &promise_client.borrow().cap.clone(),
+                    descriptor,
+                )
+                .unwrap()
             }
-            _ => {
-                unimplemented!()
-            }
+            _ => unimplemented!(),
         }
     }
 }
 
-impl <VatId> Clone for Client<VatId> {
+impl<VatId> Clone for Client<VatId> {
     fn clone(&self) -> Client<VatId> {
         let variant = match self.variant {
             ClientVariant::Import(ref import_client) => {
@@ -2719,51 +3057,54 @@ impl <VatId> Clone for Client<VatId> {
             ClientVariant::Promise(ref promise_client) => {
                 ClientVariant::Promise(promise_client.clone())
             }
-            _ => {
-                unimplemented!()
-            }
+            _ => unimplemented!(),
         };
-        Client { connection_state: self.connection_state.clone(), variant: variant}
+        Client {
+            connection_state: self.connection_state.clone(),
+            variant: variant,
+        }
     }
 }
 
-impl <VatId> ClientHook for Client<VatId> {
+impl<VatId> ClientHook for Client<VatId> {
     fn add_ref(&self) -> Box<dyn ClientHook> {
         Box::new(self.clone())
     }
-    fn new_call(&self, interface_id: u64, method_id: u16,
-                size_hint: Option<::capnp::MessageSize>)
-                -> ::capnp::capability::Request<any_pointer::Owned, any_pointer::Owned>
-    {
+    fn new_call(
+        &self,
+        interface_id: u64,
+        method_id: u16,
+        size_hint: Option<::capnp::MessageSize>,
+    ) -> ::capnp::capability::Request<any_pointer::Owned, any_pointer::Owned> {
         let request: Box<dyn RequestHook> =
-            match Request::new(self.connection_state.clone(), size_hint, self.clone())
-        {
-            Ok(mut request) => {
-                {
-                    let mut call_builder = request.init_call();
-                    call_builder.set_interface_id(interface_id);
-                    call_builder.set_method_id(method_id);
+            match Request::new(self.connection_state.clone(), size_hint, self.clone()) {
+                Ok(mut request) => {
+                    {
+                        let mut call_builder = request.init_call();
+                        call_builder.set_interface_id(interface_id);
+                        call_builder.set_method_id(method_id);
+                    }
+                    Box::new(request)
                 }
-                Box::new(request)
-            }
-            Err(e) => {
-                Box::new(broken::Request::new(e, None))
-            }
-        };
+                Err(e) => Box::new(broken::Request::new(e, None)),
+            };
 
         ::capnp::capability::Request::new(request)
     }
 
-    fn call(&self, interface_id: u64, method_id: u16, params: Box<dyn ParamsHook>,
-            mut results: Box<dyn ResultsHook>)
-        -> Promise<(), Error>
-    {
+    fn call(
+        &self,
+        interface_id: u64,
+        method_id: u16,
+        params: Box<dyn ParamsHook>,
+        mut results: Box<dyn ResultsHook>,
+    ) -> Promise<(), Error> {
         // Implement call() by copying params and results messages.
 
         let maybe_request = params.get().and_then(|p| {
-            let mut request = p.target_size().and_then(|s| {
-                Ok(self.new_call(interface_id, method_id, Some(s)))
-            })?;
+            let mut request = p
+                .target_size()
+                .and_then(|s| Ok(self.new_call(interface_id, method_id, Some(s))))?;
             request.get().set_as(p)?;
             Ok(request)
         });
@@ -2800,9 +3141,7 @@ impl <VatId> ClientHook for Client<VatId> {
             ClientVariant::Promise(ref promise_client) => {
                 (&*promise_client.borrow()) as *const _ as usize
             }
-            _ => {
-                unimplemented!()
-            }
+            _ => unimplemented!(),
         }
     }
 
@@ -2812,12 +3151,8 @@ impl <VatId> ClientHook for Client<VatId> {
 
     fn get_resolved(&self) -> Option<Box<dyn ClientHook>> {
         match self.variant {
-            ClientVariant::Import(ref _import_client) => {
-                None
-            }
-            ClientVariant::Pipeline(ref _pipeline_client) => {
-                None
-            }
+            ClientVariant::Import(ref _import_client) => None,
+            ClientVariant::Pipeline(ref _pipeline_client) => None,
             ClientVariant::Promise(ref promise_client) => {
                 if promise_client.borrow().is_resolved {
                     Some(promise_client.borrow().cap.clone())
@@ -2825,26 +3160,18 @@ impl <VatId> ClientHook for Client<VatId> {
                     None
                 }
             }
-            _ => {
-                unimplemented!()
-            }
+            _ => unimplemented!(),
         }
     }
 
     fn when_more_resolved(&self) -> Option<Promise<Box<dyn ClientHook>, Error>> {
         match self.variant {
-            ClientVariant::Import(ref _import_client) => {
-                None
-            }
-            ClientVariant::Pipeline(ref _pipeline_client) => {
-                None
-            }
+            ClientVariant::Import(ref _import_client) => None,
+            ClientVariant::Pipeline(ref _pipeline_client) => None,
             ClientVariant::Promise(ref promise_client) => {
                 Some(promise_client.borrow_mut().resolution_waiters.push(()))
             }
-            _ => {
-                unimplemented!()
-            }
+            _ => unimplemented!(),
         }
     }
 
@@ -2854,17 +3181,14 @@ impl <VatId> ClientHook for Client<VatId> {
 }
 
 pub(crate) fn default_when_resolved_impl<C>(client: &C) -> Promise<(), Error>
-    where C: ClientHook
+where
+    C: ClientHook,
 {
     match client.when_more_resolved() {
         Some(promise) => {
-            Promise::from_future(promise.and_then(|resolution| {
-                resolution.when_resolved()
-            }))
+            Promise::from_future(promise.and_then(|resolution| resolution.when_resolved()))
         }
-        None => {
-            Promise::ok(())
-        }
+        None => Promise::ok(()),
     }
 }
 
@@ -2882,7 +3206,9 @@ impl SingleCapPipeline {
 
 impl PipelineHook for SingleCapPipeline {
     fn add_ref(&self) -> Box<dyn PipelineHook> {
-        Box::new(SingleCapPipeline {cap: self.cap.clone() })
+        Box::new(SingleCapPipeline {
+            cap: self.cap.clone(),
+        })
     }
     fn get_pipelined_cap(&self, ops: &[PipelineOp]) -> Box<dyn ClientHook> {
         if ops.is_empty() {

--- a/capnp-rpc/src/sender_queue.rs
+++ b/capnp-rpc/src/sender_queue.rs
@@ -19,8 +19,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use futures::{FutureExt, TryFutureExt};
-use futures::channel::oneshot;
+use futures_channel::oneshot;
+use futures_util::{FutureExt, TryFutureExt};
 
 use std::cell::RefCell;
 use std::rc::{Rc, Weak};
@@ -31,27 +31,35 @@ use capnp::Error;
 use std::collections::BTreeMap;
 
 struct Inner<In, Out>
-    where In: 'static, Out: 'static
+where
+    In: 'static,
+    Out: 'static,
 {
     next_id: u64,
     map: BTreeMap<u64, (In, oneshot::Sender<Out>)>,
 }
 
 pub struct SenderQueue<In, Out>
-    where In: 'static, Out: 'static
+where
+    In: 'static,
+    Out: 'static,
 {
     inner: Rc<RefCell<Inner<In, Out>>>,
 }
 
 pub struct Remover<In, Out>
-    where In: 'static, Out: 'static
+where
+    In: 'static,
+    Out: 'static,
 {
     id: u64,
     inner: Weak<RefCell<Inner<In, Out>>>,
 }
 
-impl <In, Out> Drop for Remover<In, Out>
-    where In: 'static, Out: 'static
+impl<In, Out> Drop for Remover<In, Out>
+where
+    In: 'static,
+    Out: 'static,
 {
     fn drop(&mut self) {
         match self.inner.upgrade() {
@@ -64,7 +72,11 @@ impl <In, Out> Drop for Remover<In, Out>
     }
 }
 
-impl <In, Out> SenderQueue<In, Out> where In: 'static, Out: 'static {
+impl<In, Out> SenderQueue<In, Out>
+where
+    In: 'static,
+    Out: 'static,
+{
     pub fn new() -> SenderQueue<In, Out> {
         SenderQueue {
             inner: Rc::new(RefCell::new(Inner {
@@ -76,7 +88,11 @@ impl <In, Out> SenderQueue<In, Out> where In: 'static, Out: 'static {
 
     pub fn push(&mut self, value: In) -> Promise<Out, Error> {
         let weak_inner = Rc::downgrade(&self.inner);
-        let Inner { ref mut next_id, ref mut map, .. } = *self.inner.borrow_mut();
+        let Inner {
+            ref mut next_id,
+            ref mut map,
+            ..
+        } = *self.inner.borrow_mut();
         let (tx, rx) = oneshot::channel();
         map.insert(*next_id, (value, tx));
 
@@ -87,38 +103,52 @@ impl <In, Out> SenderQueue<In, Out> where In: 'static, Out: 'static {
 
         *next_id += 1;
 
-        Promise::from_future(rx.map_err(|_| Error::failed("SenderQueue canceled".into())).map(move |out| {
-            drop(remover);
-            out
-        }))
+        Promise::from_future(
+            rx.map_err(|_| Error::failed("SenderQueue canceled".into()))
+                .map(move |out| {
+                    drop(remover);
+                    out
+                }),
+        )
     }
 
     pub fn push_detach(&mut self, value: In) {
-        let Inner { ref mut next_id, ref mut map, .. } = *self.inner.borrow_mut();
+        let Inner {
+            ref mut next_id,
+            ref mut map,
+            ..
+        } = *self.inner.borrow_mut();
         let (tx, _rx) = oneshot::channel();
         map.insert(*next_id, (value, tx));
         *next_id += 1;
     }
 
-
     pub fn drain(&mut self) -> Drain<In, Out> {
-        let Inner { ref mut next_id, ref mut map, .. } = *self.inner.borrow_mut();
+        let Inner {
+            ref mut next_id,
+            ref mut map,
+            ..
+        } = *self.inner.borrow_mut();
         *next_id = 0;
         let map = ::std::mem::replace(map, BTreeMap::new());
         Drain {
-            iter: map.into_iter()
+            iter: map.into_iter(),
         }
     }
 }
 
 pub struct Drain<In, Out>
-where In: 'static, Out: 'static
+where
+    In: 'static,
+    Out: 'static,
 {
     iter: ::std::collections::btree_map::IntoIter<u64, (In, oneshot::Sender<Out>)>,
 }
 
-impl <In, Out> ::std::iter::Iterator for Drain<In, Out>
-    where In: 'static, Out: 'static
+impl<In, Out> ::std::iter::Iterator for Drain<In, Out>
+where
+    In: 'static,
+    Out: 'static,
 {
     type Item = (In, oneshot::Sender<Out>);
     fn next(&mut self) -> Option<Self::Item> {

--- a/capnp-rpc/src/split.rs
+++ b/capnp-rpc/src/split.rs
@@ -19,20 +19,32 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use futures::{Future, FutureExt};
+use futures_core::Future;
+use futures_util::FutureExt;
 
 use std::cell::RefCell;
-use std::rc::{Rc};
+use std::rc::Rc;
 
-pub fn split<F, T1, T2, E>(f: F) -> (impl Future<Output=Result<T1, E>>,
-                                     impl Future<Output=Result<T2, E>>)
-    where F: Future<Output=Result<(T1, T2), E>>,
-          E: Clone,
+pub fn split<F, T1, T2, E>(
+    f: F,
+) -> (
+    impl Future<Output = Result<T1, E>>,
+    impl Future<Output = Result<T2, E>>,
+)
+where
+    F: Future<Output = Result<(T1, T2), E>>,
+    E: Clone,
 {
-    let shared = f.map(|r| {
-        let (v1, v2) = r?;
-        Ok(Rc::new(RefCell::new((Some(v1), Some(v2)))))
-        }).shared();
-    (shared.clone().map(|r| Ok::<T1, E>(r?.borrow_mut().0.take().unwrap())),
-     shared.map(|r| Ok::<T2, E>(r?.borrow_mut().1.take().unwrap())))
+    let shared = f
+        .map(|r| {
+            let (v1, v2) = r?;
+            Ok(Rc::new(RefCell::new((Some(v1), Some(v2)))))
+        })
+        .shared();
+    (
+        shared
+            .clone()
+            .map(|r| Ok::<T1, E>(r?.borrow_mut().0.take().unwrap())),
+        shared.map(|r| Ok::<T2, E>(r?.borrow_mut().1.take().unwrap())),
+    )
 }

--- a/capnp-rpc/src/twoparty.rs
+++ b/capnp-rpc/src/twoparty.rs
@@ -21,10 +21,11 @@
 
 //! An implementation of `VatNetwork` for the common case of a client-server connection.
 
-use capnp::message::ReaderOptions;
 use capnp::capability::Promise;
-use futures::{AsyncRead, AsyncWrite, FutureExt, TryFutureExt};
-use futures::channel::oneshot;
+use capnp::message::ReaderOptions;
+use futures_channel::oneshot;
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::{FutureExt, TryFutureExt};
 
 use std::cell::RefCell;
 use std::rc::{Rc, Weak};
@@ -36,7 +37,9 @@ struct IncomingMessage {
 }
 
 impl IncomingMessage {
-    pub fn new(message: ::capnp::message::Reader<capnp::serialize::OwnedSegments>) -> IncomingMessage {
+    pub fn new(
+        message: ::capnp::message::Reader<capnp::serialize::OwnedSegments>,
+    ) -> IncomingMessage {
         IncomingMessage { message: message }
     }
 }
@@ -61,25 +64,33 @@ impl crate::OutgoingMessage for OutgoingMessage {
         self.message.get_root_as_reader()
     }
 
-    fn send(self: Box<Self>)
-            ->
-        (Promise<Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>, ::capnp::Error>,
-         Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>)
-    {
+    fn send(
+        self: Box<Self>,
+    ) -> (
+        Promise<Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>, ::capnp::Error>,
+        Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>,
+    ) {
         let tmp = *self;
-        let OutgoingMessage {message, mut sender} = tmp;
+        let OutgoingMessage {
+            message,
+            mut sender,
+        } = tmp;
         let m = Rc::new(message);
-        (Promise::from_future(sender.send(m.clone()).map_err(|e| e.into())), m)
+        (
+            Promise::from_future(sender.send(m.clone()).map_err(|e| e.into())),
+            m,
+        )
     }
 
-    fn take(self: Box<Self>)
-            -> ::capnp::message::Builder<::capnp::message::HeapAllocator>
-    {
+    fn take(self: Box<Self>) -> ::capnp::message::Builder<::capnp::message::HeapAllocator> {
         self.message
     }
 }
 
-struct ConnectionInner<T> where T: AsyncRead + 'static {
+struct ConnectionInner<T>
+where
+    T: AsyncRead + 'static,
+{
     input_stream: Rc<RefCell<Option<T>>>,
     sender: ::capnp_futures::Sender<Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>>,
     side: crate::rpc_twoparty_capnp::Side,
@@ -87,11 +98,17 @@ struct ConnectionInner<T> where T: AsyncRead + 'static {
     on_disconnect_fulfiller: Option<oneshot::Sender<()>>,
 }
 
-struct Connection<T> where T: AsyncRead + 'static {
+struct Connection<T>
+where
+    T: AsyncRead + 'static,
+{
     inner: Rc<RefCell<ConnectionInner<T>>>,
 }
 
-impl <T> Drop for ConnectionInner<T> where T: AsyncRead {
+impl<T> Drop for ConnectionInner<T>
+where
+    T: AsyncRead,
+{
     fn drop(&mut self) {
         let maybe_fulfiller = ::std::mem::replace(&mut self.on_disconnect_fulfiller, None);
         match maybe_fulfiller {
@@ -103,43 +120,52 @@ impl <T> Drop for ConnectionInner<T> where T: AsyncRead {
     }
 }
 
-impl <T> Connection<T> where T: AsyncRead {
-    fn new(input_stream: T,
-           sender: ::capnp_futures::Sender<Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>>,
-           side: crate::rpc_twoparty_capnp::Side,
-           receive_options: ReaderOptions,
-           on_disconnect_fulfiller: oneshot::Sender<()>,
-           ) -> Connection<T>
-    {
-
+impl<T> Connection<T>
+where
+    T: AsyncRead,
+{
+    fn new(
+        input_stream: T,
+        sender: ::capnp_futures::Sender<
+            Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>,
+        >,
+        side: crate::rpc_twoparty_capnp::Side,
+        receive_options: ReaderOptions,
+        on_disconnect_fulfiller: oneshot::Sender<()>,
+    ) -> Connection<T> {
         Connection {
-            inner: Rc::new(RefCell::new(
-                ConnectionInner {
-                    input_stream: Rc::new(RefCell::new(Some(input_stream))),
-                    sender: sender,
-                    side: side,
-                    receive_options: receive_options,
-                    on_disconnect_fulfiller: Some(on_disconnect_fulfiller),
-                })),
+            inner: Rc::new(RefCell::new(ConnectionInner {
+                input_stream: Rc::new(RefCell::new(Some(input_stream))),
+                sender: sender,
+                side: side,
+                receive_options: receive_options,
+                on_disconnect_fulfiller: Some(on_disconnect_fulfiller),
+            })),
         }
     }
 }
 
-impl <T> crate::Connection<crate::rpc_twoparty_capnp::Side> for Connection<T>
-    where T: AsyncRead + Unpin
+impl<T> crate::Connection<crate::rpc_twoparty_capnp::Side> for Connection<T>
+where
+    T: AsyncRead + Unpin,
 {
     fn get_peer_vat_id(&self) -> crate::rpc_twoparty_capnp::Side {
         self.inner.borrow().side
     }
 
-    fn new_outgoing_message(&mut self, _first_segment_word_size: u32) -> Box<dyn crate::OutgoingMessage> {
+    fn new_outgoing_message(
+        &mut self,
+        _first_segment_word_size: u32,
+    ) -> Box<dyn crate::OutgoingMessage> {
         Box::new(OutgoingMessage {
             message: ::capnp::message::Builder::new_default(),
             sender: self.inner.borrow().sender.clone(),
         })
     }
 
-    fn receive_incoming_message(&mut self) -> Promise<Option<Box<dyn crate::IncomingMessage + 'static>>, ::capnp::Error> {
+    fn receive_incoming_message(
+        &mut self,
+    ) -> Promise<Option<Box<dyn crate::IncomingMessage + 'static>>, ::capnp::Error> {
         let mut inner = self.inner.borrow_mut();
         let maybe_input_stream = ::std::mem::replace(&mut *inner.input_stream.borrow_mut(), None);
         let return_it_here = inner.input_stream.clone();
@@ -147,36 +173,52 @@ impl <T> crate::Connection<crate::rpc_twoparty_capnp::Side> for Connection<T>
             Some(mut s) => {
                 let receive_options = inner.receive_options;
                 Promise::from_future(async move {
-                    let maybe_message = ::capnp_futures::serialize::read_message(&mut s, receive_options).await?;
+                    let maybe_message =
+                        ::capnp_futures::serialize::read_message(&mut s, receive_options).await?;
                     *return_it_here.borrow_mut() = Some(s);
-                    Ok(maybe_message.map(|message|
-                                         Box::new(IncomingMessage::new(message)) as Box<dyn crate::IncomingMessage>))
+                    Ok(maybe_message.map(|message| {
+                        Box::new(IncomingMessage::new(message)) as Box<dyn crate::IncomingMessage>
+                    }))
                 })
             }
             None => {
-                Promise::err(::capnp::Error::failed("this should not be possible".to_string()))
-             //   unreachable!(),
+                Promise::err(::capnp::Error::failed(
+                    "this should not be possible".to_string(),
+                ))
+                //   unreachable!(),
             }
         }
     }
 
     fn shutdown(&mut self, result: ::capnp::Result<()>) -> Promise<(), ::capnp::Error> {
-        Promise::from_future(self.inner.borrow_mut().sender.terminate(result).map_err(|e| e.into()))
+        Promise::from_future(
+            self.inner
+                .borrow_mut()
+                .sender
+                .terminate(result)
+                .map_err(|e| e.into()),
+        )
     }
 }
 
 /// A vat network with two parties, the client and the server.
-pub struct VatNetwork<T> where T: AsyncRead + 'static + Unpin {
+pub struct VatNetwork<T>
+where
+    T: AsyncRead + 'static + Unpin,
+{
     connection: Option<Connection<T>>,
 
     // HACK
     weak_connection_inner: Weak<RefCell<ConnectionInner<T>>>,
 
-    execution_driver: futures::future::Shared<Promise<(), ::capnp::Error>>,
+    execution_driver: futures_util::future::Shared<Promise<(), ::capnp::Error>>,
     side: crate::rpc_twoparty_capnp::Side,
 }
 
-impl <T> VatNetwork<T> where T: AsyncRead + Unpin {
+impl<T> VatNetwork<T>
+where
+    T: AsyncRead + Unpin,
+{
     /// Creates a new two-party vat network that will receive data on `input_stream` and send data on
     /// `output_stream`.
     ///
@@ -186,28 +228,34 @@ impl <T> VatNetwork<T> where T: AsyncRead + Unpin {
     /// will make more sense once we have vat networks with more than two parties.
     ///
     /// The options in `receive_options` will be used when reading the messages that come in on `input_stream`.
-    pub fn new<U>(input_stream: T,
-               output_stream: U,
-               side: crate::rpc_twoparty_capnp::Side,
-               receive_options: ReaderOptions) -> VatNetwork<T>
-        where U: AsyncWrite + 'static + Unpin,
+    pub fn new<U>(
+        input_stream: T,
+        output_stream: U,
+        side: crate::rpc_twoparty_capnp::Side,
+        receive_options: ReaderOptions,
+    ) -> VatNetwork<T>
+    where
+        U: AsyncWrite + 'static + Unpin,
     {
-
         let (fulfiller, disconnect_promise) = oneshot::channel();
-        let disconnect_promise = disconnect_promise
-            .map_err(|_| ::capnp::Error::disconnected("disconnected".into()));
+        let disconnect_promise =
+            disconnect_promise.map_err(|_| ::capnp::Error::disconnected("disconnected".into()));
 
         let (execution_driver, sender) = {
             let (tx, write_queue) = ::capnp_futures::write_queue(output_stream);
 
             // Don't use `.join()` here because we need to make sure to wait for `disconnect_promise` to
             // resolve even if `write_queue` resolves to an error.
-            (Promise::from_future(
-                write_queue
-                    .then(move |r| disconnect_promise.then(move |_| futures::future::ready(r)).map_ok(|_| ()))).shared(),
-             tx)
+            (
+                Promise::from_future(write_queue.then(move |r| {
+                    disconnect_promise
+                        .then(move |_| futures_util::future::ready(r))
+                        .map_ok(|_| ())
+                }))
+                .shared(),
+                tx,
+            )
         };
-
 
         let connection = Connection::new(input_stream, sender, side, receive_options, fulfiller);
         let weak_inner = Rc::downgrade(&connection.inner);
@@ -220,8 +268,9 @@ impl <T> VatNetwork<T> where T: AsyncRead + Unpin {
     }
 }
 
-impl <T> crate::VatNetwork<VatId> for VatNetwork<T>
-    where T: AsyncRead + Unpin
+impl<T> crate::VatNetwork<VatId> for VatNetwork<T>
+where
+    T: AsyncRead + Unpin,
 {
     fn connect(&mut self, host_id: VatId) -> Option<Box<dyn crate::Connection<VatId>>> {
         if host_id == self.side {
@@ -229,18 +278,13 @@ impl <T> crate::VatNetwork<VatId> for VatNetwork<T>
         } else {
             let connection = ::std::mem::replace(&mut self.connection, None);
             match connection {
-                Some(c) => {
-                    Some(Box::new(c))
-                } None => {
-                    match self.weak_connection_inner.upgrade() {
-                        Some(connection_inner) => {
-                            Some(Box::new(Connection { inner: connection_inner }))
-                        }
-                        None => {
-                            panic!("tried to reconnect a disconnected twoparty vat network.")
-                        }
-                    }
-                }
+                Some(c) => Some(Box::new(c)),
+                None => match self.weak_connection_inner.upgrade() {
+                    Some(connection_inner) => Some(Box::new(Connection {
+                        inner: connection_inner,
+                    })),
+                    None => panic!("tried to reconnect a disconnected twoparty vat network."),
+                },
             }
         }
     }
@@ -249,7 +293,7 @@ impl <T> crate::VatNetwork<VatId> for VatNetwork<T>
         let connection = ::std::mem::replace(&mut self.connection, None);
         match connection {
             Some(c) => Promise::ok(Box::new(c) as Box<dyn crate::Connection<VatId>>),
-            None => Promise::from_future(::futures::future::pending()),
+            None => Promise::from_future(futures_util::future::pending()),
         }
     }
 


### PR DESCRIPTION
`futures` is kind of a heavy crate, and this PR reduces the number of sub-crates being included by capnp-rpc/capnp-futures by only pulling exactly the sub-crates that are used (futures_core, futures_channel, futures_io and futures_util).

Unfortunately, it seems my rustfmt didn't agree with yours - do you have any idea why?