### PR TITLE
Adds `BufferSegments` for long lived mmap support

### DIFF
--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -26,13 +26,13 @@
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::convert::TryInto;
+use core::ops::Deref;
 use crate::io::{Read, Write};
 
 use crate::message;
 use crate::private::units::BYTES_PER_WORD;
 use crate::{Error, Result};
 
-use std::ops::Deref;
 
 /// Segments read from a single flat slice of words.
 pub struct SliceSegments<'a> {
@@ -123,6 +123,10 @@ impl<T: Deref<Target = [u8]>> BufferSegments<T> {
             segment_table_bytes_len,
             segment_indices,
         })
+    }
+
+    pub fn to_buffer(self) -> T {
+        self.buffer
     }
 }
 

--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -88,7 +88,8 @@ pub fn read_message_from_flat_slice<'a>(slice: &mut &'a [u8],
     }
 }
 
-/// Segments read from a buffer, useful for long lived mmaps.
+/// Segments read from a buffer, useful for when you have the message in a buffer and don't want the extra 
+/// copy of `read_message`.
 pub struct BufferSegments<T> {
     buffer: T,
     
@@ -125,7 +126,7 @@ impl<T: Deref<Target = [u8]>> BufferSegments<T> {
         })
     }
 
-    pub fn to_buffer(self) -> T {
+    pub fn into_buffer(self) -> T {
         self.buffer
     }
 }
@@ -134,7 +135,7 @@ impl <T: Deref<Target = [u8]>> message::ReaderSegments for BufferSegments<T> {
     fn get_segment<'b>(&'b self, id: u32) -> Option<&'b [u8]> {
         if id < self.segment_indices.len() as u32 {
             let (a, b) = self.segment_indices[id as usize];
-            Some(&self.buffer[self.segment_table_bytes_len..][(a * BYTES_PER_WORD)..(b * BYTES_PER_WORD)])
+            Some(&self.buffer[(self.segment_table_bytes_len + a * BYTES_PER_WORD)..(self.segment_table_bytes_len + b * BYTES_PER_WORD)])
         } else {
             None
         }

--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -100,10 +100,10 @@ pub struct BufferSegments<T> {
 }
 
 impl<T: Deref<Target = [u8]>> BufferSegments<T> {
-    /// Reads a serialized message (including a segment table) from a flat slice of bytes, without copying.
-    /// The slice is allowed to extend beyond the end of the message. On success, updates `slice` to point
-    /// to the remaining bytes beyond the end of the message.
-    ///
+    /// Reads a serialized message (including a segment table) from a buffer and takes ownership, without copying.
+    /// The buffer is allowed to be longer than the message. Provide this to `Reader::new` with options that make 
+    /// sense for your use case. Very long lived mmaps may need unlimited traversal limit.
+    /// 
     /// ALIGNMENT: If the "unaligned" feature is enabled, then there are no alignment requirements on `slice`.
     /// Otherwise, `slice` must be 8-byte aligned (attempts to read the message will trigger errors).
     pub fn new(buffer: T, options: message::ReaderOptions) -> Result<BufferSegments<T>> {


### PR DESCRIPTION
This adds a new struct that's a partner to the `SliceSegments` struct. It's meant to hold an owned buffer like a mmap: 
```rust
use memmap2::Mmap;
use std::fs::File;
use capnp;

// We know the loaded message is safe, so we're allowing unlimited reads.
let unlimited_reads = ReaderOptions {
    traversal_limit_in_words: None,
    nesting_limit: 64,
};

let file = File::open("practically_static_message.capnp")?;
let mmap = unsafe { Mmap::map(&file).unwrap() };
let segments = BufferSegments::new(value, unlimited_reads)?;

let reader = capnp::message::Reader::new(segments, unlimited_reads).into_typed();
```
This struct lets me work with mmaps with little headache and I've been using it for a few weeks now. Should help others too, like [#121](https://github.com/capnproto/capnproto-rust/issues/121). 

Reason: I'm using capnp for a k-nearest neighbors library where 95% of what I need to point to are essentially dense vectors of `&[f32]` and sparse vectors of `(&[f32],&[u32])` (more or less). Parsing the pointers to the point I need takes about as much time as the distance to an the distance between two 4096 dimension dense vectors (on my machine) and is dwarfed by the mmap lookup to a NVMEe raid0 array. With some additional parsing at load the prototype capnp implementation of the underlying point storage is about 2x faster than the old protobuf one and has much less code.
