### PR TITLE
Add #[inline] to has_field methods

### DIFF
--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -2470,6 +2470,7 @@ impl <'a> PointerReader<'a> {
         self.cap_table = cap_table;
     }
 
+    #[inline]
     pub fn is_null(&self) -> bool {
         self.pointer.is_null() || unsafe { (*self.pointer).is_null() }
     }
@@ -2623,6 +2624,7 @@ impl <'a> PointerBuilder<'a> {
         self.cap_table = cap_table;
     }
 
+    #[inline]
     pub fn is_null(&self) -> bool {
         unsafe { (*self.pointer).is_null() }
     }

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1231,6 +1231,7 @@ fn generate_haser(discriminant_offset: u32,
                     interior.push(
                         Line(format!("!self.{}.get_pointer_field({}).is_null()",
                                      member, reg_field.get_offset())));
+                    result.push(Line("#[inline]".to_string()));
                     result.push(
                         Line(format!("pub fn has_{}(&self) -> bool {{", styled_name)));
                     result.push(


### PR DESCRIPTION
I noticed that setters and getters in the generated code had #[inline] annotations, this brings the hasers in line with the other methods.