### PR TITLE
Change list `get` methods to return an `Option<T>`

### DIFF
--- a/capnp/src/primitive_list.rs
+++ b/capnp/src/primitive_list.rs
@@ -62,13 +62,20 @@ impl <'a, T: PrimitiveElement> FromPointerReader<'a> for Reader<'a, T> {
 
 impl <'a, T: PrimitiveElement>  IndexMove<u32, T> for Reader<'a, T>{
     fn index_move(&self, index: u32) -> T {
-        self.get(index)
+        self.get(index).unwrap()
     }
 }
 
 impl <'a, T: PrimitiveElement> Reader<'a, T> {
-    pub fn get(&self, index: u32) -> T {
-        assert!(index < self.len());
+    pub fn get(&self, index: u32) -> Option<T> {
+        if index < self.len() {
+            Some(PrimitiveElement::get(&self.reader, index))
+        } else {
+            None
+        }
+    }
+
+    pub unsafe fn get_unchecked(&self, index: u32) -> T {
         PrimitiveElement::get(&self.reader, index)
     }
 

--- a/capnp/src/private/layout_test.rs
+++ b/capnp/src/private/layout_test.rs
@@ -120,16 +120,17 @@ fn bool_list() {
         let reader = crate::primitive_list::Reader::<bool>::get_from_pointer(&pointer_reader, None).unwrap();
 
         assert_eq!(reader.len(), 10);
-        assert_eq!(reader.get(0), true);
-        assert_eq!(reader.get(1), false);
-        assert_eq!(reader.get(2), true);
-        assert_eq!(reader.get(3), false);
-        assert_eq!(reader.get(4), true);
-        assert_eq!(reader.get(5), true);
-        assert_eq!(reader.get(6), true);
-        assert_eq!(reader.get(7), false);
-        assert_eq!(reader.get(8), false);
-        assert_eq!(reader.get(9), true);
+        assert_eq!(reader.get(0), Some(true));
+        assert_eq!(reader.get(1), Some(false));
+        assert_eq!(reader.get(2), Some(true));
+        assert_eq!(reader.get(3), Some(false));
+        assert_eq!(reader.get(4), Some(true));
+        assert_eq!(reader.get(5), Some(true));
+        assert_eq!(reader.get(6), Some(true));
+        assert_eq!(reader.get(7), Some(false));
+        assert_eq!(reader.get(8), Some(false));
+        assert_eq!(reader.get(9), Some(true));
+        assert_eq!(reader.get(10), None);
     }
 }
 

--- a/capnp/src/struct_list.rs
+++ b/capnp/src/struct_list.rs
@@ -75,13 +75,20 @@ impl <'a, T> FromPointerReader<'a> for Reader<'a, T> where T: for<'b> crate::tra
 impl <'a, T>  IndexMove<u32, <T as crate::traits::OwnedStruct<'a>>::Reader> for Reader<'a, T>
 where T: for<'b> crate::traits::OwnedStruct<'b> {
     fn index_move(&self, index: u32) -> <T as crate::traits::OwnedStruct<'a>>::Reader {
-        self.get(index)
+        self.get(index).unwrap()
     }
 }
 
 impl <'a, T> Reader<'a, T> where T: for<'b> crate::traits::OwnedStruct<'b> {
-    pub fn get(self, index: u32) -> <T as crate::traits::OwnedStruct<'a>>::Reader {
-        assert!(index < self.len());
+    pub fn get(self, index: u32) -> Option<<T as crate::traits::OwnedStruct<'a>>::Reader> {
+        if index < self.len() {
+            Some(FromStructReader::new(self.reader.get_struct_element(index)))
+        } else {
+            None
+        }
+    }
+
+    pub unsafe fn get_unchecked(self, index: u32) -> <T as crate::traits::OwnedStruct<'a>>::Reader {
         FromStructReader::new(self.reader.get_struct_element(index))
     }
 }

--- a/capnpc/src/codegen_types.rs
+++ b/capnpc/src/codegen_types.rs
@@ -223,7 +223,7 @@ impl <'a> RustTypeInfo for type_::Reader<'a> {
                     type_::any_pointer::Parameter(def) => {
                         let the_struct = &gen.node_map[&def.get_scope_id()];
                         let parameters = the_struct.get_parameters()?;
-                        let parameter = parameters.get(def.get_parameter_index() as u32);
+                        let parameter = parameters.get(def.get_parameter_index() as u32).unwrap();
                         let parameter_name = parameter.get_name()?;
                         match module {
                             Leaf::Owned => Ok(parameter_name.to_string()),


### PR DESCRIPTION
Hi @dwrensha 

I have opened this as a draft because its a work-in-progress and I have a few questions but I would like to start the discussion:

1. I have changed (some) `get` list reader methods to return an `Option<T>` and introduced a `get_unchecked` to mirror std slice API. This is a breaking change but as far as I know, the API is not considered stable at this point? I think that's the right call because its less confusing since it adhere to idiomatic rust practices but if the change is considered to severe, maybe adding a `checked_get` method instead would be more acceptable? A bonus point from this work is that in places where the index is already known to be in range, we can use `get_unchecked` directly and avoid some useless bound checks.

2. There are some `get` methods that already return a `Result<T>` but usually the index access is done *prior* to the call that returns the Result. In such case I believe the correct return type would be `Option<Result<T>>`. Do you agree?

3. What about `get` builder methods, should they be changed too for coherency?

Fixes #251