### PR TITLE
Fix total size calculation overflowing for big lists

### DIFF
--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -1716,7 +1716,7 @@ mod wire_helpers {
         value: ListReader,
         canonicalize: bool) -> Result<SegmentAnd<*mut u8>>
     {
-        let total_size = round_bits_up_to_words((value.element_count * value.step) as u64);
+        let total_size = round_bits_up_to_words(value.element_count as u64 * value.step as u64);
 
         if value.element_size != ElementSize::InlineComposite {
             //# List of non-structs.


### PR DESCRIPTION
A late conversion from `u32` to `u64` causes total size calculation of huge lists to overflow.