### PR TITLE
remove redundant field names

### DIFF
--- a/async-byte-channel/src/lib.rs
+++ b/async-byte-channel/src/lib.rs
@@ -62,7 +62,7 @@ impl Drop for Receiver {
 pub fn channel() -> (Sender, Receiver) {
     let inner = Arc::new(Mutex::new(Inner::new()));
     let sender = Sender { inner: inner.clone() };
-    let receiver = Receiver { inner: inner };
+    let receiver = Receiver { inner };
     (sender, receiver)
 }
 

--- a/capnp-futures/src/read_stream.rs
+++ b/capnp-futures/src/read_stream.rs
@@ -47,7 +47,7 @@ impl <'a, R> ReadStream<'a, R> where R: AsyncRead + Unpin + 'a  {
     {
         ReadStream {
             read: Box::pin(read_next_message(reader, options)),
-            options: options,
+            options,
         }
     }
 }

--- a/capnp-futures/src/serialize.rs
+++ b/capnp-futures/src/serialize.rs
@@ -420,7 +420,7 @@ pub mod test {
 
     impl <R> BlockingRead<R> where R: Read {
         pub(crate) fn new(read: R, blocking_period: usize) -> BlockingRead<R> {
-            BlockingRead { read: read, blocking_period, idx: 0 }
+            BlockingRead { read, blocking_period, idx: 0 }
         }
     }
 
@@ -456,7 +456,7 @@ pub mod test {
 
     impl <W> BlockingWrite<W> where W: Write {
         pub(crate) fn new(writer: W, blocking_period: usize) -> BlockingWrite<W> {
-            BlockingWrite { writer: writer, blocking_period, idx: 0 }
+            BlockingWrite { writer, blocking_period, idx: 0 }
         }
         pub(crate) fn into_writer(self) -> W {
             self.writer

--- a/capnp-rpc/src/broken.rs
+++ b/capnp-rpc/src/broken.rs
@@ -35,9 +35,7 @@ pub struct Pipeline {
 
 impl Pipeline {
     pub fn new(error: Error) -> Pipeline {
-        Pipeline {
-            error: error
-        }
+        Pipeline { error }
     }
 }
 
@@ -59,7 +57,7 @@ pub struct Request {
 impl Request {
     pub fn new(error: Error, _size_hint: Option<::capnp::MessageSize>) -> Request {
         Request {
-            error: error,
+            error,
             message: ::capnp::message::Builder::new_default(),
             cap_table: Vec::new(),
         }
@@ -103,9 +101,9 @@ impl Client {
     pub fn new(error: Error, resolved: bool, brand: usize) -> Client {
         Client {
             inner: Rc::new(ClientInner {
-                error: error,
+                error,
                 _resolved: resolved,
-                brand: brand,
+                brand,
             }),
         }
     }

--- a/capnp-rpc/src/lib.rs
+++ b/capnp-rpc/src/lib.rs
@@ -203,11 +203,11 @@ impl <VatId> RpcSystem <VatId> {
         }));
 
         let mut result = RpcSystem {
-            network: network,
-            bootstrap_cap: bootstrap_cap,
+            network,
+            bootstrap_cap,
             connection_state: Rc::new(RefCell::new(None)),
 
-            tasks: tasks,
+            tasks,
             handle: handle.clone(),
         };
 

--- a/capnp-rpc/src/local.rs
+++ b/capnp-rpc/src/local.rs
@@ -50,7 +50,7 @@ pub struct Response {
 impl Response {
     fn new(results: Box<dyn ResultsDoneHook>) -> Response {
         Response {
-            results: results
+            results
         }
     }
 }
@@ -72,8 +72,8 @@ impl Params {
            -> Params
     {
         Params {
-            request: request,
-            cap_table: cap_table,
+            request,
+            cap_table,
         }
     }
 }
@@ -157,8 +157,8 @@ impl ResultsDone {
     {
         ResultsDone {
             inner: Rc::new(ResultsDoneInner {
-                message: message,
-                cap_table: cap_table,
+                message,
+                cap_table,
             }),
         }
     }
@@ -193,9 +193,9 @@ impl Request {
         Request {
             message: message::Builder::new_default(),
             cap_table: Vec::new(),
-            interface_id: interface_id,
-            method_id: method_id,
-            client: client,
+            interface_id,
+            method_id,
+            client,
         }
     }
 }
@@ -234,7 +234,7 @@ impl RequestHook for Request {
 
         capability::RemotePromise {
             promise: Promise::from_future(left),
-            pipeline: pipeline,
+            pipeline,
         }
     }
     fn tail_send(self: Box<Self>)
@@ -255,7 +255,7 @@ pub struct Pipeline {
 impl Pipeline {
     pub fn new(results: Box<dyn ResultsDoneHook>) -> Pipeline {
         Pipeline {
-            inner: Rc::new(RefCell::new(PipelineInner { results: results }))
+            inner: Rc::new(RefCell::new(PipelineInner { results }))
         }
     }
 }

--- a/capnp-rpc/src/queued.rs
+++ b/capnp-rpc/src/queued.rs
@@ -105,7 +105,7 @@ impl Pipeline {
         }));
 
 
-        (PipelineInnerSender { inner: Some(Rc::downgrade(&inner)) }, Pipeline { inner: inner })
+        (PipelineInnerSender { inner: Some(Rc::downgrade(&inner)) }, Pipeline { inner })
     }
 
     pub fn drive<F>(&mut self, promise: F)
@@ -201,14 +201,12 @@ impl Client {
     {
         let inner = Rc::new(RefCell::new(ClientInner {
             promise_to_drive: None,
-            pipeline_inner: pipeline_inner,
+            pipeline_inner,
             redirect: None,
             call_forwarding_queue: SenderQueue::new(),
             client_resolution_queue: SenderQueue::new(),
         }));
-        Client {
-            inner: inner
-        }
+        Client { inner }
     }
 
     pub fn drive<F>(&mut self, promise: F)

--- a/capnp-rpc/src/task_set.rs
+++ b/capnp-rpc/src/task_set.rs
@@ -87,7 +87,7 @@ impl<E> TaskSet<E> where E: 'static {
         set.in_progress.push(TaskInProgress::Task(Box::pin(::futures::future::pending())));
 
         let handle = TaskSetHandle {
-            sender: sender,
+            sender,
         };
 
         (handle, set)

--- a/capnp-rpc/src/twoparty.rs
+++ b/capnp-rpc/src/twoparty.rs
@@ -37,7 +37,7 @@ struct IncomingMessage {
 
 impl IncomingMessage {
     pub fn new(message: ::capnp::message::Reader<capnp::serialize::OwnedSegments>) -> IncomingMessage {
-        IncomingMessage { message: message }
+        IncomingMessage { message }
     }
 }
 
@@ -116,9 +116,9 @@ impl <T> Connection<T> where T: AsyncRead {
             inner: Rc::new(RefCell::new(
                 ConnectionInner {
                     input_stream: Rc::new(RefCell::new(Some(input_stream))),
-                    sender: sender,
-                    side: side,
-                    receive_options: receive_options,
+                    sender,
+                    side,
+                    receive_options,
                     on_disconnect_fulfiller: Some(on_disconnect_fulfiller),
                 })),
         }
@@ -216,8 +216,8 @@ impl <T> VatNetwork<T> where T: AsyncRead + Unpin {
         VatNetwork {
             connection: Some(connection),
             weak_connection_inner: weak_inner,
-            execution_driver: execution_driver,
-            side: side,
+            execution_driver,
+            side,
         }
     }
 }

--- a/capnpc/src/codegen_types.rs
+++ b/capnpc/src/codegen_types.rs
@@ -125,11 +125,11 @@ impl <'a> RustNodeInfo for node::Reader<'a> {
             TypeParameterTexts {
                 expanded_list: params,
                 params: type_parameters,
-                where_clause: where_clause,
-                where_clause_with_static: where_clause_with_static,
-                pipeline_where_clause: pipeline_where_clause,
+                where_clause,
+                where_clause_with_static,
+                pipeline_where_clause,
                 phantom_data_type,
-                phantom_data_value: phantom_data_value
+                phantom_data_value
             }
         } else {
             TypeParameterTexts {

--- a/capnpc/src/lib.rs
+++ b/capnpc/src/lib.rs
@@ -79,7 +79,7 @@ pub(crate) fn convert_io_err(err: std::io::Error) -> capnp::Error {
         io::ErrorKind::NotConnected  => capnp::ErrorKind::Disconnected,
         _ => capnp::ErrorKind::Failed,
     };
-    capnp::Error { description: format!("{}", err), kind: kind }
+    capnp::Error { description: format!("{}", err), kind }
 }
 
 fn run_command(mut command: ::std::process::Command, mut code_generation_command: codegen::CodeGenerationCommand) -> ::capnp::Result<()> {


### PR DESCRIPTION
remove redundant field names in struct initialisors.

for future reference, rustfmt can configured to do this automatically