### PR TITLE
remove unneeded `To` type parameter of `SetPointerBuilder`

### DIFF
--- a/capnp-rpc/src/lib.rs
+++ b/capnp-rpc/src/lib.rs
@@ -354,8 +354,8 @@ impl <A> ImbuedMessageBuilder<A> where A: ::capnp::message::Allocator {
         root.get_as()
     }
 
-    pub fn set_root<To, From>(&mut self, value: From) -> ::capnp::Result<()>
-        where From: ::capnp::traits::SetPointerBuilder<To>
+    pub fn set_root<From>(&mut self, value: From) -> ::capnp::Result<()>
+        where From: ::capnp::traits::SetPointerBuilder
     {
         use capnp::traits::ImbueMut;
         let mut root: ::capnp::any_pointer::Builder = self.builder.get_root()?;

--- a/capnp-rpc/src/rpc_capnp.rs
+++ b/capnp-rpc/src/rpc_capnp.rs
@@ -215,7 +215,7 @@ pub mod message {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -623,7 +623,7 @@ pub mod bootstrap {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -794,7 +794,7 @@ pub mod call {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -1014,7 +1014,7 @@ pub mod call {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -1233,7 +1233,7 @@ pub mod return_ {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -1468,7 +1468,7 @@ pub mod finish {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -1627,7 +1627,7 @@ pub mod resolve {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -1806,7 +1806,7 @@ pub mod release {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -1946,7 +1946,7 @@ pub mod disembargo {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -2117,7 +2117,7 @@ pub mod disembargo {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -2302,7 +2302,7 @@ pub mod provide {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -2472,7 +2472,7 @@ pub mod accept {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -2635,7 +2635,7 @@ pub mod join {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -2812,7 +2812,7 @@ pub mod message_target {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -2980,7 +2980,7 @@ pub mod payload {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -3170,7 +3170,7 @@ pub mod cap_descriptor {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -3387,7 +3387,7 @@ pub mod promised_answer {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -3540,7 +3540,7 @@ pub mod promised_answer {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -3696,7 +3696,7 @@ pub mod third_party_cap_descriptor {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -3852,7 +3852,7 @@ pub mod exception {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 

--- a/capnp-rpc/src/rpc_twoparty_capnp.rs
+++ b/capnp-rpc/src/rpc_twoparty_capnp.rs
@@ -110,7 +110,7 @@ pub mod vat_id {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -235,7 +235,7 @@ pub mod provision_id {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -356,7 +356,7 @@ pub mod recipient_id {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -469,7 +469,7 @@ pub mod third_party_cap_id {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -594,7 +594,7 @@ pub mod join_key_part {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -746,7 +746,7 @@ pub mod join_result {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 

--- a/capnp/src/any_pointer.rs
+++ b/capnp/src/any_pointer.rs
@@ -99,7 +99,7 @@ impl <'a> FromPointerReader<'a> for Reader<'a> {
     }
 }
 
-impl <'a> crate::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
+impl <'a> crate::traits::SetPointerBuilder for Reader<'a> {
     fn set_pointer_builder<'b>(mut pointer: crate::private::layout::PointerBuilder<'b>,
                                value: Reader<'a>,
                                canonicalize: bool) -> Result<()> {
@@ -148,8 +148,8 @@ impl <'a> Builder<'a> {
         FromPointerBuilder::init_pointer(self.builder, size)
     }
 
-    pub fn set_as<To, From : SetPointerBuilder<To>>(self, value: From) -> Result<()> {
-        SetPointerBuilder::<To>::set_pointer_builder(self.builder, value, false)
+    pub fn set_as<From: SetPointerBuilder>(self, value: From) -> Result<()> {
+        SetPointerBuilder::set_pointer_builder(self.builder, value, false)
     }
 
     // XXX value should be a user client.

--- a/capnp/src/any_pointer_list.rs
+++ b/capnp/src/any_pointer_list.rs
@@ -115,7 +115,7 @@ impl <'a> FromPointerBuilder<'a> for Builder<'a> {
     }
 }
 
-impl <'a> crate::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
+impl <'a> crate::traits::SetPointerBuilder for Reader<'a> {
     fn set_pointer_builder<'b>(pointer: PointerBuilder<'b>,
                                value: Reader<'a>,
                                canonicalize: bool) -> Result<()> {

--- a/capnp/src/capability_list.rs
+++ b/capnp/src/capability_list.rs
@@ -143,7 +143,7 @@ impl <'a, T> Builder<'a, T> where T: FromClientHook {
     }
 }
 
-impl <'a, T> crate::traits::SetPointerBuilder<Builder<'a, T>> for Reader<'a, T>
+impl <'a, T> crate::traits::SetPointerBuilder for Reader<'a, T>
     where T: FromClientHook
 {
     fn set_pointer_builder<'b>(pointer: crate::private::layout::PointerBuilder<'b>,

--- a/capnp/src/data.rs
+++ b/capnp/src/data.rs
@@ -69,7 +69,7 @@ impl <'a> crate::traits::FromPointerBuilder<'a> for Builder<'a> {
     }
 }
 
-impl <'a> crate::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
+impl <'a> crate::traits::SetPointerBuilder for Reader<'a> {
     fn set_pointer_builder<'b>(pointer: PointerBuilder<'b>,
                                value: Reader<'a>,
                                _canonicalize: bool) -> Result<()> {

--- a/capnp/src/data_list.rs
+++ b/capnp/src/data_list.rs
@@ -124,7 +124,7 @@ impl <'a> Builder<'a> {
 }
 
 
-impl <'a> crate::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
+impl <'a> crate::traits::SetPointerBuilder for Reader<'a> {
     fn set_pointer_builder<'b>(pointer: crate::private::layout::PointerBuilder<'b>,
                                value: Reader<'a>,
                                canonicalize: bool) -> Result<()> {

--- a/capnp/src/enum_list.rs
+++ b/capnp/src/enum_list.rs
@@ -130,7 +130,7 @@ impl <'a, T : ToU16 + FromU16>  Builder<'a, T> {
     }
 }
 
-impl <'a, T> crate::traits::SetPointerBuilder<Builder<'a, T>> for Reader<'a, T> {
+impl <'a, T> crate::traits::SetPointerBuilder for Reader<'a, T> {
     fn set_pointer_builder<'b>(pointer: crate::private::layout::PointerBuilder<'b>,
                                value: Reader<'a, T>,
                                canonicalize: bool) -> Result<()> {

--- a/capnp/src/list_list.rs
+++ b/capnp/src/list_list.rs
@@ -131,7 +131,7 @@ impl <'a, T> Builder<'a, T> where T: for<'b> crate::traits::Owned<'b> {
     }
 }
 
-impl <'a, T> crate::traits::SetPointerBuilder<Builder<'a, T>> for Reader<'a, T>
+impl <'a, T> crate::traits::SetPointerBuilder for Reader<'a, T>
     where T: for<'b> crate::traits::Owned<'b>
 {
     fn set_pointer_builder<'b>(pointer: crate::private::layout::PointerBuilder<'b>,

--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -355,7 +355,7 @@ impl <A> Builder<A> where A: Allocator {
     }
 
     /// Sets the root to a deep copy of the given value.
-    pub fn set_root<To, From: SetPointerBuilder<To>>(&mut self, value: From) -> Result<()> {
+    pub fn set_root<From: SetPointerBuilder>(&mut self, value: From) -> Result<()> {
         let root = self.get_root_internal();
         root.set_as(value)
     }
@@ -363,7 +363,8 @@ impl <A> Builder<A> where A: Allocator {
     /// Sets the root to a canonicalized version of `value`. If this was the first action taken
     /// on this `Builder`, then a subsequent call to `get_segments_for_output()` should return
     /// a single segment, containing the full canonicalized message.
-    pub fn set_root_canonical<To, From: SetPointerBuilder<To>>(&mut self, value: From) -> Result<()> {
+    pub fn set_root_canonical<From: SetPointerBuilder>(&mut self, value: From) -> Result<()>
+    {
         if self.arena.len() == 0 {
             self.arena.allocate_segment(1).expect("allocate root pointer");
             self.arena.allocate(0, 1).expect("allocate root pointer");

--- a/capnp/src/primitive_list.rs
+++ b/capnp/src/primitive_list.rs
@@ -129,7 +129,7 @@ impl <'a, T : PrimitiveElement> Builder<'a, T> {
     }
 }
 
-impl <'a, T> crate::traits::SetPointerBuilder<Builder<'a, T>> for Reader<'a, T>
+impl <'a, T> crate::traits::SetPointerBuilder for Reader<'a, T>
     where T: PrimitiveElement
 {
     fn set_pointer_builder<'b>(pointer: PointerBuilder<'b>,

--- a/capnp/src/struct_list.rs
+++ b/capnp/src/struct_list.rs
@@ -161,7 +161,7 @@ impl <'a, T> Builder<'a, T> where T: for<'b> crate::traits::OwnedStruct<'b> {
     }
 }
 
-impl <'a, T> crate::traits::SetPointerBuilder<Builder<'a, T>> for Reader<'a, T>
+impl <'a, T> crate::traits::SetPointerBuilder for Reader<'a, T>
     where T: for<'b> crate::traits::OwnedStruct<'b>
 {
     fn set_pointer_builder<'b>(pointer: crate::private::layout::PointerBuilder<'b>,

--- a/capnp/src/text.rs
+++ b/capnp/src/text.rs
@@ -119,7 +119,7 @@ impl <'a> crate::traits::FromPointerBuilder<'a> for Builder<'a> {
     }
 }
 
-impl <'a> crate::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
+impl <'a> crate::traits::SetPointerBuilder for Reader<'a> {
     fn set_pointer_builder<'b>(pointer: crate::private::layout::PointerBuilder<'b>,
                                value: Reader<'a>,
                                _canonicalize: bool)

--- a/capnp/src/text_list.rs
+++ b/capnp/src/text_list.rs
@@ -121,7 +121,7 @@ impl <'a> Builder<'a> {
     }
 }
 
-impl <'a> crate::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
+impl <'a> crate::traits::SetPointerBuilder for Reader<'a> {
     fn set_pointer_builder<'b>(pointer: crate::private::layout::PointerBuilder<'b>,
                                value: Reader<'a>,
                                canonicalize: bool) -> Result<()> {

--- a/capnp/src/traits.rs
+++ b/capnp/src/traits.rs
@@ -61,12 +61,12 @@ pub trait FromPointerReader<'a> : Sized {
 /// nonetheless as a type parameter, e.g. for a generic container that owns a Cap'n Proto
 /// message of type `T: for<'a> capnp::traits::Owned<'a>`.
 pub trait Owned<'a> {
-    type Reader: FromPointerReader<'a> + SetPointerBuilder<Self::Builder>;
+    type Reader: FromPointerReader<'a> + SetPointerBuilder;
     type Builder: FromPointerBuilder<'a>;
 }
 
 pub trait OwnedStruct<'a> {
-    type Reader: FromStructReader<'a> + SetPointerBuilder<Self::Builder> + IntoInternalStructReader<'a>;
+    type Reader: FromStructReader<'a> + SetPointerBuilder + IntoInternalStructReader<'a>;
     type Builder: FromStructBuilder<'a> + HasStructSize;
 }
 
@@ -79,7 +79,7 @@ pub trait FromPointerBuilder<'a> : Sized {
     fn get_from_pointer(builder: PointerBuilder<'a>, default: Option<&'a [crate::Word]>) -> Result<Self>;
 }
 
-pub trait SetPointerBuilder<To> {
+pub trait SetPointerBuilder {
     fn set_pointer_builder<'a>(builder: PointerBuilder<'a>, from: Self, canonicalize: bool) -> Result<()>;
 }
 

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -746,9 +746,8 @@ fn generate_setter(gen: &GeneratorContext, discriminant_offset: u32,
                     if typ.is_branded()? {
                         setter_interior.push(
                             Line(format!(
-                                "<{} as ::capnp::traits::SetPointerBuilder<{}>>::set_pointer_builder(self.builder.get_pointer_field({}), value, false)",
+                                "<{} as ::capnp::traits::SetPointerBuilder>::set_pointer_builder(self.builder.get_pointer_field({}), value, false)",
                                 typ.type_string(gen, Leaf::Reader("'b"))?,
-                                typ.type_string(gen, Leaf::Builder("'b"))?,
                                 offset)));
                         (Some(typ.type_string(gen, Leaf::Reader("'b"))?),
                          Some(typ.type_string(gen, Leaf::Builder("'a"))?))
@@ -768,9 +767,6 @@ fn generate_setter(gen: &GeneratorContext, discriminant_offset: u32,
                 type_::AnyPointer(_) => {
                     if typ.is_parameter()? {
                         initter_interior.push(Line(format!("::capnp::any_pointer::Builder::new(self.builder.get_pointer_field({})).init_as()", offset)));
-                        setter_generic_param = format!(
-                            "<SPB: ::capnp::traits::SetPointerBuilder<{}>>",
-                            typ.type_string(gen, Leaf::Builder("'a"))?);
                         setter_interior.push(Line(format!("::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field({}), value, false)", offset)));
                         return_result = true;
 
@@ -785,7 +781,7 @@ fn generate_setter(gen: &GeneratorContext, discriminant_offset: u32,
                         result.push(Line("}".to_string()));
 
 
-                        (Some("SPB".to_string()), Some(builder_type))
+                        (Some(typ.type_string(gen, Leaf::Reader("'_"))?), Some(builder_type))
                     } else {
                         initter_interior.push(Line(format!("let mut result = ::capnp::any_pointer::Builder::new(self.builder.get_pointer_field({}));",
                                                    offset)));
@@ -1420,7 +1416,7 @@ fn generate_node(gen: &GeneratorContext,
 
                 from_pointer_builder_impl,
                 Line(format!(
-                    "impl <'a,{0}> ::capnp::traits::SetPointerBuilder<Builder<'a,{0}>> for Reader<'a,{0}> {1} {{",
+                    "impl <'a,{0}> ::capnp::traits::SetPointerBuilder for Reader<'a,{0}> {1} {{",
                     params.params, params.where_clause)),
                 Indent(Box::new(Line(format!("fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,{}>, canonicalize: bool) -> ::capnp::Result<()> {{ pointer.set_struct(&value.reader, canonicalize) }}", params.params)))),
                 Line("}".to_string()),
@@ -1704,7 +1700,7 @@ fn generate_node(gen: &GeneratorContext,
 
             mod_interior.push(Branch(vec![
                 Line(format!(
-                    "impl <{0}> ::capnp::traits::SetPointerBuilder<Client<{0}>> for Client<{0}> {1} {{",
+                    "impl <{0}> ::capnp::traits::SetPointerBuilder for Client<{0}> {1} {{",
                     params.params, params.where_clause)),
                 Indent(
                     Box::new(

--- a/capnpc/src/schema_capnp.rs
+++ b/capnpc/src/schema_capnp.rs
@@ -163,7 +163,7 @@ pub mod node {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -474,7 +474,7 @@ pub mod node {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -613,7 +613,7 @@ pub mod node {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -767,7 +767,7 @@ pub mod node {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -924,7 +924,7 @@ pub mod node {
         }
       }
 
-      impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
         fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
       }
 
@@ -1084,7 +1084,7 @@ pub mod node {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -1267,7 +1267,7 @@ pub mod node {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -1409,7 +1409,7 @@ pub mod node {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -1566,7 +1566,7 @@ pub mod node {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -1770,7 +1770,7 @@ pub mod node {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -2042,7 +2042,7 @@ pub mod field {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -2273,7 +2273,7 @@ pub mod field {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -2442,7 +2442,7 @@ pub mod field {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -2581,7 +2581,7 @@ pub mod field {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -2744,7 +2744,7 @@ pub mod enumerant {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -2906,7 +2906,7 @@ pub mod superclass {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -3092,7 +3092,7 @@ pub mod method {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -3413,7 +3413,7 @@ pub mod type_ {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -3749,7 +3749,7 @@ pub mod type_ {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -3891,7 +3891,7 @@ pub mod type_ {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -4041,7 +4041,7 @@ pub mod type_ {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -4191,7 +4191,7 @@ pub mod type_ {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -4353,7 +4353,7 @@ pub mod type_ {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -4540,7 +4540,7 @@ pub mod type_ {
         }
       }
 
-      impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
         fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
       }
 
@@ -4711,7 +4711,7 @@ pub mod type_ {
         }
       }
 
-      impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
         fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
       }
 
@@ -4844,7 +4844,7 @@ pub mod type_ {
         }
       }
 
-      impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
         fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
       }
 
@@ -4974,7 +4974,7 @@ pub mod brand {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -5127,7 +5127,7 @@ pub mod brand {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -5310,7 +5310,7 @@ pub mod brand {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -5587,7 +5587,7 @@ pub mod value {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -5971,7 +5971,7 @@ pub mod annotation {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -6177,7 +6177,7 @@ pub mod capnp_version {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -6342,7 +6342,7 @@ pub mod code_generator_request {
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
     fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
@@ -6535,7 +6535,7 @@ pub mod code_generator_request {
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
       fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
@@ -6696,7 +6696,7 @@ pub mod code_generator_request {
         }
       }
 
-      impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
+      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
         fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
       }
 


### PR DESCRIPTION
This is a breaking change, so it will need be bundled with the 0.14 version bump.