### PR TITLE
Make `reborrow()` unnecessary in most cases

### DIFF
--- a/capnp-futures/test/test.rs
+++ b/capnp-futures/test/test.rs
@@ -33,14 +33,14 @@ mod tests {
     fn populate_address_book(address_book: address_book::Builder) {
         let mut people = address_book.init_people(2);
         {
-            let mut alice = people.reborrow().get(0);
+            let mut alice = people.get(0);
             alice.set_id(123);
             alice.set_name("Alice");
             alice.set_email("alice@example.com");
             {
-                let mut alice_phones = alice.reborrow().init_phones(1);
-                alice_phones.reborrow().get(0).set_number("555-1212");
-                alice_phones.reborrow().get(0).set_type(person::phone_number::Type::Mobile);
+                let mut alice_phones = alice.init_phones(1);
+                alice_phones.get(0).set_number("555-1212");
+                alice_phones.get(0).set_type(person::phone_number::Type::Mobile);
             }
             alice.get_employment().set_school("MIT");
         }
@@ -51,11 +51,11 @@ mod tests {
             bob.set_name("Bob");
             bob.set_email("bob@example.com");
             {
-                let mut bob_phones = bob.reborrow().init_phones(2);
-                bob_phones.reborrow().get(0).set_number("555-4567");
-                bob_phones.reborrow().get(0).set_type(person::phone_number::Type::Home);
-                bob_phones.reborrow().get(1).set_number("555-7654");
-                bob_phones.reborrow().get(1).set_type(person::phone_number::Type::Work);
+                let mut bob_phones = bob.init_phones(2);
+                bob_phones.get(0).set_number("555-4567");
+                bob_phones.get(0).set_type(person::phone_number::Type::Home);
+                bob_phones.get(1).set_number("555-7654");
+                bob_phones.get(1).set_type(person::phone_number::Type::Work);
             }
             bob.get_employment().set_unemployed(());
         }
@@ -121,8 +121,8 @@ mod tests {
 
         {
             let mut address_book = message.init_root::<address_book::Builder>();
-            populate_address_book(address_book.reborrow());
-            read_address_book(address_book.reborrow_as_reader());
+            populate_address_book(address_book);
+            read_address_book(address_book.into_reader());
         }
 
         let mut pool = futures::executor::LocalPool::new();

--- a/capnp/fuzz/fuzzers/test_all_types.rs
+++ b/capnp/fuzz/fuzzers/test_all_types.rs
@@ -62,7 +62,7 @@ fn try_go(mut data: &[u8]) -> ::capnp::Result<()> {
 
         root_builder.set_struct_field(root)?;
         {
-            let list = root_builder.reborrow().init_struct_list(2);
+            let list = root_builder.init_struct_list(2);
             list.set_with_caveats(0,  root)?;
             list.set_with_caveats(1,  root)?;
         }

--- a/capnp/src/any_pointer_list.rs
+++ b/capnp/src/any_pointer_list.rs
@@ -52,7 +52,7 @@ impl <'a> Reader<'a> {
         ListIter::new(self, l)
     }
 
-    pub fn get(self, index : u32) -> crate::any_pointer::Reader<'a> {
+    pub fn get(&self, index : u32) -> crate::any_pointer::Reader<'a> {
         assert!(index <  self.len());
         crate::any_pointer::Reader::new(self.reader.get_pointer_element(index))
     }
@@ -87,7 +87,7 @@ impl <'a> Builder<'a> {
         Reader { reader: self.builder.into_reader() }
     }
 
-    pub fn get(self, index : u32) -> crate::any_pointer::Builder<'a> {
+    pub fn get(&mut self, index : u32) -> crate::any_pointer::Builder<'a> {
         assert!(index <  self.len());
         crate::any_pointer::Builder::new(self.builder.get_pointer_element(index))
     }

--- a/capnp/src/capability_list.rs
+++ b/capnp/src/capability_list.rs
@@ -74,7 +74,7 @@ impl <'a, T> FromPointerReader<'a> for Reader<'a, T> where T: FromClientHook {
 }
 
 impl <'a, T> Reader<'a, T> where T: FromClientHook {
-    pub fn get(self, index: u32) -> Result<T> {
+    pub fn get(&self, index: u32) -> Result<T> {
         assert!(index < self.len());
         Ok(FromClientHook::new(self.reader.get_pointer_element(index).get_capability()?))
     }
@@ -129,7 +129,7 @@ impl <'a, T> FromPointerBuilder<'a> for Builder<'a, T> where T: FromClientHook {
 }
 
 impl <'a, T> Builder<'a, T> where T: FromClientHook {
-    pub fn get(self, index: u32) -> Result<T> {
+    pub fn get(&mut self, index: u32) -> Result<T> {
         assert!(index < self.len());
         Ok(FromClientHook::new(self.builder.get_pointer_element(index).get_capability()?))
     }

--- a/capnp/src/data_list.rs
+++ b/capnp/src/data_list.rs
@@ -64,7 +64,7 @@ impl <'a> IndexMove<u32, Result<crate::data::Reader<'a>>> for Reader<'a>{
 }
 
 impl <'a> Reader<'a> {
-    pub fn get(self, index : u32) -> Result<crate::data::Reader<'a>> {
+    pub fn get(&self, index : u32) -> Result<crate::data::Reader<'a>> {
         assert!(index <  self.len());
         self.reader.get_pointer_element(index).get_data(None)
     }
@@ -117,7 +117,7 @@ impl <'a> FromPointerBuilder<'a> for Builder<'a> {
 }
 
 impl <'a> Builder<'a> {
-    pub fn get(self, index: u32) -> Result<crate::data::Builder<'a>> {
+    pub fn get(&mut self, index: u32) -> Result<crate::data::Builder<'a>> {
         assert!(index < self.len());
         self.builder.get_pointer_element(index).get_data(None)
     }

--- a/capnp/src/list_list.rs
+++ b/capnp/src/list_list.rs
@@ -70,7 +70,7 @@ impl <'a, T> FromPointerReader<'a> for Reader<'a, T> where T: for<'b> crate::tra
 }
 
 impl <'a, T> Reader<'a, T> where T: for<'b> crate::traits::Owned<'b> {
-    pub fn get(self, index: u32) -> Result<<T as crate::traits::Owned<'a>>::Reader> {
+    pub fn get(&self, index: u32) -> Result<<T as crate::traits::Owned<'a>>::Reader> {
         assert!(index <  self.len());
         FromPointerReader::get_from_pointer(&self.reader.get_pointer_element(index), None)
     }
@@ -123,7 +123,7 @@ impl <'a, T> FromPointerBuilder<'a> for Builder<'a, T> where T: for<'b> crate::t
 }
 
 impl <'a, T> Builder<'a, T> where T: for<'b> crate::traits::Owned<'b> {
-    pub fn get(self, index: u32) -> Result<<T as crate::traits::Owned<'a>>::Builder> {
+    pub fn get(&mut self, index: u32) -> Result<<T as crate::traits::Owned<'a>>::Builder> {
         assert!(index < self.len());
         FromPointerBuilder::get_from_pointer(self.builder.get_pointer_element(index), None)
     }

--- a/capnp/src/struct_list.rs
+++ b/capnp/src/struct_list.rs
@@ -80,7 +80,7 @@ where T: for<'b> crate::traits::OwnedStruct<'b> {
 }
 
 impl <'a, T> Reader<'a, T> where T: for<'b> crate::traits::OwnedStruct<'b> {
-    pub fn get(self, index: u32) -> <T as crate::traits::OwnedStruct<'a>>::Reader {
+    pub fn get(&self, index: u32) -> <T as crate::traits::OwnedStruct<'a>>::Reader {
         assert!(index < self.len());
         FromStructReader::new(self.reader.get_struct_element(index))
     }
@@ -147,7 +147,7 @@ impl <'a, T> FromPointerBuilder<'a> for Builder<'a, T> where T: for<'b> crate::t
 }
 
 impl <'a, T> Builder<'a, T> where T: for<'b> crate::traits::OwnedStruct<'b> {
-    pub fn get(self, index: u32) -> <T as crate::traits::OwnedStruct<'a>>::Builder {
+    pub fn get(&self, index: u32) -> <T as crate::traits::OwnedStruct<'a>>::Builder {
         assert!(index < self.len());
         FromStructBuilder::new(self.builder.get_struct_element(index))
     }

--- a/capnp/src/text_list.rs
+++ b/capnp/src/text_list.rs
@@ -64,7 +64,7 @@ impl <'a>  IndexMove<u32, Result<crate::text::Reader<'a>>> for Reader<'a>{
 }
 
 impl <'a> Reader<'a> {
-    pub fn get(self, index : u32) -> Result<crate::text::Reader<'a>> {
+    pub fn get(&self, index : u32) -> Result<crate::text::Reader<'a>> {
         assert!(index <  self.len());
         self.reader.get_pointer_element(index).get_text(None)
     }
@@ -116,7 +116,7 @@ impl <'a> FromPointerBuilder<'a> for Builder<'a> {
 }
 
 impl <'a> Builder<'a> {
-    pub fn get(self, index: u32) -> Result<crate::text::Builder<'a>> {
+    pub fn get(&mut self, index: u32) -> Result<crate::text::Builder<'a>> {
         self.builder.get_pointer_element(index).get_text(None)
     }
 }

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -908,7 +908,7 @@ fn generate_setter(gen: &GeneratorContext, discriminant_offset: u32,
         Some(builder_type) => {
             result.push(Line("#[inline]".to_string()));
             let args = initter_params.join(", ");
-            result.push(Line(format!("pub fn init_{}(self, {}) -> {} {{",
+            result.push(Line(format!("pub fn init_{}(&mut self, {}) -> {} {{",
                                      styled_name, args, builder_type)));
             result.push(Indent(Box::new(Branch(initter_interior))));
             result.push(Line("}".to_string()));
@@ -1280,7 +1280,7 @@ fn generate_node(gen: &GeneratorContext,
                     reader_members.push(
                         Branch(vec!(
                             Line("#[inline]".to_string()),
-                            Line(format!("pub fn get_{}(self) {} {{", styled_name, ty)),
+                            Line(format!("pub fn get_{}(&self) {} {{", styled_name, ty)),
                             Indent(Box::new(get)),
                             Line("}".to_string()))));
 
@@ -1288,7 +1288,7 @@ fn generate_node(gen: &GeneratorContext,
                     builder_members.push(
                         Branch(vec!(
                             Line("#[inline]".to_string()),
-                            Line(format!("pub fn get_{}(self) {} {{", styled_name, ty_b)),
+                            Line(format!("pub fn get_{}(&mut self) {} {{", styled_name, ty_b)),
                             Indent(Box::new(get_b)),
                             Line("}".to_string()))));
 

--- a/capnpc/src/schema_capnp.rs
+++ b/capnpc/src/schema_capnp.rs
@@ -429,7 +429,7 @@ pub mod node {
 
     impl <'a,> Reader<'a,>  {
       pub fn reborrow(&self) -> Reader<'_,> {
-        Reader { .. *self }
+        *self
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {

--- a/example/addressbook/addressbook.rs
+++ b/example/addressbook/addressbook.rs
@@ -30,19 +30,19 @@ pub mod addressbook {
     pub fn write_address_book() -> ::capnp::Result<()> {
         let mut message = ::capnp::message::Builder::new_default();
         {
-            let address_book = message.init_root::<address_book::Builder>();
+            let mut address_book = message.init_root::<address_book::Builder>();
 
-            let mut people = address_book.init_people(2);
+            let people = address_book.init_people(2);
 
             {
-                let mut alice = people.reborrow().get(0);
+                let mut alice = people.get(0);
                 alice.set_id(123);
                 alice.set_name("Alice");
                 alice.set_email("alice@example.com");
                 {
-                    let mut alice_phones = alice.reborrow().init_phones(1);
-                    alice_phones.reborrow().get(0).set_number("555-1212");
-                    alice_phones.reborrow().get(0).set_type(person::phone_number::Type::Mobile);
+                    let alice_phones = alice.init_phones(1);
+                    alice_phones.get(0).set_number("555-1212");
+                    alice_phones.get(0).set_type(person::phone_number::Type::Mobile);
                 }
                 alice.get_employment().set_school("MIT");
             }
@@ -53,11 +53,11 @@ pub mod addressbook {
                 bob.set_name("Bob");
                 bob.set_email("bob@example.com");
                 {
-                    let mut bob_phones = bob.reborrow().init_phones(2);
-                    bob_phones.reborrow().get(0).set_number("555-4567");
-                    bob_phones.reborrow().get(0).set_type(person::phone_number::Type::Home);
-                    bob_phones.reborrow().get(1).set_number("555-7654");
-                    bob_phones.reborrow().get(1).set_type(person::phone_number::Type::Work);
+                    let bob_phones = bob.init_phones(2);
+                    bob_phones.get(0).set_number("555-4567");
+                    bob_phones.get(0).set_type(person::phone_number::Type::Home);
+                    bob_phones.get(1).set_number("555-7654");
+                    bob_phones.get(1).set_type(person::phone_number::Type::Work);
                 }
                 bob.get_employment().set_unemployed(());
             }

--- a/example/addressbook_send/addressbook_send.rs
+++ b/example/addressbook_send/addressbook_send.rs
@@ -37,19 +37,19 @@ pub mod addressbook {
     pub fn build_address_book() -> TypedReader<Builder<HeapAllocator>, address_book::Owned> {
         let mut message = TypedBuilder::<address_book::Owned>::new_default();
         {
-            let address_book = message.init_root();
+            let mut address_book = message.init_root();
 
-            let mut people = address_book.init_people(2);
+            let people = address_book.init_people(2);
 
             {
-                let mut alice = people.reborrow().get(0);
+                let mut alice = people.get(0);
                 alice.set_id(123);
                 alice.set_name("Alice");
                 alice.set_email("alice@example.com");
                 {
-                    let mut alice_phones = alice.reborrow().init_phones(1);
-                    alice_phones.reborrow().get(0).set_number("555-1212");
-                    alice_phones.reborrow().get(0).set_type(person::phone_number::Type::Mobile);
+                    let alice_phones = alice.init_phones(1);
+                    alice_phones.get(0).set_number("555-1212");
+                    alice_phones.get(0).set_type(person::phone_number::Type::Mobile);
                 }
                 alice.get_employment().set_school("MIT");
             }
@@ -60,11 +60,11 @@ pub mod addressbook {
                 bob.set_name("Bob");
                 bob.set_email("bob@example.com");
                 {
-                    let mut bob_phones = bob.reborrow().init_phones(2);
-                    bob_phones.reborrow().get(0).set_number("555-4567");
-                    bob_phones.reborrow().get(0).set_type(person::phone_number::Type::Home);
-                    bob_phones.reborrow().get(1).set_number("555-7654");
-                    bob_phones.reborrow().get(1).set_type(person::phone_number::Type::Work);
+                    let bob_phones = bob.init_phones(2);
+                    bob_phones.get(0).set_number("555-4567");
+                    bob_phones.get(0).set_type(person::phone_number::Type::Home);
+                    bob_phones.get(1).set_number("555-7654");
+                    bob_phones.get(1).set_type(person::phone_number::Type::Work);
                 }
                 bob.get_employment().set_unemployed(());
             }


### PR DESCRIPTION
This is what the fix for https://github.com/capnproto/capnproto-rust/issues/241 would look like; happy to extend this to all the other uses of `reborrow()` if you like :) I just want to make sure you think this is a good idea before putting too much time into it.

- get() doesn't consume the data being read from, so reflect that in the type signature.
- `init_*()` can take `&mut self` instead of consuming `self`
- update lots of examples
