### PR TITLE
Make `IndexMove` private and unsafely implement it for all lists

### DIFF
--- a/capnp/src/any_pointer_list.rs
+++ b/capnp/src/any_pointer_list.rs
@@ -71,8 +71,9 @@ impl <'a> Reader<'a> {
 }
 
 impl <'a> IndexMove<u32, Result<crate::any_pointer::Reader<'a>>> for Reader<'a>{
-    fn index_move(&self, index: u32) -> Result<crate::any_pointer::Reader<'a>> {
-        Ok(self.get(index))
+    unsafe fn index_move(&self, index: u32) -> Result<crate::any_pointer::Reader<'a>> {
+        debug_assert!(index <  self.len());
+        Ok(crate::any_pointer::Reader::new(self.reader.get_pointer_element(index)))
     }
 }
 

--- a/capnp/src/capability_list.rs
+++ b/capnp/src/capability_list.rs
@@ -93,8 +93,9 @@ impl <'a, T> Reader<'a, T> where T: FromClientHook {
 }
 
 impl <'a, T>  IndexMove<u32, Result<T>> for Reader<'a, T> where T: FromClientHook {
-    fn index_move(&self, index: u32) -> Result<T> {
-        self.get(index)
+    unsafe fn index_move(&self, index: u32) -> Result<T> {
+        debug_assert!(index < self.len());
+        Ok(FromClientHook::new(self.reader.get_pointer_element(index).get_capability()?))
     }
 }
 

--- a/capnp/src/data_list.rs
+++ b/capnp/src/data_list.rs
@@ -58,8 +58,9 @@ impl <'a> FromPointerReader<'a> for Reader<'a> {
 }
 
 impl <'a> IndexMove<u32, Result<crate::data::Reader<'a>>> for Reader<'a>{
-    fn index_move(&self, index: u32) -> Result<crate::data::Reader<'a>> {
-        self.get(index)
+    unsafe fn index_move(&self, index: u32) -> Result<crate::data::Reader<'a>> {
+        debug_assert!(index <  self.len());
+        self.reader.get_pointer_element(index).get_data(None)
     }
 }
 

--- a/capnp/src/enum_list.rs
+++ b/capnp/src/enum_list.rs
@@ -62,8 +62,10 @@ impl <'a, T : FromU16> FromPointerReader<'a> for Reader<'a, T> {
 }
 
 impl <'a, T: FromU16>  IndexMove<u32, ::core::result::Result<T, NotInSchema>> for Reader<'a, T>{
-    fn index_move(&self, index: u32) -> ::core::result::Result<T, NotInSchema> {
-        self.get(index)
+    unsafe fn index_move(&self, index: u32) -> ::core::result::Result<T, NotInSchema> {
+        debug_assert!(index < self.len());
+        let result: u16 = PrimitiveElement::get(&self.reader, index);
+        FromU16::from_u16(result)
     }
 }
 

--- a/capnp/src/list_list.rs
+++ b/capnp/src/list_list.rs
@@ -57,8 +57,9 @@ impl <'a, T> Copy for Reader<'a, T> where T: for<'b> crate::traits::Owned<'b> {}
 
 impl <'a, T>  IndexMove<u32, Result<<T as crate::traits::Owned<'a>>::Reader>> for Reader<'a, T>
 where T: for<'b> crate::traits::Owned<'b> {
-    fn index_move(&self, index : u32) -> Result<<T as crate::traits::Owned<'a>>::Reader> {
-        self.get(index)
+    unsafe fn index_move(&self, index : u32) -> Result<<T as crate::traits::Owned<'a>>::Reader> {
+        debug_assert!(index <  self.len());
+        FromPointerReader::get_from_pointer(&self.reader.get_pointer_element(index), None)
     }
 }
 

--- a/capnp/src/primitive_list.rs
+++ b/capnp/src/primitive_list.rs
@@ -61,8 +61,9 @@ impl <'a, T: PrimitiveElement> FromPointerReader<'a> for Reader<'a, T> {
 }
 
 impl <'a, T: PrimitiveElement>  IndexMove<u32, T> for Reader<'a, T>{
-    fn index_move(&self, index: u32) -> T {
-        self.get(index)
+    unsafe fn index_move(&self, index: u32) -> T {
+        debug_assert!(index < self.len());
+        PrimitiveElement::get(&self.reader, index)
     }
 }
 

--- a/capnp/src/struct_list.rs
+++ b/capnp/src/struct_list.rs
@@ -74,8 +74,9 @@ impl <'a, T> FromPointerReader<'a> for Reader<'a, T> where T: for<'b> crate::tra
 
 impl <'a, T>  IndexMove<u32, <T as crate::traits::OwnedStruct<'a>>::Reader> for Reader<'a, T>
 where T: for<'b> crate::traits::OwnedStruct<'b> {
-    fn index_move(&self, index: u32) -> <T as crate::traits::OwnedStruct<'a>>::Reader {
-        self.get(index)
+    unsafe fn index_move(&self, index: u32) -> <T as crate::traits::OwnedStruct<'a>>::Reader {
+        debug_assert!(index < self.len());
+        FromStructReader::new(self.reader.get_struct_element(index))
     }
 }
 

--- a/capnp/src/text_list.rs
+++ b/capnp/src/text_list.rs
@@ -58,8 +58,9 @@ impl <'a> FromPointerReader<'a> for Reader<'a> {
 }
 
 impl <'a>  IndexMove<u32, Result<crate::text::Reader<'a>>> for Reader<'a>{
-    fn index_move(&self, index : u32) -> Result<crate::text::Reader<'a>> {
-        self.get(index)
+    unsafe fn index_move(&self, index : u32) -> Result<crate::text::Reader<'a>> {
+        debug_assert!(index <  self.len());
+        self.reader.get_pointer_element(index).get_text(None)
     }
 }
 

--- a/capnp/src/traits.rs
+++ b/capnp/src/traits.rs
@@ -103,8 +103,8 @@ pub trait FromU16 : Sized {
     fn from_u16(value: u16) -> ::core::result::Result<Self, crate::NotInSchema>;
 }
 
-pub trait IndexMove<I, T> {
-    fn index_move(&self, index: I) -> T;
+pub(crate) trait IndexMove<I, T> {
+    unsafe fn index_move(&self, index: I) -> T;
 }
 
 pub struct ListIter<T, U> {
@@ -124,7 +124,7 @@ impl <U, T : IndexMove<u32, U>> ::core::iter::Iterator for ListIter<T, U> {
     type Item = U;
     fn next(&mut self) -> ::core::option::Option<U> {
         if self.index < self.size {
-            let result = self.list.index_move(self.index);
+            let result = unsafe { self.list.index_move(self.index) };
             self.index += 1;
             Some(result)
         } else {
@@ -139,7 +139,7 @@ impl <U, T : IndexMove<u32, U>> ::core::iter::Iterator for ListIter<T, U> {
     fn nth(&mut self, p: usize) -> Option<U>{
         if self.index + (p as u32) < self.size  {
             self.index += p as u32;
-            let result = self.list.index_move(self.index);
+            let result = unsafe { self.list.index_move(self.index) };
             self.index += 1;
             Some(result)
         } else {
@@ -159,7 +159,7 @@ impl <U, T: IndexMove<u32, U>> ::core::iter::DoubleEndedIterator for ListIter<T,
     fn next_back(&mut self) -> ::core::option::Option<U> {
         if self.size > self.index {
             self.size -= 1;
-            Some(self.list.index_move(self.size))
+            Some(unsafe { self.list.index_move(self.size) })
         } else {
             None
         }


### PR DESCRIPTION
In some sense it acts as a `get_unchecked` method but is not
exposed publicly anymore to prevent rogue implementations.