### PR TITLE
add into_client_hook and cast_to methods to FromClientHook

### DIFF
--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -22,7 +22,7 @@
 #![cfg(test)]
 
 use capnp::Error;
-use capnp::capability::Promise;
+use capnp::capability::{FromClientHook, Promise};
 use capnp_rpc::{RpcSystem, rpc_twoparty_capnp, twoparty};
 
 use futures::{Future, FutureExt, TryFutureExt};
@@ -459,9 +459,8 @@ fn retain_and_release() {
                 request.send().promise.await?;
             }
 
-            // Do some other call to add a round trip.
-            // ugh, we need upcasting.
-            let client1 = crate::test_capnp::test_call_order::Client { client: client.clone().client };
+            let client1 : crate::test_capnp::test_call_order::Client = client.clone().cast_to();
+
             let response = client1.get_call_sequence_request().send().promise.await?;
             if response.get()?.get_n() != 1 {
                 return Err(Error::failed("N should equal 1".to_string()))
@@ -564,8 +563,7 @@ fn cancel_releases_params() {
 
                 // Allow some time to settle.
 
-                // ugh, we need upcasting.
-                let client = crate::test_capnp::test_call_order::Client { client: client.client };
+                let client : crate::test_capnp::test_call_order::Client = client.cast_to();
                 let response = client.get_call_sequence_request().send().promise.await?;
                 if response.get()?.get_n() != 1 {
                     return Err(Error::failed("N should equal 1.".to_string()));
@@ -630,8 +628,7 @@ fn embargo_success() {
 
         let server = crate::impls::TestCallOrder::new();
 
-        // ugh, we need upcasting.
-        let client2 = crate::test_capnp::test_call_order::Client { client: client.clone().client };
+        let client2 : crate::test_capnp::test_call_order::Client = client.clone().cast_to();
         let early_call = client2.get_call_sequence_request().send();
         drop(client2);
 
@@ -694,8 +691,7 @@ fn embargo_error() {
         let cap: crate::test_capnp::test_call_order::Client =
             ::capnp_rpc::new_promise_client(promise.map_err(canceled_to_error));
 
-        // ugh, we need upcasting.
-        let client2 = crate::test_capnp::test_call_order::Client { client: client.clone().client };
+        let client2 : crate::test_capnp::test_call_order::Client = client.clone().cast_to();
         let early_call = client2.get_call_sequence_request().send();
         drop(client2);
 
@@ -740,8 +736,7 @@ fn echo_destruction() {
         let cap: crate::test_capnp::test_call_order::Client =
             ::capnp_rpc::new_promise_client(promise.map_err(canceled_to_error));
 
-        // ugh, we need upcasting.
-        let client2 = crate::test_capnp::test_call_order::Client { client: client.clone().client };
+        let client2 : crate::test_capnp::test_call_order::Client = client.clone().cast_to();
         let early_call = client2.get_call_sequence_request().send();
         drop(client2);
 

--- a/capnp/src/capability.rs
+++ b/capnp/src/capability.rs
@@ -216,8 +216,20 @@ pub trait FromTypelessPipeline {
     fn new (typeless: any_pointer::Pipeline) -> Self;
 }
 
+/// Trait implemented (via codegen) by all user-defined capability client types.
 pub trait FromClientHook {
+    /// Wraps a client hook to create a new client.
     fn new(hook: Box<dyn ClientHook>) -> Self;
+
+    /// Unwraps client to get the underlying client hook.
+    fn into_client_hook(self) -> Box<dyn ClientHook>;
+
+    /// Casts `self` to another instance of `FromClientHook`. This always succeeds,
+    /// but if the underlying capability does not actually implement `T`'s interface,
+    /// then method calls will fail with "unimplemented" errors.
+    fn cast_to<T: FromClientHook + Sized>(self) -> T where Self: Sized {
+        FromClientHook::new(self.into_client_hook())
+    }
 }
 
 /// An untyped client.

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1933,6 +1933,9 @@ fn generate_node(gen: &GeneratorContext,
                     Indent(Box::new(Line(format!("fn new(hook: Box<dyn (::capnp::private::capability::ClientHook)>) -> Client{} {{", bracketed_params)))),
                     Indent(Box::new(Indent(Box::new(Line(format!("Client {{ client: ::capnp::capability::Client::new(hook), {} }}", params.phantom_data_value)))))),
                     Indent(Box::new(Line("}".to_string()))),
+                    Indent(Box::new(Line(format!("fn into_client_hook(self) -> Box<dyn (::capnp::private::capability::ClientHook)> {{")))),
+                    Indent(Box::new(Indent(Box::new(Line(format!("self.client.hook")))))),
+                    Indent(Box::new(Line("}".to_string()))),
                     Line("}".to_string()))));
 
 


### PR DESCRIPTION
This makes it much less awkward to cast between capability types.