### PR TITLE
capnpc: add option to build `capnp` exe from src

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "capnpc/capnproto"]
+	path = capnpc/capnproto
+	url = https://github.com/capnproto/capnproto.git

--- a/capnpc/Cargo.toml
+++ b/capnpc/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 
 keywords = ["encoding", "protocol", "serialization"]
 
+[features]
+build-capnp = []
+
 [lib]
 
 name = "capnpc"
@@ -37,3 +40,7 @@ path = "../capnp"
 # Fortunately, this is pretty easy, and is just an internal implementation detail.
 default-features=false
 features=[]
+
+[build-dependencies]
+cmake = "0.1"
+which = "4.2"

--- a/capnpc/build.rs
+++ b/capnpc/build.rs
@@ -1,0 +1,14 @@
+#[cfg(feature = "build-capnp")]
+fn main() {
+    cmake::build("capnproto");
+}
+
+#[cfg(not(feature = "build-capnp"))]
+fn main() {
+    if !which::which("capnp").is_ok() {
+        panic!(
+            "capnp executable not found. install it with your package manager or enable the \
+            \"build-capnp\" feature to build it from source"
+        );
+    }
+}

--- a/capnpc/src/lib.rs
+++ b/capnpc/src/lib.rs
@@ -66,6 +66,19 @@ mod pointer_constants;
 
 use std::path::{Path, PathBuf};
 
+#[cfg(feature = "build-capnp")]
+fn capnp_exe() -> PathBuf {
+    let mut p = PathBuf::from(env!("OUT_DIR"));
+    p.push("bin");
+    p.push("capnp");
+    p
+}
+
+#[cfg(not(feature = "build-capnp"))]
+fn capnp_exe() -> PathBuf {
+    PathBuf::from("capnp")
+}
+
 // Copied from capnp/src/lib.rs, where this conversion lives behind the "std" feature flag,
 // which we don't want to depend on here.
 pub(crate) fn convert_io_err(err: std::io::Error) -> capnp::Error {
@@ -218,7 +231,7 @@ impl CompilerCommand {
         let mut command = if let Some(executable) = &self.executable_path {
             ::std::process::Command::new(executable)
         } else {
-            ::std::process::Command::new("capnp")
+            ::std::process::Command::new(&capnp_exe())
         };
 
         command.arg("compile").arg("-o").arg("-");


### PR DESCRIPTION
Related to #182.

This is one potential way we could implement option `2.)` while keeping in mind @zenhack's concern about pushing users away from their package manager. The idea is that we check for the existence of `capnp` at build time. If it does not exist, we throw an error letting the user know to either install it OR provide `feature = "build-capnp"` to the crate so that we can build it for them. 

I think that it is good to at least provide this option to the user since many may find it desirable to have a plug-and-play solution without the need for prerequisites when building their crate.

You may find adding the `capnproto` submodule undesirable, in which case we could potentially clone the repo at build time.