### PR TITLE
Avoid manual indexing of slices in for loops

### DIFF
--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -391,9 +391,7 @@ fn flatten_segments<R: message::ReaderSegments + ?Sized>(segments: &R) -> Vec<u8
     }
     for i in 0..segment_count {
         let segment = segments.get_segment(i as u32).unwrap();
-        for idx in 0..segment.len() {
-            result.push(segment[idx]);
-        }
+        result.extend(segment);
     }
     result
 }
@@ -442,7 +440,7 @@ where W: Write, R: message::ReaderSegments + ?Sized {
                     &((segments.get_segment(idx as u32).unwrap().len() / BYTES_PER_WORD) as u32).to_le_bytes());
             }
             if segment_count == 2 {
-                for idx in 4..8 { buf[idx] = 0 }
+                for b in &mut buf[4..8] { *b = 0 }
             }
             write.write_all(&buf)?;
         } else {
@@ -743,9 +741,9 @@ pub mod test {
         let message = read_message_from_flat_slice(&mut byte_slice, message::ReaderOptions::new()).unwrap();
         assert_eq!(byte_slice, extra_bytes);
         let result_segments = message.into_segments();
-        for idx in 0..segments.len() {
+        for (idx, segment) in segments.iter().enumerate() {
             assert_eq!(
-                segments[idx],
+                *segment,
                 result_segments.get_segment(idx as u32).expect("segment should exist"));
         }
     }

--- a/capnp/src/serialize/no_alloc_slice_segments.rs
+++ b/capnp/src/serialize/no_alloc_slice_segments.rs
@@ -439,8 +439,8 @@ mod tests {
                 NoAllocSliceSegments::try_new(&mut msg.as_slice(), ReaderOptions::new()).unwrap();
 
             assert_eq!(no_alloc_segments.len(), segments.len());
-            for i in 0..no_alloc_segments.len() {
-                assert_eq!(no_alloc_segments.get_segment(i as u32), Some(segments[i]));
+            for (i, segment) in segments.iter().enumerate() {
+                assert_eq!(no_alloc_segments.get_segment(i as u32), Some(*segment));
             }
 
             assert_eq!(

--- a/capnp/src/text.rs
+++ b/capnp/src/text.rs
@@ -74,15 +74,13 @@ impl <'a> Builder <'a> {
 
     pub fn push_str(&mut self, string: &str) {
         let bytes = string.as_bytes();
-        for ii in 0..bytes.len() {
-            self.bytes[self.pos + ii] = bytes[ii];
-        }
+        self.bytes[self.pos..(self.pos+bytes.len())].copy_from_slice(bytes);
         self.pos += bytes.len();
     }
 
     pub fn clear(&mut self) {
-        for ii in 0..self.pos {
-            self.bytes[ii] = 0;
+        for b in &mut self.bytes[..self.pos] {
+            *b = 0;
         }
         self.pos = 0;
     }


### PR DESCRIPTION
This is replaced by either iterating over the elements of the slice
or by calling the appropriate slice method.