### PR TITLE
Change capnp::io::Write trait to return the number of written bytes on success

### DIFF
--- a/benchmark/benchmark.rs
+++ b/benchmark/benchmark.rs
@@ -78,7 +78,7 @@ impl Serialize for NoCompression {
 
     fn write_message<W, A>(&self, write: &mut W, message: &message::Builder<A>) -> ::capnp::Result<()>
         where W: io::Write, A: message::Allocator {
-        serialize::write_message(write, message).map_err(|e| e.into())
+        serialize::write_message(write, message).map(|_| ()).map_err(|e| e.into())
     }
 }
 
@@ -95,7 +95,7 @@ impl Serialize for Packed {
 
     fn write_message<W, A>(&self, write: &mut W, message: &message::Builder<A>) -> ::capnp::Result<()>
         where W: io::Write, A: message::Allocator {
-        serialize_packed::write_message(write, message).map_err(|e| e.into())
+        serialize_packed::write_message(write, message).map(|_| ()).map_err(|e| e.into())
     }
 }
 

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -2229,9 +2229,9 @@ struct WriteWrapper<W> where W: std::io::Write {
 }
 
 impl <W> capnp::io::Write for WriteWrapper<W> where W: std::io::Write {
-    fn write_all(&mut self, buf: &[u8]) -> ::capnp::Result<()> {
+    fn write_all(&mut self, buf: &[u8]) -> ::capnp::Result<usize> {
         std::io::Write::write_all(&mut self.inner, buf).map_err(convert_io_err)?;
-        Ok(())
+        Ok(buf.len())
     }
 }
 

--- a/example/addressbook/addressbook.rs
+++ b/example/addressbook/addressbook.rs
@@ -63,7 +63,11 @@ pub mod addressbook {
             }
         }
 
-        serialize_packed::write_message(&mut ::std::io::stdout(), &message)
+        let written_bytes = serialize_packed::write_message(&mut ::std::io::stdout(), &message)?;
+
+        assert_eq!(written_bytes, 151);
+
+        Ok(())
     }
 
     pub fn print_address_book() -> ::capnp::Result<()> {


### PR DESCRIPTION
This PR change the `capnp::io::Write` trait to return the number of written bytes on success. It is particularly useful when using `serialize_packed::write_message` on embedded platform where we usually serialize to an array then send the serialized bytes over the wire (like UART, SPI, ...).

We usually end up with the following code:
```rust
let mut buf: [u8; 32] = [0; 32];

capnp::serialize_packed::write_message(&mut buf.as_mut_slice(), &message).unwrap();

// with current capnp, the only way to retrieve the size of the packed message
// is copy and modify PackedWrite struct to record the amount of written bytes
// and copy and modify write_message function to return the written bytes.      
```
with the following PR, the amount of written bytes is returned by `write_message` function and used like this:
```rust
let mut buf: [u8; 32] = [0; 32];

let written_bytes = capnp::serialize_packed::write_message(&mut buf.as_mut_slice(), &message).unwrap();

send_to_uart(buf[..written_bytes]);

```