### PR TITLE
remove needless borrows

### DIFF
--- a/async-byte-channel/src/lib.rs
+++ b/async-byte-channel/src/lib.rs
@@ -83,7 +83,7 @@ impl AsyncRead for Receiver {
         } else {
             assert!(inner.read_cursor < inner.write_cursor);
             let copy_len = std::cmp::min(buf.len(), inner.write_cursor - inner.read_cursor);
-            (&mut buf[0..copy_len]).copy_from_slice(&inner.buffer[inner.read_cursor .. inner.read_cursor + copy_len]);
+            buf[0..copy_len].copy_from_slice(&inner.buffer[inner.read_cursor .. inner.read_cursor + copy_len]);
             inner.read_cursor += copy_len;
             if let Some(write_waker) = inner.write_waker.take() {
                 write_waker.wake();
@@ -117,7 +117,7 @@ impl AsyncWrite for Sender {
 
         let copy_len = std::cmp::min(buf.len(), inner.buffer.len() - inner.write_cursor);
         let dest_range = inner.write_cursor..inner.write_cursor + copy_len;
-        (&mut inner.buffer[dest_range]).copy_from_slice(&buf[0..copy_len]);
+        inner.buffer[dest_range].copy_from_slice(&buf[0..copy_len]);
         inner.write_cursor += copy_len;
         if let Some(read_waker) = inner.read_waker.take() {
             read_waker.wake();

--- a/capnp-futures/src/serialize_packed.rs
+++ b/capnp-futures/src/serialize_packed.rs
@@ -448,14 +448,14 @@ impl <W> AsyncWrite for PackedWrite<W> where W: AsyncWrite + Unpin {
         cx: &mut Context<'_>,
         inbuf: &[u8]
     ) -> Poll<std::result::Result<usize, std::io::Error>> {
-        (&mut *self).poll_write_aux(cx, inbuf)
+        (*self).poll_write_aux(cx, inbuf)
     }
 
     fn poll_flush(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>
     ) -> Poll<std::result::Result<(), std::io::Error>> {
-        match (&mut *self).finish_pending_writes(cx)? {
+        match (*self).finish_pending_writes(cx)? {
             Poll::Pending => return Poll::Pending,
             Poll::Ready(_) => (),
         }

--- a/capnp-rpc/src/task_set.rs
+++ b/capnp-rpc/src/task_set.rs
@@ -134,7 +134,7 @@ impl <E> Future for TaskSet<E> where E: 'static {
                         in_progress.push(TaskInProgress::Terminate(Some(r)));
                     }
                     Poll::Ready(Some(EnqueuedTask::Task(f))) => {
-                        let reaper = Rc::downgrade(&reaper);
+                        let reaper = Rc::downgrade(reaper);
                         in_progress.push(
                             TaskInProgress::Task(Box::pin(
                                 f.map(move |r| {

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -131,7 +131,7 @@ impl CodeGenerationCommand {
         }
 
         if let Some(raw_code_generator_request) = &self.raw_code_generator_request_path {
-            let raw_code_generator_request_file = ::std::fs::File::create(&raw_code_generator_request).map_err(convert_io_err)?;
+            let raw_code_generator_request_file = ::std::fs::File::create(raw_code_generator_request).map_err(convert_io_err)?;
             serialize::write_message_segments(WriteWrapper{ inner: raw_code_generator_request_file }, &message.into_segments())?;
         }
 
@@ -205,7 +205,7 @@ impl <'a> GeneratorContext<'a> {
             None => Err(Error::failed(format!("node not found: {}", id))),
             Some(v) => match v.last() {
                 None => Err(Error::failed(format!("node has no scope: {}", id))),
-                Some(n) => Ok(&n),
+                Some(n) => Ok(n),
             }
         }
     }
@@ -315,7 +315,7 @@ fn to_lines(ft : &FormattedText, indent : usize) -> Vec<String> {
         }
         Line(ref s) => {
             let mut s1 : String = ::std::iter::repeat(' ').take(indent * 2).collect();
-            s1.push_str(&s);
+            s1.push_str(s);
             return vec!(s1.to_string());
         }
         BlankLine => return vec!("".to_string())
@@ -1831,7 +1831,7 @@ fn generate_node(gen: &GeneratorContext,
                     (gen.scope_map[&param_node.get_id()].clone(),
                      get_ty_params_of_brand(gen, method.get_param_brand()?)?)
                 };
-                let param_type = do_branding(&gen, param_id, method.get_param_brand()?,
+                let param_type = do_branding(gen, param_id, method.get_param_brand()?,
                                              Leaf::Owned, param_scopes.join("::"), Some(node_id))?;
 
                 let result_id = method.get_result_struct_type();
@@ -1846,7 +1846,7 @@ fn generate_node(gen: &GeneratorContext,
                     (gen.scope_map[&result_node.get_id()].clone(),
                      get_ty_params_of_brand(gen, method.get_result_brand()?)?)
                 };
-                let result_type = do_branding(&gen, result_id, method.get_result_brand()?,
+                let result_type = do_branding(gen, result_id, method.get_result_brand()?,
                                               Leaf::Owned, result_scopes.join("::"), Some(node_id))?;
 
                 dispatch_arms.push(

--- a/capnpc/src/codegen_types.rs
+++ b/capnpc/src/codegen_types.rs
@@ -101,7 +101,7 @@ impl <'a> RustNodeInfo for node::Reader<'a> {
     fn parameters_texts(&self, gen:&crate::codegen::GeneratorContext,
                         parent_node_id: Option<u64>) -> TypeParameterTexts {
         if self.get_is_generic() {
-            let params = get_type_parameters(&gen, self.get_id(), parent_node_id);
+            let params = get_type_parameters(gen, self.get_id(), parent_node_id);
             let type_parameters = params.iter().map(|param| {
                 format!("{}",param)
             }).collect::<Vec<String>>().join(",");


### PR DESCRIPTION
these explicit borrows are duplicating the behaviour of the compiler, and can be removed