### PR TITLE
`to_slice` for little endian systems 

### DIFF
--- a/capnp/src/primitive_list.rs
+++ b/capnp/src/primitive_list.rs
@@ -75,8 +75,8 @@ impl <'a, T: PrimitiveElement> Reader<'a, T> {
     #[cfg(all(target_endian = "little"))]
     /// Returns something if the slice is as expected in memory. 
     pub fn to_slice(&self) -> Option<&[T]> {
-        let bytes = self.reader.into_raw_bytes();
         if self.reader.get_element_size() == T::element_size() {
+            let bytes = self.reader.into_raw_bytes();
             Some (unsafe {
                 use std::slice;
                 slice::from_raw_parts(bytes.as_ptr() as *mut T, 8*bytes.len()/(data_bits_per_element(T::element_size())) as usize)
@@ -113,11 +113,15 @@ impl <'a, T> Builder<'a, T> where T: PrimitiveElement {
     }
 
     #[cfg(all(target_endian = "little"))]
-    pub fn to_slice(&self) -> &mut [T] {
-        let bytes = self.builder.into_raw_bytes();
-        unsafe {
-            use std::slice;
-            slice::from_raw_parts_mut(bytes.as_ptr() as *mut T, 8*bytes.len()/(data_bits_per_element(T::element_size())) as usize)
+    pub fn to_slice(&self) -> Option<&mut [T]> {
+        if self.builder.get_element_size() == T::element_size() {
+            let bytes = self.builder.into_raw_bytes();
+            Some (unsafe {
+                use std::slice;
+                slice::from_raw_parts_mut(bytes.as_ptr() as *mut T, 8*bytes.len()/(data_bits_per_element(T::element_size())) as usize)
+            })
+        } else {
+            None
         }
     }
 }

--- a/capnp/src/primitive_list.rs
+++ b/capnp/src/primitive_list.rs
@@ -112,7 +112,7 @@ impl <'a, T> Builder<'a, T> where T: PrimitiveElement {
         let bytes = self.builder.into_raw_bytes();
         unsafe {
             use std::slice;
-            slice::from_raw_parts_mut(bytes.as_ptr() as *mut T, (data_bits_per_element(T::element_size())/8) as usize)
+            slice::from_raw_parts_mut(bytes.as_ptr() as *mut T, 8*bytes.len()/(data_bits_per_element(T::element_size())) as usize)
         }
     }
 }

--- a/capnp/src/primitive_list.rs
+++ b/capnp/src/primitive_list.rs
@@ -73,11 +73,16 @@ impl <'a, T: PrimitiveElement> Reader<'a, T> {
     }
 
     #[cfg(all(target_endian = "little"))]
-    pub fn to_slice(&self) -> &[T] {
+    /// Returns something if the slice is as expected in memory. 
+    pub fn to_slice(&self) -> Option<&[T]> {
         let bytes = self.reader.into_raw_bytes();
-        unsafe {
-            use std::slice;
-            slice::from_raw_parts(bytes.as_ptr() as *mut T, (data_bits_per_element(T::element_size())/8) as usize)
+        if self.reader.get_element_size() == T::element_size() {
+            Some (unsafe {
+                use std::slice;
+                slice::from_raw_parts(bytes.as_ptr() as *mut T, 8*bytes.len()/(data_bits_per_element(T::element_size())) as usize)
+            })
+        } else {
+            None
         }
     }
 }

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -3419,6 +3419,20 @@ impl <'a> ListBuilder<'a> {
             pointer: unsafe { self.ptr.offset(offset as isize) } as *mut _,
         }
     }
+
+    pub(crate) fn into_raw_bytes(self) -> &'a mut [u8] {
+        if self.element_count == 0 {
+            // Explictly handle this case to avoid forming a slice to a null pointer,
+            // which would be undefined behavior.
+            &mut []
+        } else {
+            let num_bytes = wire_helpers::round_bits_up_to_bytes(
+                self.step as u64 * self.element_count as u64) as usize;
+            unsafe {
+                ::core::slice::from_raw_parts_mut(self.ptr, num_bytes)
+            }
+        }
+    }
 }
 
 

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -3409,6 +3409,10 @@ impl <'a> ListBuilder<'a> {
         }
     }
 
+    pub(crate) fn get_element_size(&self) -> ElementSize {
+        self.element_size
+    }
+
     #[inline]
     pub fn get_pointer_element(self, index: ElementCount32) -> PointerBuilder<'a> {
         let offset = (index as u64 * self.step as u64 / BITS_PER_BYTE as u64) as u32;


### PR DESCRIPTION
Adds a `to_slice` call for the `primitive_list` `Reader` and `Builder` structs on little endian systems. For the reader it produces a just a slice, and for the builder it produces a mutable slice. 

This is to resolve issue https://github.com/capnproto/capnproto-rust/issues/239 