### PR TITLE
capnp: use 'rand' in unit tests

### DIFF
--- a/capnp/Cargo.toml
+++ b/capnp/Cargo.toml
@@ -23,6 +23,7 @@ quickcheck = { version = "0.9", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.9"
+rand = "0.7"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Follow-up to https://github.com/capnproto/capnproto-rust/pull/276: use `rand` instead of housemade random number generator in tests.

I tried to figure out how to use `quickcheck` but don't have experience with it and did not figure out how exactly to use it.