### PR TITLE
remove redundant 'extern crate' calls

### DIFF
--- a/capnpc/src/codegen_types.rs
+++ b/capnpc/src/codegen_types.rs
@@ -36,8 +36,8 @@ pub enum Leaf {
     Pipeline
 }
 
-impl ::std::fmt::Display for Leaf {
-    fn fmt(&self, fmt:&mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+impl std::fmt::Display for Leaf {
+    fn fmt(&self, fmt:&mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         let display_string = match self {
             &Leaf::Reader(lt) => format!("Reader<{}>", lt),
             &Leaf::Builder(lt) => format!("Builder<{}>", lt),
@@ -47,7 +47,7 @@ impl ::std::fmt::Display for Leaf {
             &Leaf::ServerDispatch => "ServerDispatch".to_string(),
             &Leaf::Pipeline => "Pipeline".to_string(),
         };
-        ::std::fmt::Display::fmt(&display_string, fmt)
+        std::fmt::Display::fmt(&display_string, fmt)
     }
 }
 
@@ -106,21 +106,21 @@ impl <'a> RustNodeInfo for node::Reader<'a> {
                 format!("{}",param)
             }).collect::<Vec<String>>().join(",");
             let where_clause = "where ".to_string() + &*(params.iter().map(|param| {
-                format!("{}: ::capnp::traits::Owned", param)
+                format!("{}: capnp::traits::Owned", param)
             }).collect::<Vec<String>>().join(", ") + " ");
             let where_clause_with_static = "where ".to_string() + &*(params.iter().map(|param| {
-                format!("{}:'static + ::capnp::traits::Owned", param)
+                format!("{}:'static + capnp::traits::Owned", param)
             }).collect::<Vec<String>>().join(", ") + " ");
             let pipeline_where_clause = "where ".to_string() + &*(params.iter().map(|param| {
-                format!("{}: ::capnp::traits::Pipelined, <{} as ::capnp::traits::Pipelined>::Pipeline: ::capnp::capability::FromTypelessPipeline", param, param)
+                format!("{}: capnp::traits::Pipelined, <{} as capnp::traits::Pipelined>::Pipeline: capnp::capability::FromTypelessPipeline", param, param)
             }).collect::<Vec<String>>().join(", ") + " ");
             let phantom_data_type = if params.len() == 1 {
                 // omit parens to avoid linter error
-                format!("_phantom: ::core::marker::PhantomData<{}>", type_parameters)
+                format!("_phantom: core::marker::PhantomData<{}>", type_parameters)
             } else {
-                format!("_phantom: ::core::marker::PhantomData<({})>", type_parameters)
+                format!("_phantom: core::marker::PhantomData<({})>", type_parameters)
             };
-            let phantom_data_value = "_phantom: ::core::marker::PhantomData,".to_string();
+            let phantom_data_value = "_phantom: core::marker::PhantomData,".to_string();
 
             TypeParameterTexts {
                 expanded_list: params,
@@ -147,7 +147,7 @@ impl <'a> RustNodeInfo for node::Reader<'a> {
 
 impl <'a> RustTypeInfo for type_::Reader<'a> {
 
-    fn type_string(&self, gen:&codegen::GeneratorContext, module:Leaf) -> Result<String, ::capnp::Error> {
+    fn type_string(&self, gen:&codegen::GeneratorContext, module:Leaf) -> Result<String, capnp::Error> {
 
         let local_lifetime = match module {
             Leaf::Reader(lt) => lt,
@@ -229,16 +229,16 @@ impl <'a> RustTypeInfo for type_::Reader<'a> {
                             Leaf::Owned => Ok(parameter_name.to_string()),
                             Leaf::Reader(lifetime) => {
                                 Ok(format!(
-                                    "<{} as ::capnp::traits::Owned>::Reader<{}>",
+                                    "<{} as capnp::traits::Owned>::Reader<{}>",
                                     parameter_name, lifetime))
                             }
                             Leaf::Builder(lifetime) => {
                                 Ok(format!(
-                                    "<{} as ::capnp::traits::Owned>::Builder<{}>",
+                                    "<{} as capnp::traits::Owned>::Builder<{}>",
                                     parameter_name, lifetime))
                             }
                             Leaf::Pipeline => {
-                                Ok(format!("<{} as ::capnp::traits::Pipelined>::Pipeline", parameter_name))
+                                Ok(format!("<{} as capnp::traits::Pipelined>::Pipeline", parameter_name))
                             }
                             _ => Err(Error::unimplemented("unimplemented any_pointer leaf".to_string())),
                         }

--- a/capnpc/src/lib.rs
+++ b/capnpc/src/lib.rs
@@ -82,7 +82,7 @@ pub(crate) fn convert_io_err(err: std::io::Error) -> capnp::Error {
     capnp::Error { description: format!("{}", err), kind: kind }
 }
 
-fn run_command(mut command: ::std::process::Command, mut code_generation_command: codegen::CodeGenerationCommand) -> ::capnp::Result<()> {
+fn run_command(mut command: std::process::Command, mut code_generation_command: codegen::CodeGenerationCommand) -> capnp::Result<()> {
     let mut p = command.spawn().map_err(convert_io_err)?;
     code_generation_command.run(p.stdout.take().unwrap())?;
     let exit_status = p.wait().map_err(convert_io_err)?;
@@ -214,11 +214,11 @@ impl CompilerCommand {
 
     /// Runs the command.
     /// Returns an error if `OUT_DIR` or a custom output directory was not set, or if `capnp compile` fails.
-    pub fn run(&mut self) -> ::capnp::Result<()> {
+    pub fn run(&mut self) -> capnp::Result<()> {
         let mut command = if let Some(executable) = &self.executable_path {
-            ::std::process::Command::new(executable)
+            std::process::Command::new(executable)
         } else {
-            ::std::process::Command::new("capnp")
+            std::process::Command::new("capnp")
         };
 
         command.arg("compile").arg("-o").arg("-");
@@ -242,7 +242,7 @@ impl CompilerCommand {
                     Err(..) => "<unknown working directory>".to_string(),
                 };
 
-                ::capnp::Error::failed(format!(
+                capnp::Error::failed(format!(
                     "Unable to stat capnp input file `{}` in working directory {}: {}.  \
                      Please check that the file exists and is accessible for read.",
                     file.display(),
@@ -259,7 +259,7 @@ impl CompilerCommand {
         } else {
             // Try `OUT_DIR` by default
             PathBuf::from(::std::env::var("OUT_DIR").map_err(|error| {
-                ::capnp::Error::failed(format!(
+                capnp::Error::failed(format!(
                     "Could not access `OUT_DIR` environment variable: {}. \
                      You might need to set it up or instead create you own output \
                      structure using `CompilerCommand::output_path`",
@@ -280,7 +280,7 @@ impl CompilerCommand {
         }
 
         run_command(command, code_generation_command).map_err(|error| {
-            ::capnp::Error::failed(format!(
+            capnp::Error::failed(format!(
                 "Error while trying to execute `capnp compile`: {}.  \
                  Please verify that version 0.5.2 or higher of the capnp executable \
                  is installed on your system. See https://capnproto.org/install.html",

--- a/capnpc/src/schema_capnp.rs
+++ b/capnpc/src/schema_capnp.rs
@@ -8,36 +8,36 @@ pub mod node {
 
   #[derive(Copy, Clone)]
   pub struct Owned(());
-  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+  impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
   #[derive(Clone, Copy)]
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+  pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+  impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
       Reader { reader,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+  impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+  impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
       self.reader
     }
   }
 
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
       self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
     }
   }
@@ -47,7 +47,7 @@ pub mod node {
       Reader { .. *self }
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.reader.total_size()
     }
     #[inline]
@@ -55,8 +55,8 @@ pub mod node {
       self.reader.get_data_field::<u64>(0)
     }
     #[inline]
-    pub fn get_display_name(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_display_name(self) -> capnp::Result<capnp::text::Reader<'a>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
     pub fn has_display_name(&self) -> bool {
@@ -71,24 +71,24 @@ pub mod node {
       self.reader.get_data_field::<u64>(2)
     }
     #[inline]
-    pub fn get_nested_nodes(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::node::nested_node::Owned>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
+    pub fn get_nested_nodes(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::node::nested_node::Owned>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), core::option::Option::None)
     }
     #[inline]
     pub fn has_nested_nodes(&self) -> bool {
       !self.reader.get_pointer_field(1).is_null()
     }
     #[inline]
-    pub fn get_annotations(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::core::option::Option::None)
+    pub fn get_annotations(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), core::option::Option::None)
     }
     #[inline]
     pub fn has_annotations(&self) -> bool {
       !self.reader.get_pointer_field(2).is_null()
     }
     #[inline]
-    pub fn get_parameters(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::node::parameter::Owned>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(5), ::core::option::Option::None)
+    pub fn get_parameters(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::node::parameter::Owned>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(5), core::option::Option::None)
     }
     #[inline]
     pub fn has_parameters(&self) -> bool {
@@ -99,87 +99,87 @@ pub mod node {
       self.reader.get_bool_field(288)
     }
     #[inline]
-    pub fn which(self) -> ::core::result::Result<WhichReader<'a,>, ::capnp::NotInSchema> {
+    pub fn which(self) -> core::result::Result<WhichReader<'a,>, capnp::NotInSchema> {
       match self.reader.get_data_field::<u16>(6) {
         0 => {
-          ::core::result::Result::Ok(File(
+          core::result::Result::Ok(File(
             ()
           ))
         }
         1 => {
-          ::core::result::Result::Ok(Struct(
-            ::capnp::traits::FromStructReader::new(self.reader)
+          core::result::Result::Ok(Struct(
+            capnp::traits::FromStructReader::new(self.reader)
           ))
         }
         2 => {
-          ::core::result::Result::Ok(Enum(
-            ::capnp::traits::FromStructReader::new(self.reader)
+          core::result::Result::Ok(Enum(
+            capnp::traits::FromStructReader::new(self.reader)
           ))
         }
         3 => {
-          ::core::result::Result::Ok(Interface(
-            ::capnp::traits::FromStructReader::new(self.reader)
+          core::result::Result::Ok(Interface(
+            capnp::traits::FromStructReader::new(self.reader)
           ))
         }
         4 => {
-          ::core::result::Result::Ok(Const(
-            ::capnp::traits::FromStructReader::new(self.reader)
+          core::result::Result::Ok(Const(
+            capnp::traits::FromStructReader::new(self.reader)
           ))
         }
         5 => {
-          ::core::result::Result::Ok(Annotation(
-            ::capnp::traits::FromStructReader::new(self.reader)
+          core::result::Result::Ok(Annotation(
+            capnp::traits::FromStructReader::new(self.reader)
           ))
         }
-        x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+        x => core::result::Result::Err(::capnp::NotInSchema(x))
       }
     }
   }
 
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 5, pointers: 6 };
+  pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+    const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 5, pointers: 6 };
   }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+  impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
       Builder { builder,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
       self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-      ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+  impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
     }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+    fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
     pub fn into_reader(self) -> Reader<'a,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
       Builder { .. *self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.builder.into_reader().total_size()
     }
     #[inline]
@@ -191,15 +191,15 @@ pub mod node {
       self.builder.set_data_field::<u64>(0, value);
     }
     #[inline]
-    pub fn get_display_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_display_name(self) -> capnp::Result<capnp::text::Builder<'a>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
-    pub fn set_display_name(&mut self, value: ::capnp::text::Reader<'_>)  {
+    pub fn set_display_name(&mut self, value: capnp::text::Reader<'_>)  {
       self.builder.get_pointer_field(0).set_text(value);
     }
     #[inline]
-    pub fn init_display_name(self, size: u32) -> ::capnp::text::Builder<'a> {
+    pub fn init_display_name(self, size: u32) -> capnp::text::Builder<'a> {
       self.builder.get_pointer_field(0).init_text(size)
     }
     #[inline]
@@ -223,32 +223,32 @@ pub mod node {
       self.builder.set_data_field::<u64>(2, value);
     }
     #[inline]
-    pub fn get_nested_nodes(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::node::nested_node::Owned>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
+    pub fn get_nested_nodes(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::node::nested_node::Owned>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), core::option::Option::None)
     }
     #[inline]
-    pub fn set_nested_nodes(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::node::nested_node::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+    pub fn set_nested_nodes(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::node::nested_node::Owned>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
     }
     #[inline]
-    pub fn init_nested_nodes(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::node::nested_node::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), size)
+    pub fn init_nested_nodes(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::node::nested_node::Owned> {
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), size)
     }
     #[inline]
     pub fn has_nested_nodes(&self) -> bool {
       !self.builder.get_pointer_field(1).is_null()
     }
     #[inline]
-    pub fn get_annotations(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
+    pub fn get_annotations(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), core::option::Option::None)
     }
     #[inline]
-    pub fn set_annotations(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
+    pub fn set_annotations(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
     }
     #[inline]
-    pub fn init_annotations(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), size)
+    pub fn init_annotations(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned> {
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), size)
     }
     #[inline]
     pub fn has_annotations(&self) -> bool {
@@ -268,27 +268,27 @@ pub mod node {
       self.builder.set_data_field::<u16>(15, 0u16);
       self.builder.set_data_field::<u32>(8, 0u32);
       self.builder.get_pointer_field(3).clear();
-      ::capnp::traits::FromStructBuilder::new(self.builder)
+      capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
     pub fn init_enum(self, ) -> crate::schema_capnp::node::enum_::Builder<'a> {
       self.builder.set_data_field::<u16>(6, 2);
       self.builder.get_pointer_field(3).clear();
-      ::capnp::traits::FromStructBuilder::new(self.builder)
+      capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
     pub fn init_interface(self, ) -> crate::schema_capnp::node::interface::Builder<'a> {
       self.builder.set_data_field::<u16>(6, 3);
       self.builder.get_pointer_field(3).clear();
       self.builder.get_pointer_field(4).clear();
-      ::capnp::traits::FromStructBuilder::new(self.builder)
+      capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
     pub fn init_const(self, ) -> crate::schema_capnp::node::const_::Builder<'a> {
       self.builder.set_data_field::<u16>(6, 4);
       self.builder.get_pointer_field(3).clear();
       self.builder.get_pointer_field(4).clear();
-      ::capnp::traits::FromStructBuilder::new(self.builder)
+      capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
     pub fn init_annotation(self, ) -> crate::schema_capnp::node::annotation::Builder<'a> {
@@ -306,19 +306,19 @@ pub mod node {
       self.builder.set_bool_field(121, false);
       self.builder.set_bool_field(122, false);
       self.builder.set_bool_field(123, false);
-      ::capnp::traits::FromStructBuilder::new(self.builder)
+      capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn get_parameters(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::node::parameter::Owned>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(5), ::core::option::Option::None)
+    pub fn get_parameters(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::node::parameter::Owned>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(5), core::option::Option::None)
     }
     #[inline]
-    pub fn set_parameters(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::node::parameter::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(5), value, false)
+    pub fn set_parameters(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::node::parameter::Owned>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(5), value, false)
     }
     #[inline]
-    pub fn init_parameters(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::node::parameter::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(5), size)
+    pub fn init_parameters(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::node::parameter::Owned> {
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(5), size)
     }
     #[inline]
     pub fn has_parameters(&self) -> bool {
@@ -333,46 +333,46 @@ pub mod node {
       self.builder.set_bool_field(288, value);
     }
     #[inline]
-    pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
+    pub fn which(self) -> core::result::Result<WhichBuilder<'a,>, capnp::NotInSchema> {
       match self.builder.get_data_field::<u16>(6) {
         0 => {
-          ::core::result::Result::Ok(File(
+          core::result::Result::Ok(File(
             ()
           ))
         }
         1 => {
-          ::core::result::Result::Ok(Struct(
-            ::capnp::traits::FromStructBuilder::new(self.builder)
+          core::result::Result::Ok(Struct(
+            capnp::traits::FromStructBuilder::new(self.builder)
           ))
         }
         2 => {
-          ::core::result::Result::Ok(Enum(
-            ::capnp::traits::FromStructBuilder::new(self.builder)
+          core::result::Result::Ok(Enum(
+            capnp::traits::FromStructBuilder::new(self.builder)
           ))
         }
         3 => {
-          ::core::result::Result::Ok(Interface(
-            ::capnp::traits::FromStructBuilder::new(self.builder)
+          core::result::Result::Ok(Interface(
+            capnp::traits::FromStructBuilder::new(self.builder)
           ))
         }
         4 => {
-          ::core::result::Result::Ok(Const(
-            ::capnp::traits::FromStructBuilder::new(self.builder)
+          core::result::Result::Ok(Const(
+            capnp::traits::FromStructBuilder::new(self.builder)
           ))
         }
         5 => {
-          ::core::result::Result::Ok(Annotation(
-            ::capnp::traits::FromStructBuilder::new(self.builder)
+          core::result::Result::Ok(Annotation(
+            capnp::traits::FromStructBuilder::new(self.builder)
           ))
         }
-        x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+        x => core::result::Result::Err(::capnp::NotInSchema(x))
       }
     }
   }
 
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+  pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+  impl capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
       Pipeline { _typeless: typeless,  }
     }
   }
@@ -395,36 +395,36 @@ pub mod node {
   pub mod parameter {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -434,12 +434,12 @@ pub mod node {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
-      pub fn get_name(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_name(self) -> capnp::Result<capnp::text::Reader<'a>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
       pub fn has_name(&self) -> bool {
@@ -447,62 +447,62 @@ pub mod node {
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 1 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 0, pointers: 1 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
-      pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_name(self) -> capnp::Result<capnp::text::Builder<'a>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
-      pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
+      pub fn set_name(&mut self, value: capnp::text::Reader<'_>)  {
         self.builder.get_pointer_field(0).set_text(value);
       }
       #[inline]
-      pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
+      pub fn init_name(self, size: u32) -> capnp::text::Builder<'a> {
         self.builder.get_pointer_field(0).init_text(size)
       }
       #[inline]
@@ -511,9 +511,9 @@ pub mod node {
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
@@ -527,36 +527,36 @@ pub mod node {
   pub mod nested_node {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -566,12 +566,12 @@ pub mod node {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
-      pub fn get_name(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_name(self) -> capnp::Result<capnp::text::Reader<'a>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
       pub fn has_name(&self) -> bool {
@@ -583,62 +583,62 @@ pub mod node {
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 1 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 1, pointers: 1 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
-      pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_name(self) -> capnp::Result<capnp::text::Builder<'a>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
-      pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
+      pub fn set_name(&mut self, value: capnp::text::Reader<'_>)  {
         self.builder.get_pointer_field(0).set_text(value);
       }
       #[inline]
-      pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
+      pub fn init_name(self, size: u32) -> capnp::text::Builder<'a> {
         self.builder.get_pointer_field(0).init_text(size)
       }
       #[inline]
@@ -655,9 +655,9 @@ pub mod node {
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
@@ -671,36 +671,36 @@ pub mod node {
   pub mod source_info {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -710,7 +710,7 @@ pub mod node {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
@@ -718,16 +718,16 @@ pub mod node {
         self.reader.get_data_field::<u64>(0)
       }
       #[inline]
-      pub fn get_doc_comment(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_doc_comment(self) -> capnp::Result<capnp::text::Reader<'a>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
       pub fn has_doc_comment(&self) -> bool {
         !self.reader.get_pointer_field(0).is_null()
       }
       #[inline]
-      pub fn get_members(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::node::source_info::member::Owned>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
+      pub fn get_members(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::node::source_info::member::Owned>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), core::option::Option::None)
       }
       #[inline]
       pub fn has_members(&self) -> bool {
@@ -735,50 +735,50 @@ pub mod node {
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 2 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 1, pointers: 2 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
@@ -790,15 +790,15 @@ pub mod node {
         self.builder.set_data_field::<u64>(0, value);
       }
       #[inline]
-      pub fn get_doc_comment(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_doc_comment(self) -> capnp::Result<capnp::text::Builder<'a>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
-      pub fn set_doc_comment(&mut self, value: ::capnp::text::Reader<'_>)  {
+      pub fn set_doc_comment(&mut self, value: capnp::text::Reader<'_>)  {
         self.builder.get_pointer_field(0).set_text(value);
       }
       #[inline]
-      pub fn init_doc_comment(self, size: u32) -> ::capnp::text::Builder<'a> {
+      pub fn init_doc_comment(self, size: u32) -> capnp::text::Builder<'a> {
         self.builder.get_pointer_field(0).init_text(size)
       }
       #[inline]
@@ -806,16 +806,16 @@ pub mod node {
         !self.builder.get_pointer_field(0).is_null()
       }
       #[inline]
-      pub fn get_members(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::node::source_info::member::Owned>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
+      pub fn get_members(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::node::source_info::member::Owned>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), core::option::Option::None)
       }
       #[inline]
-      pub fn set_members(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::node::source_info::member::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+      pub fn set_members(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::node::source_info::member::Owned>) -> capnp::Result<()> {
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
       }
       #[inline]
-      pub fn init_members(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::node::source_info::member::Owned> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), size)
+      pub fn init_members(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::node::source_info::member::Owned> {
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), size)
       }
       #[inline]
       pub fn has_members(&self) -> bool {
@@ -823,9 +823,9 @@ pub mod node {
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
@@ -838,36 +838,36 @@ pub mod node {
     pub mod member {
       #[derive(Copy, Clone)]
       pub struct Owned(());
-      impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+      impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+      impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+      impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
       #[derive(Clone, Copy)]
-      pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+      pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-      impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+      impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
         const TYPE_ID: u64 = _private::TYPE_ID;
       }
-      impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-        fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+      impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+        fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
           Reader { reader,  }
         }
       }
 
-      impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-          ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+      impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+          core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
         }
       }
 
-      impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+      impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+        fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
           self.reader
         }
       }
 
-      impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+      impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+        fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
           self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
         }
       }
@@ -877,12 +877,12 @@ pub mod node {
           Reader { .. *self }
         }
 
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
           self.reader.total_size()
         }
         #[inline]
-        pub fn get_doc_comment(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-          ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+        pub fn get_doc_comment(self) -> capnp::Result<capnp::text::Reader<'a>> {
+          capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
         }
         #[inline]
         pub fn has_doc_comment(&self) -> bool {
@@ -890,62 +890,62 @@ pub mod node {
         }
       }
 
-      pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-      impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-        const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 1 };
+      pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+      impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+        const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 0, pointers: 1 };
       }
-      impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+      impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
         const TYPE_ID: u64 = _private::TYPE_ID;
       }
-      impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-        fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+      impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+        fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
           Builder { builder,  }
         }
       }
 
-      impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+      impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+        fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
           self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
         }
       }
 
-      impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-        fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-          ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+      impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+        fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+          capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
         }
-        fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-          ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+        fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+          core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
         }
       }
 
-      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+        fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
       }
 
       impl <'a,> Builder<'a,>  {
         pub fn into_reader(self) -> Reader<'a,> {
-          ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+          capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
         pub fn reborrow(&mut self) -> Builder<'_,> {
           Builder { .. *self }
         }
         pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+          capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
 
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
           self.builder.into_reader().total_size()
         }
         #[inline]
-        pub fn get_doc_comment(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-          ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+        pub fn get_doc_comment(self) -> capnp::Result<capnp::text::Builder<'a>> {
+          capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
         }
         #[inline]
-        pub fn set_doc_comment(&mut self, value: ::capnp::text::Reader<'_>)  {
+        pub fn set_doc_comment(&mut self, value: capnp::text::Reader<'_>)  {
           self.builder.get_pointer_field(0).set_text(value);
         }
         #[inline]
-        pub fn init_doc_comment(self, size: u32) -> ::capnp::text::Builder<'a> {
+        pub fn init_doc_comment(self, size: u32) -> capnp::text::Builder<'a> {
           self.builder.get_pointer_field(0).init_text(size)
         }
         #[inline]
@@ -954,9 +954,9 @@ pub mod node {
         }
       }
 
-      pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-      impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+      pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+      impl capnp::capability::FromTypelessPipeline for Pipeline {
+        fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
           Pipeline { _typeless: typeless,  }
         }
       }
@@ -971,36 +971,36 @@ pub mod node {
   pub mod struct_ {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -1010,7 +1010,7 @@ pub mod node {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
@@ -1022,8 +1022,8 @@ pub mod node {
         self.reader.get_data_field::<u16>(12)
       }
       #[inline]
-      pub fn get_preferred_list_encoding(self) -> ::core::result::Result<crate::schema_capnp::ElementSize,::capnp::NotInSchema> {
-        ::capnp::traits::FromU16::from_u16(self.reader.get_data_field::<u16>(13))
+      pub fn get_preferred_list_encoding(self) -> core::result::Result<crate::schema_capnp::ElementSize,::capnp::NotInSchema> {
+        capnp::traits::FromU16::from_u16(self.reader.get_data_field::<u16>(13))
       }
       #[inline]
       pub fn get_is_group(self) -> bool {
@@ -1038,8 +1038,8 @@ pub mod node {
         self.reader.get_data_field::<u32>(8)
       }
       #[inline]
-      pub fn get_fields(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::field::Owned>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::core::option::Option::None)
+      pub fn get_fields(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::field::Owned>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), core::option::Option::None)
       }
       #[inline]
       pub fn has_fields(&self) -> bool {
@@ -1047,50 +1047,50 @@ pub mod node {
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 5, pointers: 6 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 5, pointers: 6 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
@@ -1110,8 +1110,8 @@ pub mod node {
         self.builder.set_data_field::<u16>(12, value);
       }
       #[inline]
-      pub fn get_preferred_list_encoding(self) -> ::core::result::Result<crate::schema_capnp::ElementSize,::capnp::NotInSchema> {
-        ::capnp::traits::FromU16::from_u16(self.builder.get_data_field::<u16>(13))
+      pub fn get_preferred_list_encoding(self) -> core::result::Result<crate::schema_capnp::ElementSize,::capnp::NotInSchema> {
+        capnp::traits::FromU16::from_u16(self.builder.get_data_field::<u16>(13))
       }
       #[inline]
       pub fn set_preferred_list_encoding(&mut self, value: crate::schema_capnp::ElementSize)  {
@@ -1142,16 +1142,16 @@ pub mod node {
         self.builder.set_data_field::<u32>(8, value);
       }
       #[inline]
-      pub fn get_fields(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::field::Owned>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
+      pub fn get_fields(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::field::Owned>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), core::option::Option::None)
       }
       #[inline]
-      pub fn set_fields(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::field::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+      pub fn set_fields(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::field::Owned>) -> capnp::Result<()> {
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
       }
       #[inline]
-      pub fn init_fields(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::field::Owned> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), size)
+      pub fn init_fields(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::field::Owned> {
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), size)
       }
       #[inline]
       pub fn has_fields(&self) -> bool {
@@ -1159,9 +1159,9 @@ pub mod node {
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
@@ -1175,36 +1175,36 @@ pub mod node {
   pub mod enum_ {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -1214,12 +1214,12 @@ pub mod node {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
-      pub fn get_enumerants(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::enumerant::Owned>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::core::option::Option::None)
+      pub fn get_enumerants(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::enumerant::Owned>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), core::option::Option::None)
       }
       #[inline]
       pub fn has_enumerants(&self) -> bool {
@@ -1227,63 +1227,63 @@ pub mod node {
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 5, pointers: 6 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 5, pointers: 6 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
-      pub fn get_enumerants(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::enumerant::Owned>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
+      pub fn get_enumerants(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::enumerant::Owned>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), core::option::Option::None)
       }
       #[inline]
-      pub fn set_enumerants(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::enumerant::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+      pub fn set_enumerants(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::enumerant::Owned>) -> capnp::Result<()> {
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
       }
       #[inline]
-      pub fn init_enumerants(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::enumerant::Owned> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), size)
+      pub fn init_enumerants(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::enumerant::Owned> {
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), size)
       }
       #[inline]
       pub fn has_enumerants(&self) -> bool {
@@ -1291,9 +1291,9 @@ pub mod node {
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
@@ -1307,36 +1307,36 @@ pub mod node {
   pub mod interface {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -1346,20 +1346,20 @@ pub mod node {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
-      pub fn get_methods(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::method::Owned>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::core::option::Option::None)
+      pub fn get_methods(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::method::Owned>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), core::option::Option::None)
       }
       #[inline]
       pub fn has_methods(&self) -> bool {
         !self.reader.get_pointer_field(3).is_null()
       }
       #[inline]
-      pub fn get_superclasses(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::superclass::Owned>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(4), ::core::option::Option::None)
+      pub fn get_superclasses(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::superclass::Owned>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(4), core::option::Option::None)
       }
       #[inline]
       pub fn has_superclasses(&self) -> bool {
@@ -1367,79 +1367,79 @@ pub mod node {
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 5, pointers: 6 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 5, pointers: 6 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
-      pub fn get_methods(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::method::Owned>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
+      pub fn get_methods(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::method::Owned>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), core::option::Option::None)
       }
       #[inline]
-      pub fn set_methods(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::method::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+      pub fn set_methods(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::method::Owned>) -> capnp::Result<()> {
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
       }
       #[inline]
-      pub fn init_methods(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::method::Owned> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), size)
+      pub fn init_methods(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::method::Owned> {
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), size)
       }
       #[inline]
       pub fn has_methods(&self) -> bool {
         !self.builder.get_pointer_field(3).is_null()
       }
       #[inline]
-      pub fn get_superclasses(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::superclass::Owned>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(4), ::core::option::Option::None)
+      pub fn get_superclasses(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::superclass::Owned>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(4), core::option::Option::None)
       }
       #[inline]
-      pub fn set_superclasses(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::superclass::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(4), value, false)
+      pub fn set_superclasses(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::superclass::Owned>) -> capnp::Result<()> {
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(4), value, false)
       }
       #[inline]
-      pub fn init_superclasses(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::superclass::Owned> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(4), size)
+      pub fn init_superclasses(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::superclass::Owned> {
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(4), size)
       }
       #[inline]
       pub fn has_superclasses(&self) -> bool {
@@ -1447,9 +1447,9 @@ pub mod node {
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
@@ -1463,36 +1463,36 @@ pub mod node {
   pub mod const_ {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -1502,20 +1502,20 @@ pub mod node {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
-      pub fn get_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::core::option::Option::None)
+      pub fn get_type(self) -> capnp::Result<crate::schema_capnp::type_::Reader<'a>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), core::option::Option::None)
       }
       #[inline]
       pub fn has_type(&self) -> bool {
         !self.reader.get_pointer_field(3).is_null()
       }
       #[inline]
-      pub fn get_value(self) -> ::capnp::Result<crate::schema_capnp::value::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(4), ::core::option::Option::None)
+      pub fn get_value(self) -> capnp::Result<crate::schema_capnp::value::Reader<'a>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(4), core::option::Option::None)
       }
       #[inline]
       pub fn has_value(&self) -> bool {
@@ -1523,79 +1523,79 @@ pub mod node {
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 5, pointers: 6 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 5, pointers: 6 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
-      pub fn get_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
+      pub fn get_type(self) -> capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), core::option::Option::None)
       }
       #[inline]
-      pub fn set_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+      pub fn set_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> capnp::Result<()> {
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
       }
       #[inline]
       pub fn init_type(self, ) -> crate::schema_capnp::type_::Builder<'a> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), 0)
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), 0)
       }
       #[inline]
       pub fn has_type(&self) -> bool {
         !self.builder.get_pointer_field(3).is_null()
       }
       #[inline]
-      pub fn get_value(self) -> ::capnp::Result<crate::schema_capnp::value::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(4), ::core::option::Option::None)
+      pub fn get_value(self) -> capnp::Result<crate::schema_capnp::value::Builder<'a>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(4), core::option::Option::None)
       }
       #[inline]
-      pub fn set_value(&mut self, value: crate::schema_capnp::value::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(4), value, false)
+      pub fn set_value(&mut self, value: crate::schema_capnp::value::Reader<'_>) -> capnp::Result<()> {
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(4), value, false)
       }
       #[inline]
       pub fn init_value(self, ) -> crate::schema_capnp::value::Builder<'a> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(4), 0)
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(4), 0)
       }
       #[inline]
       pub fn has_value(&self) -> bool {
@@ -1603,18 +1603,18 @@ pub mod node {
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
     impl Pipeline  {
       pub fn get_type(&self) -> crate::schema_capnp::type_::Pipeline {
-        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(3))
+        capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(3))
       }
       pub fn get_value(&self) -> crate::schema_capnp::value::Pipeline {
-        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(4))
+        capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(4))
       }
     }
     mod _private {
@@ -1625,36 +1625,36 @@ pub mod node {
   pub mod annotation {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -1664,12 +1664,12 @@ pub mod node {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
-      pub fn get_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::core::option::Option::None)
+      pub fn get_type(self) -> capnp::Result<crate::schema_capnp::type_::Reader<'a>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), core::option::Option::None)
       }
       #[inline]
       pub fn has_type(&self) -> bool {
@@ -1725,63 +1725,63 @@ pub mod node {
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 5, pointers: 6 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 5, pointers: 6 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
-      pub fn get_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
+      pub fn get_type(self) -> capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), core::option::Option::None)
       }
       #[inline]
-      pub fn set_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+      pub fn set_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> capnp::Result<()> {
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
       }
       #[inline]
       pub fn init_type(self, ) -> crate::schema_capnp::type_::Builder<'a> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), 0)
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), 0)
       }
       #[inline]
       pub fn has_type(&self) -> bool {
@@ -1885,15 +1885,15 @@ pub mod node {
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
     impl Pipeline  {
       pub fn get_type(&self) -> crate::schema_capnp::type_::Pipeline {
-        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(3))
+        capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(3))
       }
     }
     mod _private {
@@ -1907,36 +1907,36 @@ pub mod field {
 
   #[derive(Copy, Clone)]
   pub struct Owned(());
-  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+  impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
   #[derive(Clone, Copy)]
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+  pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+  impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
       Reader { reader,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+  impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+  impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
       self.reader
     }
   }
 
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
       self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
     }
   }
@@ -1946,12 +1946,12 @@ pub mod field {
       Reader { .. *self }
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.reader.total_size()
     }
     #[inline]
-    pub fn get_name(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_name(self) -> capnp::Result<capnp::text::Reader<'a>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
     pub fn has_name(&self) -> bool {
@@ -1962,8 +1962,8 @@ pub mod field {
       self.reader.get_data_field::<u16>(0)
     }
     #[inline]
-    pub fn get_annotations(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
+    pub fn get_annotations(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), core::option::Option::None)
     }
     #[inline]
     pub fn has_annotations(&self) -> bool {
@@ -1975,82 +1975,82 @@ pub mod field {
     }
     #[inline]
     pub fn get_ordinal(self) -> crate::schema_capnp::field::ordinal::Reader<'a> {
-      ::capnp::traits::FromStructReader::new(self.reader)
+      capnp::traits::FromStructReader::new(self.reader)
     }
     #[inline]
-    pub fn which(self) -> ::core::result::Result<WhichReader<'a,>, ::capnp::NotInSchema> {
+    pub fn which(self) -> core::result::Result<WhichReader<'a,>, capnp::NotInSchema> {
       match self.reader.get_data_field::<u16>(4) {
         0 => {
-          ::core::result::Result::Ok(Slot(
-            ::capnp::traits::FromStructReader::new(self.reader)
+          core::result::Result::Ok(Slot(
+            capnp::traits::FromStructReader::new(self.reader)
           ))
         }
         1 => {
-          ::core::result::Result::Ok(Group(
-            ::capnp::traits::FromStructReader::new(self.reader)
+          core::result::Result::Ok(Group(
+            capnp::traits::FromStructReader::new(self.reader)
           ))
         }
-        x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+        x => core::result::Result::Err(::capnp::NotInSchema(x))
       }
     }
   }
 
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 3, pointers: 4 };
+  pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+    const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 3, pointers: 4 };
   }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+  impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
       Builder { builder,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
       self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-      ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+  impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
     }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+    fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
     pub fn into_reader(self) -> Reader<'a,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
       Builder { .. *self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.builder.into_reader().total_size()
     }
     #[inline]
-    pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_name(self) -> capnp::Result<capnp::text::Builder<'a>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
-    pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
+    pub fn set_name(&mut self, value: capnp::text::Reader<'_>)  {
       self.builder.get_pointer_field(0).set_text(value);
     }
     #[inline]
-    pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
+    pub fn init_name(self, size: u32) -> capnp::text::Builder<'a> {
       self.builder.get_pointer_field(0).init_text(size)
     }
     #[inline]
@@ -2066,16 +2066,16 @@ pub mod field {
       self.builder.set_data_field::<u16>(0, value);
     }
     #[inline]
-    pub fn get_annotations(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
+    pub fn get_annotations(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), core::option::Option::None)
     }
     #[inline]
-    pub fn set_annotations(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+    pub fn set_annotations(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
     }
     #[inline]
-    pub fn init_annotations(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), size)
+    pub fn init_annotations(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned> {
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), size)
     }
     #[inline]
     pub fn has_annotations(&self) -> bool {
@@ -2096,51 +2096,51 @@ pub mod field {
       self.builder.get_pointer_field(2).clear();
       self.builder.get_pointer_field(3).clear();
       self.builder.set_bool_field(128, false);
-      ::capnp::traits::FromStructBuilder::new(self.builder)
+      capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
     pub fn init_group(self, ) -> crate::schema_capnp::field::group::Builder<'a> {
       self.builder.set_data_field::<u16>(4, 1);
       self.builder.set_data_field::<u64>(2, 0u64);
-      ::capnp::traits::FromStructBuilder::new(self.builder)
+      capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
     pub fn get_ordinal(self) -> crate::schema_capnp::field::ordinal::Builder<'a> {
-      ::capnp::traits::FromStructBuilder::new(self.builder)
+      capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
     pub fn init_ordinal(self, ) -> crate::schema_capnp::field::ordinal::Builder<'a> {
       self.builder.set_data_field::<u16>(5, 0);
       self.builder.set_data_field::<u16>(6, 0u16);
-      ::capnp::traits::FromStructBuilder::new(self.builder)
+      capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
+    pub fn which(self) -> core::result::Result<WhichBuilder<'a,>, capnp::NotInSchema> {
       match self.builder.get_data_field::<u16>(4) {
         0 => {
-          ::core::result::Result::Ok(Slot(
-            ::capnp::traits::FromStructBuilder::new(self.builder)
+          core::result::Result::Ok(Slot(
+            capnp::traits::FromStructBuilder::new(self.builder)
           ))
         }
         1 => {
-          ::core::result::Result::Ok(Group(
-            ::capnp::traits::FromStructBuilder::new(self.builder)
+          core::result::Result::Ok(Group(
+            capnp::traits::FromStructBuilder::new(self.builder)
           ))
         }
-        x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+        x => core::result::Result::Err(::capnp::NotInSchema(x))
       }
     }
   }
 
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+  pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+  impl capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
       Pipeline { _typeless: typeless,  }
     }
   }
   impl Pipeline  {
     pub fn get_ordinal(&self) -> crate::schema_capnp::field::ordinal::Pipeline {
-      ::capnp::capability::FromTypelessPipeline::new(self._typeless.noop())
+      capnp::capability::FromTypelessPipeline::new(self._typeless.noop())
     }
   }
   mod _private {
@@ -2157,36 +2157,36 @@ pub mod field {
   pub mod slot {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -2196,7 +2196,7 @@ pub mod field {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
@@ -2204,16 +2204,16 @@ pub mod field {
         self.reader.get_data_field::<u32>(1)
       }
       #[inline]
-      pub fn get_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::core::option::Option::None)
+      pub fn get_type(self) -> capnp::Result<crate::schema_capnp::type_::Reader<'a>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), core::option::Option::None)
       }
       #[inline]
       pub fn has_type(&self) -> bool {
         !self.reader.get_pointer_field(2).is_null()
       }
       #[inline]
-      pub fn get_default_value(self) -> ::capnp::Result<crate::schema_capnp::value::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::core::option::Option::None)
+      pub fn get_default_value(self) -> capnp::Result<crate::schema_capnp::value::Reader<'a>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), core::option::Option::None)
       }
       #[inline]
       pub fn has_default_value(&self) -> bool {
@@ -2225,50 +2225,50 @@ pub mod field {
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 3, pointers: 4 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 3, pointers: 4 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
@@ -2280,32 +2280,32 @@ pub mod field {
         self.builder.set_data_field::<u32>(1, value);
       }
       #[inline]
-      pub fn get_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
+      pub fn get_type(self) -> capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), core::option::Option::None)
       }
       #[inline]
-      pub fn set_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
+      pub fn set_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> capnp::Result<()> {
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
       }
       #[inline]
       pub fn init_type(self, ) -> crate::schema_capnp::type_::Builder<'a> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
       }
       #[inline]
       pub fn has_type(&self) -> bool {
         !self.builder.get_pointer_field(2).is_null()
       }
       #[inline]
-      pub fn get_default_value(self) -> ::capnp::Result<crate::schema_capnp::value::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
+      pub fn get_default_value(self) -> capnp::Result<crate::schema_capnp::value::Builder<'a>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), core::option::Option::None)
       }
       #[inline]
-      pub fn set_default_value(&mut self, value: crate::schema_capnp::value::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+      pub fn set_default_value(&mut self, value: crate::schema_capnp::value::Reader<'_>) -> capnp::Result<()> {
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
       }
       #[inline]
       pub fn init_default_value(self, ) -> crate::schema_capnp::value::Builder<'a> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), 0)
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), 0)
       }
       #[inline]
       pub fn has_default_value(&self) -> bool {
@@ -2321,18 +2321,18 @@ pub mod field {
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
     impl Pipeline  {
       pub fn get_type(&self) -> crate::schema_capnp::type_::Pipeline {
-        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
+        capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
       }
       pub fn get_default_value(&self) -> crate::schema_capnp::value::Pipeline {
-        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(3))
+        capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(3))
       }
     }
     mod _private {
@@ -2343,36 +2343,36 @@ pub mod field {
   pub mod group {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -2382,7 +2382,7 @@ pub mod field {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
@@ -2391,50 +2391,50 @@ pub mod field {
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 3, pointers: 4 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 3, pointers: 4 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
@@ -2447,9 +2447,9 @@ pub mod field {
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
@@ -2465,36 +2465,36 @@ pub mod field {
 
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -2504,71 +2504,71 @@ pub mod field {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
-      pub fn which(self) -> ::core::result::Result<WhichReader, ::capnp::NotInSchema> {
+      pub fn which(self) -> core::result::Result<WhichReader, capnp::NotInSchema> {
         match self.reader.get_data_field::<u16>(5) {
           0 => {
-            ::core::result::Result::Ok(Implicit(
+            core::result::Result::Ok(Implicit(
               ()
             ))
           }
           1 => {
-            ::core::result::Result::Ok(Explicit(
+            core::result::Result::Ok(Explicit(
               self.reader.get_data_field::<u16>(6)
             ))
           }
-          x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+          x => core::result::Result::Err(::capnp::NotInSchema(x))
         }
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 3, pointers: 4 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 3, pointers: 4 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
@@ -2581,26 +2581,26 @@ pub mod field {
         self.builder.set_data_field::<u16>(6, value);
       }
       #[inline]
-      pub fn which(self) -> ::core::result::Result<WhichBuilder, ::capnp::NotInSchema> {
+      pub fn which(self) -> core::result::Result<WhichBuilder, capnp::NotInSchema> {
         match self.builder.get_data_field::<u16>(5) {
           0 => {
-            ::core::result::Result::Ok(Implicit(
+            core::result::Result::Ok(Implicit(
               ()
             ))
           }
           1 => {
-            ::core::result::Result::Ok(Explicit(
+            core::result::Result::Ok(Explicit(
               self.builder.get_data_field::<u16>(6)
             ))
           }
-          x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+          x => core::result::Result::Err(::capnp::NotInSchema(x))
         }
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
@@ -2621,36 +2621,36 @@ pub mod field {
 pub mod enumerant {
   #[derive(Copy, Clone)]
   pub struct Owned(());
-  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+  impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
   #[derive(Clone, Copy)]
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+  pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+  impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
       Reader { reader,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+  impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+  impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
       self.reader
     }
   }
 
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
       self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
     }
   }
@@ -2660,12 +2660,12 @@ pub mod enumerant {
       Reader { .. *self }
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.reader.total_size()
     }
     #[inline]
-    pub fn get_name(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_name(self) -> capnp::Result<capnp::text::Reader<'a>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
     pub fn has_name(&self) -> bool {
@@ -2676,8 +2676,8 @@ pub mod enumerant {
       self.reader.get_data_field::<u16>(0)
     }
     #[inline]
-    pub fn get_annotations(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
+    pub fn get_annotations(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), core::option::Option::None)
     }
     #[inline]
     pub fn has_annotations(&self) -> bool {
@@ -2685,62 +2685,62 @@ pub mod enumerant {
     }
   }
 
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 2 };
+  pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+    const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 1, pointers: 2 };
   }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+  impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
       Builder { builder,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
       self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-      ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+  impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
     }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+    fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
     pub fn into_reader(self) -> Reader<'a,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
       Builder { .. *self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.builder.into_reader().total_size()
     }
     #[inline]
-    pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_name(self) -> capnp::Result<capnp::text::Builder<'a>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
-    pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
+    pub fn set_name(&mut self, value: capnp::text::Reader<'_>)  {
       self.builder.get_pointer_field(0).set_text(value);
     }
     #[inline]
-    pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
+    pub fn init_name(self, size: u32) -> capnp::text::Builder<'a> {
       self.builder.get_pointer_field(0).init_text(size)
     }
     #[inline]
@@ -2756,16 +2756,16 @@ pub mod enumerant {
       self.builder.set_data_field::<u16>(0, value);
     }
     #[inline]
-    pub fn get_annotations(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
+    pub fn get_annotations(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), core::option::Option::None)
     }
     #[inline]
-    pub fn set_annotations(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+    pub fn set_annotations(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
     }
     #[inline]
-    pub fn init_annotations(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), size)
+    pub fn init_annotations(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned> {
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), size)
     }
     #[inline]
     pub fn has_annotations(&self) -> bool {
@@ -2773,9 +2773,9 @@ pub mod enumerant {
     }
   }
 
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+  pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+  impl capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
       Pipeline { _typeless: typeless,  }
     }
   }
@@ -2789,36 +2789,36 @@ pub mod enumerant {
 pub mod superclass {
   #[derive(Copy, Clone)]
   pub struct Owned(());
-  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+  impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
   #[derive(Clone, Copy)]
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+  pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+  impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
       Reader { reader,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+  impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+  impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
       self.reader
     }
   }
 
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
       self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
     }
   }
@@ -2828,7 +2828,7 @@ pub mod superclass {
       Reader { .. *self }
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.reader.total_size()
     }
     #[inline]
@@ -2836,8 +2836,8 @@ pub mod superclass {
       self.reader.get_data_field::<u64>(0)
     }
     #[inline]
-    pub fn get_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_brand(self) -> capnp::Result<crate::schema_capnp::brand::Reader<'a>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
     pub fn has_brand(&self) -> bool {
@@ -2845,50 +2845,50 @@ pub mod superclass {
     }
   }
 
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 1 };
+  pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+    const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 1, pointers: 1 };
   }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+  impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
       Builder { builder,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
       self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-      ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+  impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
     }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+    fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
     pub fn into_reader(self) -> Reader<'a,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
       Builder { .. *self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.builder.into_reader().total_size()
     }
     #[inline]
@@ -2900,16 +2900,16 @@ pub mod superclass {
       self.builder.set_data_field::<u64>(0, value);
     }
     #[inline]
-    pub fn get_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_brand(self) -> capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
-    pub fn set_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+    pub fn set_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
     }
     #[inline]
     pub fn init_brand(self, ) -> crate::schema_capnp::brand::Builder<'a> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
     }
     #[inline]
     pub fn has_brand(&self) -> bool {
@@ -2917,15 +2917,15 @@ pub mod superclass {
     }
   }
 
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+  pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+  impl capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
       Pipeline { _typeless: typeless,  }
     }
   }
   impl Pipeline  {
     pub fn get_brand(&self) -> crate::schema_capnp::brand::Pipeline {
-      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
+      capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
     }
   }
   mod _private {
@@ -2936,36 +2936,36 @@ pub mod superclass {
 pub mod method {
   #[derive(Copy, Clone)]
   pub struct Owned(());
-  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+  impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
   #[derive(Clone, Copy)]
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+  pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+  impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
       Reader { reader,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+  impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+  impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
       self.reader
     }
   }
 
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
       self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
     }
   }
@@ -2975,12 +2975,12 @@ pub mod method {
       Reader { .. *self }
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.reader.total_size()
     }
     #[inline]
-    pub fn get_name(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_name(self) -> capnp::Result<capnp::text::Reader<'a>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
     pub fn has_name(&self) -> bool {
@@ -2999,32 +2999,32 @@ pub mod method {
       self.reader.get_data_field::<u64>(2)
     }
     #[inline]
-    pub fn get_annotations(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
+    pub fn get_annotations(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), core::option::Option::None)
     }
     #[inline]
     pub fn has_annotations(&self) -> bool {
       !self.reader.get_pointer_field(1).is_null()
     }
     #[inline]
-    pub fn get_param_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::core::option::Option::None)
+    pub fn get_param_brand(self) -> capnp::Result<crate::schema_capnp::brand::Reader<'a>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), core::option::Option::None)
     }
     #[inline]
     pub fn has_param_brand(&self) -> bool {
       !self.reader.get_pointer_field(2).is_null()
     }
     #[inline]
-    pub fn get_result_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::core::option::Option::None)
+    pub fn get_result_brand(self) -> capnp::Result<crate::schema_capnp::brand::Reader<'a>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), core::option::Option::None)
     }
     #[inline]
     pub fn has_result_brand(&self) -> bool {
       !self.reader.get_pointer_field(3).is_null()
     }
     #[inline]
-    pub fn get_implicit_parameters(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::node::parameter::Owned>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(4), ::core::option::Option::None)
+    pub fn get_implicit_parameters(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::node::parameter::Owned>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(4), core::option::Option::None)
     }
     #[inline]
     pub fn has_implicit_parameters(&self) -> bool {
@@ -3032,62 +3032,62 @@ pub mod method {
     }
   }
 
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 3, pointers: 5 };
+  pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+    const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 3, pointers: 5 };
   }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+  impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
       Builder { builder,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
       self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-      ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+  impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
     }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+    fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
     pub fn into_reader(self) -> Reader<'a,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
       Builder { .. *self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.builder.into_reader().total_size()
     }
     #[inline]
-    pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_name(self) -> capnp::Result<capnp::text::Builder<'a>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
-    pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
+    pub fn set_name(&mut self, value: capnp::text::Reader<'_>)  {
       self.builder.get_pointer_field(0).set_text(value);
     }
     #[inline]
-    pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
+    pub fn init_name(self, size: u32) -> capnp::text::Builder<'a> {
       self.builder.get_pointer_field(0).init_text(size)
     }
     #[inline]
@@ -3119,64 +3119,64 @@ pub mod method {
       self.builder.set_data_field::<u64>(2, value);
     }
     #[inline]
-    pub fn get_annotations(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
+    pub fn get_annotations(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), core::option::Option::None)
     }
     #[inline]
-    pub fn set_annotations(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+    pub fn set_annotations(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
     }
     #[inline]
-    pub fn init_annotations(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), size)
+    pub fn init_annotations(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned> {
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), size)
     }
     #[inline]
     pub fn has_annotations(&self) -> bool {
       !self.builder.get_pointer_field(1).is_null()
     }
     #[inline]
-    pub fn get_param_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
+    pub fn get_param_brand(self) -> capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), core::option::Option::None)
     }
     #[inline]
-    pub fn set_param_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
+    pub fn set_param_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
     }
     #[inline]
     pub fn init_param_brand(self, ) -> crate::schema_capnp::brand::Builder<'a> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
     }
     #[inline]
     pub fn has_param_brand(&self) -> bool {
       !self.builder.get_pointer_field(2).is_null()
     }
     #[inline]
-    pub fn get_result_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
+    pub fn get_result_brand(self) -> capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), core::option::Option::None)
     }
     #[inline]
-    pub fn set_result_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+    pub fn set_result_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
     }
     #[inline]
     pub fn init_result_brand(self, ) -> crate::schema_capnp::brand::Builder<'a> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), 0)
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), 0)
     }
     #[inline]
     pub fn has_result_brand(&self) -> bool {
       !self.builder.get_pointer_field(3).is_null()
     }
     #[inline]
-    pub fn get_implicit_parameters(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::node::parameter::Owned>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(4), ::core::option::Option::None)
+    pub fn get_implicit_parameters(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::node::parameter::Owned>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(4), core::option::Option::None)
     }
     #[inline]
-    pub fn set_implicit_parameters(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::node::parameter::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(4), value, false)
+    pub fn set_implicit_parameters(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::node::parameter::Owned>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(4), value, false)
     }
     #[inline]
-    pub fn init_implicit_parameters(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::node::parameter::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(4), size)
+    pub fn init_implicit_parameters(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::node::parameter::Owned> {
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(4), size)
     }
     #[inline]
     pub fn has_implicit_parameters(&self) -> bool {
@@ -3184,18 +3184,18 @@ pub mod method {
     }
   }
 
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+  pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+  impl capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
       Pipeline { _typeless: typeless,  }
     }
   }
   impl Pipeline  {
     pub fn get_param_brand(&self) -> crate::schema_capnp::brand::Pipeline {
-      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
+      capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
     }
     pub fn get_result_brand(&self) -> crate::schema_capnp::brand::Pipeline {
-      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(3))
+      capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(3))
     }
   }
   mod _private {
@@ -3208,36 +3208,36 @@ pub mod type_ {
 
   #[derive(Copy, Clone)]
   pub struct Owned(());
-  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+  impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
   #[derive(Clone, Copy)]
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+  pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+  impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
       Reader { reader,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+  impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+  impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
       self.reader
     }
   }
 
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
       self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
     }
   }
@@ -3247,156 +3247,156 @@ pub mod type_ {
       Reader { .. *self }
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.reader.total_size()
     }
     #[inline]
-    pub fn which(self) -> ::core::result::Result<WhichReader<'a,>, ::capnp::NotInSchema> {
+    pub fn which(self) -> core::result::Result<WhichReader<'a,>, capnp::NotInSchema> {
       match self.reader.get_data_field::<u16>(0) {
         0 => {
-          ::core::result::Result::Ok(Void(
+          core::result::Result::Ok(Void(
             ()
           ))
         }
         1 => {
-          ::core::result::Result::Ok(Bool(
+          core::result::Result::Ok(Bool(
             ()
           ))
         }
         2 => {
-          ::core::result::Result::Ok(Int8(
+          core::result::Result::Ok(Int8(
             ()
           ))
         }
         3 => {
-          ::core::result::Result::Ok(Int16(
+          core::result::Result::Ok(Int16(
             ()
           ))
         }
         4 => {
-          ::core::result::Result::Ok(Int32(
+          core::result::Result::Ok(Int32(
             ()
           ))
         }
         5 => {
-          ::core::result::Result::Ok(Int64(
+          core::result::Result::Ok(Int64(
             ()
           ))
         }
         6 => {
-          ::core::result::Result::Ok(Uint8(
+          core::result::Result::Ok(Uint8(
             ()
           ))
         }
         7 => {
-          ::core::result::Result::Ok(Uint16(
+          core::result::Result::Ok(Uint16(
             ()
           ))
         }
         8 => {
-          ::core::result::Result::Ok(Uint32(
+          core::result::Result::Ok(Uint32(
             ()
           ))
         }
         9 => {
-          ::core::result::Result::Ok(Uint64(
+          core::result::Result::Ok(Uint64(
             ()
           ))
         }
         10 => {
-          ::core::result::Result::Ok(Float32(
+          core::result::Result::Ok(Float32(
             ()
           ))
         }
         11 => {
-          ::core::result::Result::Ok(Float64(
+          core::result::Result::Ok(Float64(
             ()
           ))
         }
         12 => {
-          ::core::result::Result::Ok(Text(
+          core::result::Result::Ok(Text(
             ()
           ))
         }
         13 => {
-          ::core::result::Result::Ok(Data(
+          core::result::Result::Ok(Data(
             ()
           ))
         }
         14 => {
-          ::core::result::Result::Ok(List(
-            ::capnp::traits::FromStructReader::new(self.reader)
+          core::result::Result::Ok(List(
+            capnp::traits::FromStructReader::new(self.reader)
           ))
         }
         15 => {
-          ::core::result::Result::Ok(Enum(
-            ::capnp::traits::FromStructReader::new(self.reader)
+          core::result::Result::Ok(Enum(
+            capnp::traits::FromStructReader::new(self.reader)
           ))
         }
         16 => {
-          ::core::result::Result::Ok(Struct(
-            ::capnp::traits::FromStructReader::new(self.reader)
+          core::result::Result::Ok(Struct(
+            capnp::traits::FromStructReader::new(self.reader)
           ))
         }
         17 => {
-          ::core::result::Result::Ok(Interface(
-            ::capnp::traits::FromStructReader::new(self.reader)
+          core::result::Result::Ok(Interface(
+            capnp::traits::FromStructReader::new(self.reader)
           ))
         }
         18 => {
-          ::core::result::Result::Ok(AnyPointer(
-            ::capnp::traits::FromStructReader::new(self.reader)
+          core::result::Result::Ok(AnyPointer(
+            capnp::traits::FromStructReader::new(self.reader)
           ))
         }
-        x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+        x => core::result::Result::Err(::capnp::NotInSchema(x))
       }
     }
   }
 
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 3, pointers: 1 };
+  pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+    const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 3, pointers: 1 };
   }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+  impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
       Builder { builder,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
       self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-      ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+  impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
     }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+    fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
     pub fn into_reader(self) -> Reader<'a,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
       Builder { .. *self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.builder.into_reader().total_size()
     }
     #[inline]
@@ -3459,28 +3459,28 @@ pub mod type_ {
     pub fn init_list(self, ) -> crate::schema_capnp::type_::list::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 14);
       self.builder.get_pointer_field(0).clear();
-      ::capnp::traits::FromStructBuilder::new(self.builder)
+      capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
     pub fn init_enum(self, ) -> crate::schema_capnp::type_::enum_::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 15);
       self.builder.set_data_field::<u64>(1, 0u64);
       self.builder.get_pointer_field(0).clear();
-      ::capnp::traits::FromStructBuilder::new(self.builder)
+      capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
     pub fn init_struct(self, ) -> crate::schema_capnp::type_::struct_::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 16);
       self.builder.set_data_field::<u64>(1, 0u64);
       self.builder.get_pointer_field(0).clear();
-      ::capnp::traits::FromStructBuilder::new(self.builder)
+      capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
     pub fn init_interface(self, ) -> crate::schema_capnp::type_::interface::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 17);
       self.builder.set_data_field::<u64>(1, 0u64);
       self.builder.get_pointer_field(0).clear();
-      ::capnp::traits::FromStructBuilder::new(self.builder)
+      capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
     pub fn init_any_pointer(self, ) -> crate::schema_capnp::type_::any_pointer::Builder<'a> {
@@ -3490,114 +3490,114 @@ pub mod type_ {
       self.builder.set_data_field::<u64>(2, 0u64);
       self.builder.set_data_field::<u16>(5, 0u16);
       self.builder.set_data_field::<u16>(5, 0u16);
-      ::capnp::traits::FromStructBuilder::new(self.builder)
+      capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
+    pub fn which(self) -> core::result::Result<WhichBuilder<'a,>, capnp::NotInSchema> {
       match self.builder.get_data_field::<u16>(0) {
         0 => {
-          ::core::result::Result::Ok(Void(
+          core::result::Result::Ok(Void(
             ()
           ))
         }
         1 => {
-          ::core::result::Result::Ok(Bool(
+          core::result::Result::Ok(Bool(
             ()
           ))
         }
         2 => {
-          ::core::result::Result::Ok(Int8(
+          core::result::Result::Ok(Int8(
             ()
           ))
         }
         3 => {
-          ::core::result::Result::Ok(Int16(
+          core::result::Result::Ok(Int16(
             ()
           ))
         }
         4 => {
-          ::core::result::Result::Ok(Int32(
+          core::result::Result::Ok(Int32(
             ()
           ))
         }
         5 => {
-          ::core::result::Result::Ok(Int64(
+          core::result::Result::Ok(Int64(
             ()
           ))
         }
         6 => {
-          ::core::result::Result::Ok(Uint8(
+          core::result::Result::Ok(Uint8(
             ()
           ))
         }
         7 => {
-          ::core::result::Result::Ok(Uint16(
+          core::result::Result::Ok(Uint16(
             ()
           ))
         }
         8 => {
-          ::core::result::Result::Ok(Uint32(
+          core::result::Result::Ok(Uint32(
             ()
           ))
         }
         9 => {
-          ::core::result::Result::Ok(Uint64(
+          core::result::Result::Ok(Uint64(
             ()
           ))
         }
         10 => {
-          ::core::result::Result::Ok(Float32(
+          core::result::Result::Ok(Float32(
             ()
           ))
         }
         11 => {
-          ::core::result::Result::Ok(Float64(
+          core::result::Result::Ok(Float64(
             ()
           ))
         }
         12 => {
-          ::core::result::Result::Ok(Text(
+          core::result::Result::Ok(Text(
             ()
           ))
         }
         13 => {
-          ::core::result::Result::Ok(Data(
+          core::result::Result::Ok(Data(
             ()
           ))
         }
         14 => {
-          ::core::result::Result::Ok(List(
-            ::capnp::traits::FromStructBuilder::new(self.builder)
+          core::result::Result::Ok(List(
+            capnp::traits::FromStructBuilder::new(self.builder)
           ))
         }
         15 => {
-          ::core::result::Result::Ok(Enum(
-            ::capnp::traits::FromStructBuilder::new(self.builder)
+          core::result::Result::Ok(Enum(
+            capnp::traits::FromStructBuilder::new(self.builder)
           ))
         }
         16 => {
-          ::core::result::Result::Ok(Struct(
-            ::capnp::traits::FromStructBuilder::new(self.builder)
+          core::result::Result::Ok(Struct(
+            capnp::traits::FromStructBuilder::new(self.builder)
           ))
         }
         17 => {
-          ::core::result::Result::Ok(Interface(
-            ::capnp::traits::FromStructBuilder::new(self.builder)
+          core::result::Result::Ok(Interface(
+            capnp::traits::FromStructBuilder::new(self.builder)
           ))
         }
         18 => {
-          ::core::result::Result::Ok(AnyPointer(
-            ::capnp::traits::FromStructBuilder::new(self.builder)
+          core::result::Result::Ok(AnyPointer(
+            capnp::traits::FromStructBuilder::new(self.builder)
           ))
         }
-        x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+        x => core::result::Result::Err(::capnp::NotInSchema(x))
       }
     }
   }
 
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+  pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+  impl capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
       Pipeline { _typeless: typeless,  }
     }
   }
@@ -3633,36 +3633,36 @@ pub mod type_ {
   pub mod list {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -3672,12 +3672,12 @@ pub mod type_ {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
-      pub fn get_element_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_element_type(self) -> capnp::Result<crate::schema_capnp::type_::Reader<'a>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
       pub fn has_element_type(&self) -> bool {
@@ -3685,63 +3685,63 @@ pub mod type_ {
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 3, pointers: 1 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 3, pointers: 1 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
-      pub fn get_element_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_element_type(self) -> capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
-      pub fn set_element_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      pub fn set_element_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> capnp::Result<()> {
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
       }
       #[inline]
       pub fn init_element_type(self, ) -> crate::schema_capnp::type_::Builder<'a> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
       }
       #[inline]
       pub fn has_element_type(&self) -> bool {
@@ -3749,15 +3749,15 @@ pub mod type_ {
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
     impl Pipeline  {
       pub fn get_element_type(&self) -> crate::schema_capnp::type_::Pipeline {
-        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
+        capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
       }
     }
     mod _private {
@@ -3768,36 +3768,36 @@ pub mod type_ {
   pub mod enum_ {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -3807,7 +3807,7 @@ pub mod type_ {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
@@ -3815,8 +3815,8 @@ pub mod type_ {
         self.reader.get_data_field::<u64>(1)
       }
       #[inline]
-      pub fn get_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_brand(self) -> capnp::Result<crate::schema_capnp::brand::Reader<'a>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
       pub fn has_brand(&self) -> bool {
@@ -3824,50 +3824,50 @@ pub mod type_ {
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 3, pointers: 1 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 3, pointers: 1 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
@@ -3879,16 +3879,16 @@ pub mod type_ {
         self.builder.set_data_field::<u64>(1, value);
       }
       #[inline]
-      pub fn get_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_brand(self) -> capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
-      pub fn set_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      pub fn set_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> capnp::Result<()> {
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
       }
       #[inline]
       pub fn init_brand(self, ) -> crate::schema_capnp::brand::Builder<'a> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
       }
       #[inline]
       pub fn has_brand(&self) -> bool {
@@ -3896,15 +3896,15 @@ pub mod type_ {
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
     impl Pipeline  {
       pub fn get_brand(&self) -> crate::schema_capnp::brand::Pipeline {
-        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
+        capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
       }
     }
     mod _private {
@@ -3915,36 +3915,36 @@ pub mod type_ {
   pub mod struct_ {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -3954,7 +3954,7 @@ pub mod type_ {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
@@ -3962,8 +3962,8 @@ pub mod type_ {
         self.reader.get_data_field::<u64>(1)
       }
       #[inline]
-      pub fn get_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_brand(self) -> capnp::Result<crate::schema_capnp::brand::Reader<'a>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
       pub fn has_brand(&self) -> bool {
@@ -3971,50 +3971,50 @@ pub mod type_ {
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 3, pointers: 1 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 3, pointers: 1 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
@@ -4026,16 +4026,16 @@ pub mod type_ {
         self.builder.set_data_field::<u64>(1, value);
       }
       #[inline]
-      pub fn get_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_brand(self) -> capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
-      pub fn set_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      pub fn set_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> capnp::Result<()> {
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
       }
       #[inline]
       pub fn init_brand(self, ) -> crate::schema_capnp::brand::Builder<'a> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
       }
       #[inline]
       pub fn has_brand(&self) -> bool {
@@ -4043,15 +4043,15 @@ pub mod type_ {
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
     impl Pipeline  {
       pub fn get_brand(&self) -> crate::schema_capnp::brand::Pipeline {
-        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
+        capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
       }
     }
     mod _private {
@@ -4062,36 +4062,36 @@ pub mod type_ {
   pub mod interface {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -4101,7 +4101,7 @@ pub mod type_ {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
@@ -4109,8 +4109,8 @@ pub mod type_ {
         self.reader.get_data_field::<u64>(1)
       }
       #[inline]
-      pub fn get_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_brand(self) -> capnp::Result<crate::schema_capnp::brand::Reader<'a>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
       pub fn has_brand(&self) -> bool {
@@ -4118,50 +4118,50 @@ pub mod type_ {
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 3, pointers: 1 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 3, pointers: 1 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
@@ -4173,16 +4173,16 @@ pub mod type_ {
         self.builder.set_data_field::<u64>(1, value);
       }
       #[inline]
-      pub fn get_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_brand(self) -> capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
-      pub fn set_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      pub fn set_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> capnp::Result<()> {
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
       }
       #[inline]
       pub fn init_brand(self, ) -> crate::schema_capnp::brand::Builder<'a> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
       }
       #[inline]
       pub fn has_brand(&self) -> bool {
@@ -4190,15 +4190,15 @@ pub mod type_ {
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
     impl Pipeline  {
       pub fn get_brand(&self) -> crate::schema_capnp::brand::Pipeline {
-        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
+        capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
       }
     }
     mod _private {
@@ -4211,36 +4211,36 @@ pub mod type_ {
 
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -4250,123 +4250,123 @@ pub mod type_ {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
-      pub fn which(self) -> ::core::result::Result<WhichReader<'a,>, ::capnp::NotInSchema> {
+      pub fn which(self) -> core::result::Result<WhichReader<'a,>, capnp::NotInSchema> {
         match self.reader.get_data_field::<u16>(4) {
           0 => {
-            ::core::result::Result::Ok(Unconstrained(
-              ::capnp::traits::FromStructReader::new(self.reader)
+            core::result::Result::Ok(Unconstrained(
+              capnp::traits::FromStructReader::new(self.reader)
             ))
           }
           1 => {
-            ::core::result::Result::Ok(Parameter(
-              ::capnp::traits::FromStructReader::new(self.reader)
+            core::result::Result::Ok(Parameter(
+              capnp::traits::FromStructReader::new(self.reader)
             ))
           }
           2 => {
-            ::core::result::Result::Ok(ImplicitMethodParameter(
-              ::capnp::traits::FromStructReader::new(self.reader)
+            core::result::Result::Ok(ImplicitMethodParameter(
+              capnp::traits::FromStructReader::new(self.reader)
             ))
           }
-          x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+          x => core::result::Result::Err(::capnp::NotInSchema(x))
         }
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 3, pointers: 1 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 3, pointers: 1 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
       pub fn init_unconstrained(self, ) -> crate::schema_capnp::type_::any_pointer::unconstrained::Builder<'a> {
         self.builder.set_data_field::<u16>(4, 0);
         self.builder.set_data_field::<u16>(5, 0);
-        ::capnp::traits::FromStructBuilder::new(self.builder)
+        capnp::traits::FromStructBuilder::new(self.builder)
       }
       #[inline]
       pub fn init_parameter(self, ) -> crate::schema_capnp::type_::any_pointer::parameter::Builder<'a> {
         self.builder.set_data_field::<u16>(4, 1);
         self.builder.set_data_field::<u64>(2, 0u64);
         self.builder.set_data_field::<u16>(5, 0u16);
-        ::capnp::traits::FromStructBuilder::new(self.builder)
+        capnp::traits::FromStructBuilder::new(self.builder)
       }
       #[inline]
       pub fn init_implicit_method_parameter(self, ) -> crate::schema_capnp::type_::any_pointer::implicit_method_parameter::Builder<'a> {
         self.builder.set_data_field::<u16>(4, 2);
         self.builder.set_data_field::<u16>(5, 0u16);
-        ::capnp::traits::FromStructBuilder::new(self.builder)
+        capnp::traits::FromStructBuilder::new(self.builder)
       }
       #[inline]
-      pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
+      pub fn which(self) -> core::result::Result<WhichBuilder<'a,>, capnp::NotInSchema> {
         match self.builder.get_data_field::<u16>(4) {
           0 => {
-            ::core::result::Result::Ok(Unconstrained(
-              ::capnp::traits::FromStructBuilder::new(self.builder)
+            core::result::Result::Ok(Unconstrained(
+              capnp::traits::FromStructBuilder::new(self.builder)
             ))
           }
           1 => {
-            ::core::result::Result::Ok(Parameter(
-              ::capnp::traits::FromStructBuilder::new(self.builder)
+            core::result::Result::Ok(Parameter(
+              capnp::traits::FromStructBuilder::new(self.builder)
             ))
           }
           2 => {
-            ::core::result::Result::Ok(ImplicitMethodParameter(
-              ::capnp::traits::FromStructBuilder::new(self.builder)
+            core::result::Result::Ok(ImplicitMethodParameter(
+              capnp::traits::FromStructBuilder::new(self.builder)
             ))
           }
-          x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+          x => core::result::Result::Err(::capnp::NotInSchema(x))
         }
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
@@ -4388,36 +4388,36 @@ pub mod type_ {
 
       #[derive(Copy, Clone)]
       pub struct Owned(());
-      impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+      impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+      impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+      impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
       #[derive(Clone, Copy)]
-      pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+      pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-      impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+      impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
         const TYPE_ID: u64 = _private::TYPE_ID;
       }
-      impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-        fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+      impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+        fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
           Reader { reader,  }
         }
       }
 
-      impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-          ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+      impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+          core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
         }
       }
 
-      impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+      impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+        fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
           self.reader
         }
       }
 
-      impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+      impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+        fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
           self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
         }
       }
@@ -4427,81 +4427,81 @@ pub mod type_ {
           Reader { .. *self }
         }
 
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
           self.reader.total_size()
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichReader, ::capnp::NotInSchema> {
+        pub fn which(self) -> core::result::Result<WhichReader, capnp::NotInSchema> {
           match self.reader.get_data_field::<u16>(5) {
             0 => {
-              ::core::result::Result::Ok(AnyKind(
+              core::result::Result::Ok(AnyKind(
                 ()
               ))
             }
             1 => {
-              ::core::result::Result::Ok(Struct(
+              core::result::Result::Ok(Struct(
                 ()
               ))
             }
             2 => {
-              ::core::result::Result::Ok(List(
+              core::result::Result::Ok(List(
                 ()
               ))
             }
             3 => {
-              ::core::result::Result::Ok(Capability(
+              core::result::Result::Ok(Capability(
                 ()
               ))
             }
-            x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+            x => core::result::Result::Err(::capnp::NotInSchema(x))
           }
         }
       }
 
-      pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-      impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-        const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 3, pointers: 1 };
+      pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+      impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+        const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 3, pointers: 1 };
       }
-      impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+      impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
         const TYPE_ID: u64 = _private::TYPE_ID;
       }
-      impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-        fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+      impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+        fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
           Builder { builder,  }
         }
       }
 
-      impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+      impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+        fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
           self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
         }
       }
 
-      impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-        fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-          ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+      impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+        fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+          capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
         }
-        fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-          ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+        fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+          core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
         }
       }
 
-      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+        fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
       }
 
       impl <'a,> Builder<'a,>  {
         pub fn into_reader(self) -> Reader<'a,> {
-          ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+          capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
         pub fn reborrow(&mut self) -> Builder<'_,> {
           Builder { .. *self }
         }
         pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+          capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
 
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
           self.builder.into_reader().total_size()
         }
         #[inline]
@@ -4521,36 +4521,36 @@ pub mod type_ {
           self.builder.set_data_field::<u16>(5, 3);
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichBuilder, ::capnp::NotInSchema> {
+        pub fn which(self) -> core::result::Result<WhichBuilder, capnp::NotInSchema> {
           match self.builder.get_data_field::<u16>(5) {
             0 => {
-              ::core::result::Result::Ok(AnyKind(
+              core::result::Result::Ok(AnyKind(
                 ()
               ))
             }
             1 => {
-              ::core::result::Result::Ok(Struct(
+              core::result::Result::Ok(Struct(
                 ()
               ))
             }
             2 => {
-              ::core::result::Result::Ok(List(
+              core::result::Result::Ok(List(
                 ()
               ))
             }
             3 => {
-              ::core::result::Result::Ok(Capability(
+              core::result::Result::Ok(Capability(
                 ()
               ))
             }
-            x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+            x => core::result::Result::Err(::capnp::NotInSchema(x))
           }
         }
       }
 
-      pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-      impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+      pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+      impl capnp::capability::FromTypelessPipeline for Pipeline {
+        fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
           Pipeline { _typeless: typeless,  }
         }
       }
@@ -4572,36 +4572,36 @@ pub mod type_ {
     pub mod parameter {
       #[derive(Copy, Clone)]
       pub struct Owned(());
-      impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+      impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+      impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+      impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
       #[derive(Clone, Copy)]
-      pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+      pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-      impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+      impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
         const TYPE_ID: u64 = _private::TYPE_ID;
       }
-      impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-        fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+      impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+        fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
           Reader { reader,  }
         }
       }
 
-      impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-          ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+      impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+          core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
         }
       }
 
-      impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+      impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+        fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
           self.reader
         }
       }
 
-      impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+      impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+        fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
           self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
         }
       }
@@ -4611,7 +4611,7 @@ pub mod type_ {
           Reader { .. *self }
         }
 
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
           self.reader.total_size()
         }
         #[inline]
@@ -4624,50 +4624,50 @@ pub mod type_ {
         }
       }
 
-      pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-      impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-        const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 3, pointers: 1 };
+      pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+      impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+        const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 3, pointers: 1 };
       }
-      impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+      impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
         const TYPE_ID: u64 = _private::TYPE_ID;
       }
-      impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-        fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+      impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+        fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
           Builder { builder,  }
         }
       }
 
-      impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+      impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+        fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
           self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
         }
       }
 
-      impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-        fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-          ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+      impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+        fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+          capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
         }
-        fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-          ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+        fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+          core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
         }
       }
 
-      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+        fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
       }
 
       impl <'a,> Builder<'a,>  {
         pub fn into_reader(self) -> Reader<'a,> {
-          ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+          capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
         pub fn reborrow(&mut self) -> Builder<'_,> {
           Builder { .. *self }
         }
         pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+          capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
 
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
           self.builder.into_reader().total_size()
         }
         #[inline]
@@ -4688,9 +4688,9 @@ pub mod type_ {
         }
       }
 
-      pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-      impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+      pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+      impl capnp::capability::FromTypelessPipeline for Pipeline {
+        fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
           Pipeline { _typeless: typeless,  }
         }
       }
@@ -4704,36 +4704,36 @@ pub mod type_ {
     pub mod implicit_method_parameter {
       #[derive(Copy, Clone)]
       pub struct Owned(());
-      impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+      impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+      impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+      impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
       #[derive(Clone, Copy)]
-      pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+      pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-      impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+      impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
         const TYPE_ID: u64 = _private::TYPE_ID;
       }
-      impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-        fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+      impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+        fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
           Reader { reader,  }
         }
       }
 
-      impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-          ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+      impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+          core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
         }
       }
 
-      impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+      impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+        fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
           self.reader
         }
       }
 
-      impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+      impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+        fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
           self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
         }
       }
@@ -4743,7 +4743,7 @@ pub mod type_ {
           Reader { .. *self }
         }
 
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
           self.reader.total_size()
         }
         #[inline]
@@ -4752,50 +4752,50 @@ pub mod type_ {
         }
       }
 
-      pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-      impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-        const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 3, pointers: 1 };
+      pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+      impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+        const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 3, pointers: 1 };
       }
-      impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+      impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
         const TYPE_ID: u64 = _private::TYPE_ID;
       }
-      impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-        fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+      impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+        fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
           Builder { builder,  }
         }
       }
 
-      impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+      impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+        fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
           self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
         }
       }
 
-      impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-        fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-          ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+      impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+        fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+          capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
         }
-        fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-          ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+        fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+          core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
         }
       }
 
-      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+        fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
       }
 
       impl <'a,> Builder<'a,>  {
         pub fn into_reader(self) -> Reader<'a,> {
-          ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+          capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
         pub fn reborrow(&mut self) -> Builder<'_,> {
           Builder { .. *self }
         }
         pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+          capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
 
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
           self.builder.into_reader().total_size()
         }
         #[inline]
@@ -4808,9 +4808,9 @@ pub mod type_ {
         }
       }
 
-      pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-      impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+      pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+      impl capnp::capability::FromTypelessPipeline for Pipeline {
+        fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
           Pipeline { _typeless: typeless,  }
         }
       }
@@ -4826,36 +4826,36 @@ pub mod type_ {
 pub mod brand {
   #[derive(Copy, Clone)]
   pub struct Owned(());
-  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+  impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
   #[derive(Clone, Copy)]
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+  pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+  impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
       Reader { reader,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+  impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+  impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
       self.reader
     }
   }
 
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
       self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
     }
   }
@@ -4865,12 +4865,12 @@ pub mod brand {
       Reader { .. *self }
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.reader.total_size()
     }
     #[inline]
-    pub fn get_scopes(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::brand::scope::Owned>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_scopes(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::brand::scope::Owned>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
     pub fn has_scopes(&self) -> bool {
@@ -4878,63 +4878,63 @@ pub mod brand {
     }
   }
 
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 1 };
+  pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+    const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 0, pointers: 1 };
   }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+  impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
       Builder { builder,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
       self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-      ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+  impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
     }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+    fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
     pub fn into_reader(self) -> Reader<'a,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
       Builder { .. *self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.builder.into_reader().total_size()
     }
     #[inline]
-    pub fn get_scopes(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::brand::scope::Owned>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_scopes(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::brand::scope::Owned>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
-    pub fn set_scopes(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::brand::scope::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+    pub fn set_scopes(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::brand::scope::Owned>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
     }
     #[inline]
-    pub fn init_scopes(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::brand::scope::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), size)
+    pub fn init_scopes(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::brand::scope::Owned> {
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), size)
     }
     #[inline]
     pub fn has_scopes(&self) -> bool {
@@ -4942,9 +4942,9 @@ pub mod brand {
     }
   }
 
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+  pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+  impl capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
       Pipeline { _typeless: typeless,  }
     }
   }
@@ -4959,36 +4959,36 @@ pub mod brand {
 
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -4998,7 +4998,7 @@ pub mod brand {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
@@ -5011,67 +5011,67 @@ pub mod brand {
         !self.reader.get_pointer_field(0).is_null()
       }
       #[inline]
-      pub fn which(self) -> ::core::result::Result<WhichReader<'a,>, ::capnp::NotInSchema> {
+      pub fn which(self) -> core::result::Result<WhichReader<'a,>, capnp::NotInSchema> {
         match self.reader.get_data_field::<u16>(4) {
           0 => {
-            ::core::result::Result::Ok(Bind(
-              ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+            core::result::Result::Ok(Bind(
+              capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
             ))
           }
           1 => {
-            ::core::result::Result::Ok(Inherit(
+            core::result::Result::Ok(Inherit(
               ()
             ))
           }
-          x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+          x => core::result::Result::Err(::capnp::NotInSchema(x))
         }
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 2, pointers: 1 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 2, pointers: 1 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
@@ -5083,14 +5083,14 @@ pub mod brand {
         self.builder.set_data_field::<u64>(0, value);
       }
       #[inline]
-      pub fn set_bind(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::brand::binding::Owned>) -> ::capnp::Result<()> {
+      pub fn set_bind(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::brand::binding::Owned>) -> capnp::Result<()> {
         self.builder.set_data_field::<u16>(4, 0);
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
       }
       #[inline]
-      pub fn init_bind(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::brand::binding::Owned> {
+      pub fn init_bind(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::brand::binding::Owned> {
         self.builder.set_data_field::<u16>(4, 0);
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), size)
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), size)
       }
       #[inline]
       pub fn has_bind(&self) -> bool {
@@ -5102,26 +5102,26 @@ pub mod brand {
         self.builder.set_data_field::<u16>(4, 1);
       }
       #[inline]
-      pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
+      pub fn which(self) -> core::result::Result<WhichBuilder<'a,>, capnp::NotInSchema> {
         match self.builder.get_data_field::<u16>(4) {
           0 => {
-            ::core::result::Result::Ok(Bind(
-              ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+            core::result::Result::Ok(Bind(
+              capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
             ))
           }
           1 => {
-            ::core::result::Result::Ok(Inherit(
+            core::result::Result::Ok(Inherit(
               ()
             ))
           }
-          x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+          x => core::result::Result::Err(::capnp::NotInSchema(x))
         }
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
@@ -5134,8 +5134,8 @@ pub mod brand {
       Bind(A0),
       Inherit(()),
     }
-    pub type WhichReader<'a,> = Which<::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::brand::binding::Owned>>>;
-    pub type WhichBuilder<'a,> = Which<::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::brand::binding::Owned>>>;
+    pub type WhichReader<'a,> = Which<capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::brand::binding::Owned>>>;
+    pub type WhichBuilder<'a,> = Which<capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::brand::binding::Owned>>>;
   }
 
   pub mod binding {
@@ -5143,36 +5143,36 @@ pub mod brand {
 
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -5182,7 +5182,7 @@ pub mod brand {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
@@ -5191,67 +5191,67 @@ pub mod brand {
         !self.reader.get_pointer_field(0).is_null()
       }
       #[inline]
-      pub fn which(self) -> ::core::result::Result<WhichReader<'a,>, ::capnp::NotInSchema> {
+      pub fn which(self) -> core::result::Result<WhichReader<'a,>, capnp::NotInSchema> {
         match self.reader.get_data_field::<u16>(0) {
           0 => {
-            ::core::result::Result::Ok(Unbound(
+            core::result::Result::Ok(Unbound(
               ()
             ))
           }
           1 => {
-            ::core::result::Result::Ok(Type(
-              ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+            core::result::Result::Ok(Type(
+              capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
             ))
           }
-          x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+          x => core::result::Result::Err(::capnp::NotInSchema(x))
         }
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 1 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 1, pointers: 1 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
@@ -5259,14 +5259,14 @@ pub mod brand {
         self.builder.set_data_field::<u16>(0, 0);
       }
       #[inline]
-      pub fn set_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
+      pub fn set_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> capnp::Result<()> {
         self.builder.set_data_field::<u16>(0, 1);
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
       }
       #[inline]
       pub fn init_type(self, ) -> crate::schema_capnp::type_::Builder<'a> {
         self.builder.set_data_field::<u16>(0, 1);
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
       }
       #[inline]
       pub fn has_type(&self) -> bool {
@@ -5274,26 +5274,26 @@ pub mod brand {
         !self.builder.get_pointer_field(0).is_null()
       }
       #[inline]
-      pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
+      pub fn which(self) -> core::result::Result<WhichBuilder<'a,>, capnp::NotInSchema> {
         match self.builder.get_data_field::<u16>(0) {
           0 => {
-            ::core::result::Result::Ok(Unbound(
+            core::result::Result::Ok(Unbound(
               ()
             ))
           }
           1 => {
-            ::core::result::Result::Ok(Type(
-              ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+            core::result::Result::Ok(Type(
+              capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
             ))
           }
-          x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+          x => core::result::Result::Err(::capnp::NotInSchema(x))
         }
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
@@ -5306,8 +5306,8 @@ pub mod brand {
       Unbound(()),
       Type(A0),
     }
-    pub type WhichReader<'a,> = Which<::capnp::Result<crate::schema_capnp::type_::Reader<'a>>>;
-    pub type WhichBuilder<'a,> = Which<::capnp::Result<crate::schema_capnp::type_::Builder<'a>>>;
+    pub type WhichReader<'a,> = Which<capnp::Result<crate::schema_capnp::type_::Reader<'a>>>;
+    pub type WhichBuilder<'a,> = Which<capnp::Result<crate::schema_capnp::type_::Builder<'a>>>;
   }
 }
 
@@ -5316,36 +5316,36 @@ pub mod value {
 
   #[derive(Copy, Clone)]
   pub struct Owned(());
-  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+  impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
   #[derive(Clone, Copy)]
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+  pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+  impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
       Reader { reader,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+  impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+  impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
       self.reader
     }
   }
 
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
       self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
     }
   }
@@ -5355,7 +5355,7 @@ pub mod value {
       Reader { .. *self }
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.reader.total_size()
     }
     #[inline]
@@ -5384,152 +5384,152 @@ pub mod value {
       !self.reader.get_pointer_field(0).is_null()
     }
     #[inline]
-    pub fn which(self) -> ::core::result::Result<WhichReader<'a,>, ::capnp::NotInSchema> {
+    pub fn which(self) -> core::result::Result<WhichReader<'a,>, capnp::NotInSchema> {
       match self.reader.get_data_field::<u16>(0) {
         0 => {
-          ::core::result::Result::Ok(Void(
+          core::result::Result::Ok(Void(
             ()
           ))
         }
         1 => {
-          ::core::result::Result::Ok(Bool(
+          core::result::Result::Ok(Bool(
             self.reader.get_bool_field(16)
           ))
         }
         2 => {
-          ::core::result::Result::Ok(Int8(
+          core::result::Result::Ok(Int8(
             self.reader.get_data_field::<i8>(2)
           ))
         }
         3 => {
-          ::core::result::Result::Ok(Int16(
+          core::result::Result::Ok(Int16(
             self.reader.get_data_field::<i16>(1)
           ))
         }
         4 => {
-          ::core::result::Result::Ok(Int32(
+          core::result::Result::Ok(Int32(
             self.reader.get_data_field::<i32>(1)
           ))
         }
         5 => {
-          ::core::result::Result::Ok(Int64(
+          core::result::Result::Ok(Int64(
             self.reader.get_data_field::<i64>(1)
           ))
         }
         6 => {
-          ::core::result::Result::Ok(Uint8(
+          core::result::Result::Ok(Uint8(
             self.reader.get_data_field::<u8>(2)
           ))
         }
         7 => {
-          ::core::result::Result::Ok(Uint16(
+          core::result::Result::Ok(Uint16(
             self.reader.get_data_field::<u16>(1)
           ))
         }
         8 => {
-          ::core::result::Result::Ok(Uint32(
+          core::result::Result::Ok(Uint32(
             self.reader.get_data_field::<u32>(1)
           ))
         }
         9 => {
-          ::core::result::Result::Ok(Uint64(
+          core::result::Result::Ok(Uint64(
             self.reader.get_data_field::<u64>(1)
           ))
         }
         10 => {
-          ::core::result::Result::Ok(Float32(
+          core::result::Result::Ok(Float32(
             self.reader.get_data_field::<f32>(1)
           ))
         }
         11 => {
-          ::core::result::Result::Ok(Float64(
+          core::result::Result::Ok(Float64(
             self.reader.get_data_field::<f64>(1)
           ))
         }
         12 => {
-          ::core::result::Result::Ok(Text(
-            ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+          core::result::Result::Ok(Text(
+            capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
           ))
         }
         13 => {
-          ::core::result::Result::Ok(Data(
-            ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+          core::result::Result::Ok(Data(
+            capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
           ))
         }
         14 => {
-          ::core::result::Result::Ok(List(
-            ::capnp::any_pointer::Reader::new(self.reader.get_pointer_field(0))
+          core::result::Result::Ok(List(
+            capnp::any_pointer::Reader::new(self.reader.get_pointer_field(0))
           ))
         }
         15 => {
-          ::core::result::Result::Ok(Enum(
+          core::result::Result::Ok(Enum(
             self.reader.get_data_field::<u16>(1)
           ))
         }
         16 => {
-          ::core::result::Result::Ok(Struct(
-            ::capnp::any_pointer::Reader::new(self.reader.get_pointer_field(0))
+          core::result::Result::Ok(Struct(
+            capnp::any_pointer::Reader::new(self.reader.get_pointer_field(0))
           ))
         }
         17 => {
-          ::core::result::Result::Ok(Interface(
+          core::result::Result::Ok(Interface(
             ()
           ))
         }
         18 => {
-          ::core::result::Result::Ok(AnyPointer(
-            ::capnp::any_pointer::Reader::new(self.reader.get_pointer_field(0))
+          core::result::Result::Ok(AnyPointer(
+            capnp::any_pointer::Reader::new(self.reader.get_pointer_field(0))
           ))
         }
-        x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+        x => core::result::Result::Err(::capnp::NotInSchema(x))
       }
     }
   }
 
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 2, pointers: 1 };
+  pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+    const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 2, pointers: 1 };
   }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+  impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
       Builder { builder,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
       self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-      ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+  impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
     }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+    fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
     pub fn into_reader(self) -> Reader<'a,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
       Builder { .. *self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.builder.into_reader().total_size()
     }
     #[inline]
@@ -5592,12 +5592,12 @@ pub mod value {
       self.builder.set_data_field::<f64>(1, value);
     }
     #[inline]
-    pub fn set_text(&mut self, value: ::capnp::text::Reader<'_>)  {
+    pub fn set_text(&mut self, value: capnp::text::Reader<'_>)  {
       self.builder.set_data_field::<u16>(0, 12);
       self.builder.get_pointer_field(0).set_text(value);
     }
     #[inline]
-    pub fn init_text(self, size: u32) -> ::capnp::text::Builder<'a> {
+    pub fn init_text(self, size: u32) -> capnp::text::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 12);
       self.builder.get_pointer_field(0).init_text(size)
     }
@@ -5607,12 +5607,12 @@ pub mod value {
       !self.builder.get_pointer_field(0).is_null()
     }
     #[inline]
-    pub fn set_data(&mut self, value: ::capnp::data::Reader<'_>)  {
+    pub fn set_data(&mut self, value: capnp::data::Reader<'_>)  {
       self.builder.set_data_field::<u16>(0, 13);
       self.builder.get_pointer_field(0).set_data(value);
     }
     #[inline]
-    pub fn init_data(self, size: u32) -> ::capnp::data::Builder<'a> {
+    pub fn init_data(self, size: u32) -> capnp::data::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 13);
       self.builder.get_pointer_field(0).init_data(size)
     }
@@ -5622,9 +5622,9 @@ pub mod value {
       !self.builder.get_pointer_field(0).is_null()
     }
     #[inline]
-    pub fn init_list(self, ) -> ::capnp::any_pointer::Builder<'a> {
+    pub fn init_list(self, ) -> capnp::any_pointer::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 14);
-      let mut result = ::capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0));
+      let mut result = capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0));
       result.clear();
       result
     }
@@ -5639,9 +5639,9 @@ pub mod value {
       self.builder.set_data_field::<u16>(1, value);
     }
     #[inline]
-    pub fn init_struct(self, ) -> ::capnp::any_pointer::Builder<'a> {
+    pub fn init_struct(self, ) -> capnp::any_pointer::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 16);
-      let mut result = ::capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0));
+      let mut result = capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0));
       result.clear();
       result
     }
@@ -5655,9 +5655,9 @@ pub mod value {
       self.builder.set_data_field::<u16>(0, 17);
     }
     #[inline]
-    pub fn init_any_pointer(self, ) -> ::capnp::any_pointer::Builder<'a> {
+    pub fn init_any_pointer(self, ) -> capnp::any_pointer::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 18);
-      let mut result = ::capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0));
+      let mut result = capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0));
       result.clear();
       result
     }
@@ -5667,111 +5667,111 @@ pub mod value {
       !self.builder.get_pointer_field(0).is_null()
     }
     #[inline]
-    pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
+    pub fn which(self) -> core::result::Result<WhichBuilder<'a,>, capnp::NotInSchema> {
       match self.builder.get_data_field::<u16>(0) {
         0 => {
-          ::core::result::Result::Ok(Void(
+          core::result::Result::Ok(Void(
             ()
           ))
         }
         1 => {
-          ::core::result::Result::Ok(Bool(
+          core::result::Result::Ok(Bool(
             self.builder.get_bool_field(16)
           ))
         }
         2 => {
-          ::core::result::Result::Ok(Int8(
+          core::result::Result::Ok(Int8(
             self.builder.get_data_field::<i8>(2)
           ))
         }
         3 => {
-          ::core::result::Result::Ok(Int16(
+          core::result::Result::Ok(Int16(
             self.builder.get_data_field::<i16>(1)
           ))
         }
         4 => {
-          ::core::result::Result::Ok(Int32(
+          core::result::Result::Ok(Int32(
             self.builder.get_data_field::<i32>(1)
           ))
         }
         5 => {
-          ::core::result::Result::Ok(Int64(
+          core::result::Result::Ok(Int64(
             self.builder.get_data_field::<i64>(1)
           ))
         }
         6 => {
-          ::core::result::Result::Ok(Uint8(
+          core::result::Result::Ok(Uint8(
             self.builder.get_data_field::<u8>(2)
           ))
         }
         7 => {
-          ::core::result::Result::Ok(Uint16(
+          core::result::Result::Ok(Uint16(
             self.builder.get_data_field::<u16>(1)
           ))
         }
         8 => {
-          ::core::result::Result::Ok(Uint32(
+          core::result::Result::Ok(Uint32(
             self.builder.get_data_field::<u32>(1)
           ))
         }
         9 => {
-          ::core::result::Result::Ok(Uint64(
+          core::result::Result::Ok(Uint64(
             self.builder.get_data_field::<u64>(1)
           ))
         }
         10 => {
-          ::core::result::Result::Ok(Float32(
+          core::result::Result::Ok(Float32(
             self.builder.get_data_field::<f32>(1)
           ))
         }
         11 => {
-          ::core::result::Result::Ok(Float64(
+          core::result::Result::Ok(Float64(
             self.builder.get_data_field::<f64>(1)
           ))
         }
         12 => {
-          ::core::result::Result::Ok(Text(
-            ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+          core::result::Result::Ok(Text(
+            capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
           ))
         }
         13 => {
-          ::core::result::Result::Ok(Data(
-            ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+          core::result::Result::Ok(Data(
+            capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
           ))
         }
         14 => {
-          ::core::result::Result::Ok(List(
-            ::capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0))
+          core::result::Result::Ok(List(
+            capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0))
           ))
         }
         15 => {
-          ::core::result::Result::Ok(Enum(
+          core::result::Result::Ok(Enum(
             self.builder.get_data_field::<u16>(1)
           ))
         }
         16 => {
-          ::core::result::Result::Ok(Struct(
-            ::capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0))
+          core::result::Result::Ok(Struct(
+            capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0))
           ))
         }
         17 => {
-          ::core::result::Result::Ok(Interface(
+          core::result::Result::Ok(Interface(
             ()
           ))
         }
         18 => {
-          ::core::result::Result::Ok(AnyPointer(
-            ::capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0))
+          core::result::Result::Ok(AnyPointer(
+            capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0))
           ))
         }
-        x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+        x => core::result::Result::Err(::capnp::NotInSchema(x))
       }
     }
   }
 
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+  pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+  impl capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
       Pipeline { _typeless: typeless,  }
     }
   }
@@ -5801,43 +5801,43 @@ pub mod value {
     Interface(()),
     AnyPointer(A4),
   }
-  pub type WhichReader<'a,> = Which<::capnp::Result<::capnp::text::Reader<'a>>,::capnp::Result<::capnp::data::Reader<'a>>,::capnp::any_pointer::Reader<'a>,::capnp::any_pointer::Reader<'a>,::capnp::any_pointer::Reader<'a>>;
-  pub type WhichBuilder<'a,> = Which<::capnp::Result<::capnp::text::Builder<'a>>,::capnp::Result<::capnp::data::Builder<'a>>,::capnp::any_pointer::Builder<'a>,::capnp::any_pointer::Builder<'a>,::capnp::any_pointer::Builder<'a>>;
+  pub type WhichReader<'a,> = Which<capnp::Result<capnp::text::Reader<'a>>,::capnp::Result<capnp::data::Reader<'a>>,::capnp::any_pointer::Reader<'a>,::capnp::any_pointer::Reader<'a>,::capnp::any_pointer::Reader<'a>>;
+  pub type WhichBuilder<'a,> = Which<capnp::Result<capnp::text::Builder<'a>>,::capnp::Result<capnp::data::Builder<'a>>,::capnp::any_pointer::Builder<'a>,::capnp::any_pointer::Builder<'a>,::capnp::any_pointer::Builder<'a>>;
 }
 
 pub mod annotation {
   #[derive(Copy, Clone)]
   pub struct Owned(());
-  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+  impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
   #[derive(Clone, Copy)]
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+  pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+  impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
       Reader { reader,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+  impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+  impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
       self.reader
     }
   }
 
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
       self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
     }
   }
@@ -5847,7 +5847,7 @@ pub mod annotation {
       Reader { .. *self }
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.reader.total_size()
     }
     #[inline]
@@ -5855,16 +5855,16 @@ pub mod annotation {
       self.reader.get_data_field::<u64>(0)
     }
     #[inline]
-    pub fn get_value(self) -> ::capnp::Result<crate::schema_capnp::value::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_value(self) -> capnp::Result<crate::schema_capnp::value::Reader<'a>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
     pub fn has_value(&self) -> bool {
       !self.reader.get_pointer_field(0).is_null()
     }
     #[inline]
-    pub fn get_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
+    pub fn get_brand(self) -> capnp::Result<crate::schema_capnp::brand::Reader<'a>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), core::option::Option::None)
     }
     #[inline]
     pub fn has_brand(&self) -> bool {
@@ -5872,50 +5872,50 @@ pub mod annotation {
     }
   }
 
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 2 };
+  pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+    const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 1, pointers: 2 };
   }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+  impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
       Builder { builder,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
       self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-      ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+  impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
     }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+    fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
     pub fn into_reader(self) -> Reader<'a,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
       Builder { .. *self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.builder.into_reader().total_size()
     }
     #[inline]
@@ -5927,32 +5927,32 @@ pub mod annotation {
       self.builder.set_data_field::<u64>(0, value);
     }
     #[inline]
-    pub fn get_value(self) -> ::capnp::Result<crate::schema_capnp::value::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_value(self) -> capnp::Result<crate::schema_capnp::value::Builder<'a>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
-    pub fn set_value(&mut self, value: crate::schema_capnp::value::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+    pub fn set_value(&mut self, value: crate::schema_capnp::value::Reader<'_>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
     }
     #[inline]
     pub fn init_value(self, ) -> crate::schema_capnp::value::Builder<'a> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
     }
     #[inline]
     pub fn has_value(&self) -> bool {
       !self.builder.get_pointer_field(0).is_null()
     }
     #[inline]
-    pub fn get_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
+    pub fn get_brand(self) -> capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), core::option::Option::None)
     }
     #[inline]
-    pub fn set_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+    pub fn set_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
     }
     #[inline]
     pub fn init_brand(self, ) -> crate::schema_capnp::brand::Builder<'a> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), 0)
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), 0)
     }
     #[inline]
     pub fn has_brand(&self) -> bool {
@@ -5960,18 +5960,18 @@ pub mod annotation {
     }
   }
 
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+  pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+  impl capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
       Pipeline { _typeless: typeless,  }
     }
   }
   impl Pipeline  {
     pub fn get_value(&self) -> crate::schema_capnp::value::Pipeline {
-      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
+      capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
     }
     pub fn get_brand(&self) -> crate::schema_capnp::brand::Pipeline {
-      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(1))
+      capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(1))
     }
   }
   mod _private {
@@ -5991,63 +5991,63 @@ pub enum ElementSize {
   Pointer = 6,
   InlineComposite = 7,
 }
-impl ::capnp::traits::FromU16 for ElementSize {
+impl capnp::traits::FromU16 for ElementSize {
   #[inline]
-  fn from_u16(value: u16) -> ::core::result::Result<ElementSize, ::capnp::NotInSchema> {
+  fn from_u16(value: u16) -> core::result::Result<ElementSize, capnp::NotInSchema> {
     match value {
-      0 => ::core::result::Result::Ok(ElementSize::Empty),
-      1 => ::core::result::Result::Ok(ElementSize::Bit),
-      2 => ::core::result::Result::Ok(ElementSize::Byte),
-      3 => ::core::result::Result::Ok(ElementSize::TwoBytes),
-      4 => ::core::result::Result::Ok(ElementSize::FourBytes),
-      5 => ::core::result::Result::Ok(ElementSize::EightBytes),
-      6 => ::core::result::Result::Ok(ElementSize::Pointer),
-      7 => ::core::result::Result::Ok(ElementSize::InlineComposite),
-      n => ::core::result::Result::Err(::capnp::NotInSchema(n)),
+      0 => core::result::Result::Ok(ElementSize::Empty),
+      1 => core::result::Result::Ok(ElementSize::Bit),
+      2 => core::result::Result::Ok(ElementSize::Byte),
+      3 => core::result::Result::Ok(ElementSize::TwoBytes),
+      4 => core::result::Result::Ok(ElementSize::FourBytes),
+      5 => core::result::Result::Ok(ElementSize::EightBytes),
+      6 => core::result::Result::Ok(ElementSize::Pointer),
+      7 => core::result::Result::Ok(ElementSize::InlineComposite),
+      n => core::result::Result::Err(::capnp::NotInSchema(n)),
     }
   }
 }
-impl ::capnp::traits::ToU16 for ElementSize {
+impl capnp::traits::ToU16 for ElementSize {
   #[inline]
   fn to_u16(self) -> u16 { self as u16 }
 }
-impl ::capnp::traits::HasTypeId for ElementSize {
+impl capnp::traits::HasTypeId for ElementSize {
   const TYPE_ID: u64 = 0xd195_8f7d_ba52_1926u64;
 }
 
 pub mod capnp_version {
   #[derive(Copy, Clone)]
   pub struct Owned(());
-  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+  impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
   #[derive(Clone, Copy)]
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+  pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+  impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
       Reader { reader,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+  impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+  impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
       self.reader
     }
   }
 
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
       self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
     }
   }
@@ -6057,7 +6057,7 @@ pub mod capnp_version {
       Reader { .. *self }
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.reader.total_size()
     }
     #[inline]
@@ -6074,50 +6074,50 @@ pub mod capnp_version {
     }
   }
 
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 0 };
+  pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+    const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 1, pointers: 0 };
   }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+  impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
       Builder { builder,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
       self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-      ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+  impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
     }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+    fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
     pub fn into_reader(self) -> Reader<'a,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
       Builder { .. *self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.builder.into_reader().total_size()
     }
     #[inline]
@@ -6146,9 +6146,9 @@ pub mod capnp_version {
     }
   }
 
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+  pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+  impl capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
       Pipeline { _typeless: typeless,  }
     }
   }
@@ -6162,36 +6162,36 @@ pub mod capnp_version {
 pub mod code_generator_request {
   #[derive(Copy, Clone)]
   pub struct Owned(());
-  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+  impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
   #[derive(Clone, Copy)]
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+  pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+  impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
       Reader { reader,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+  impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+  impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
       self.reader
     }
   }
 
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
       self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
     }
   }
@@ -6201,36 +6201,36 @@ pub mod code_generator_request {
       Reader { .. *self }
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.reader.total_size()
     }
     #[inline]
-    pub fn get_nodes(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::node::Owned>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_nodes(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::node::Owned>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
     pub fn has_nodes(&self) -> bool {
       !self.reader.get_pointer_field(0).is_null()
     }
     #[inline]
-    pub fn get_requested_files(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::code_generator_request::requested_file::Owned>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
+    pub fn get_requested_files(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::code_generator_request::requested_file::Owned>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), core::option::Option::None)
     }
     #[inline]
     pub fn has_requested_files(&self) -> bool {
       !self.reader.get_pointer_field(1).is_null()
     }
     #[inline]
-    pub fn get_capnp_version(self) -> ::capnp::Result<crate::schema_capnp::capnp_version::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::core::option::Option::None)
+    pub fn get_capnp_version(self) -> capnp::Result<crate::schema_capnp::capnp_version::Reader<'a>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), core::option::Option::None)
     }
     #[inline]
     pub fn has_capnp_version(&self) -> bool {
       !self.reader.get_pointer_field(2).is_null()
     }
     #[inline]
-    pub fn get_source_info(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::node::source_info::Owned>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::core::option::Option::None)
+    pub fn get_source_info(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::node::source_info::Owned>> {
+      capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), core::option::Option::None)
     }
     #[inline]
     pub fn has_source_info(&self) -> bool {
@@ -6238,111 +6238,111 @@ pub mod code_generator_request {
     }
   }
 
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 4 };
+  pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+    const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 0, pointers: 4 };
   }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+  impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
   }
-  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+  impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
       Builder { builder,  }
     }
   }
 
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+  impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
       self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
     }
   }
 
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-      ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+  impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
     }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+    fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+      core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
     }
   }
 
-  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
     pub fn into_reader(self) -> Reader<'a,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
       Builder { .. *self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+    pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
       self.builder.into_reader().total_size()
     }
     #[inline]
-    pub fn get_nodes(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::node::Owned>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+    pub fn get_nodes(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::node::Owned>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
     }
     #[inline]
-    pub fn set_nodes(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::node::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+    pub fn set_nodes(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::node::Owned>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
     }
     #[inline]
-    pub fn init_nodes(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::node::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), size)
+    pub fn init_nodes(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::node::Owned> {
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), size)
     }
     #[inline]
     pub fn has_nodes(&self) -> bool {
       !self.builder.get_pointer_field(0).is_null()
     }
     #[inline]
-    pub fn get_requested_files(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::code_generator_request::requested_file::Owned>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
+    pub fn get_requested_files(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::code_generator_request::requested_file::Owned>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), core::option::Option::None)
     }
     #[inline]
-    pub fn set_requested_files(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::code_generator_request::requested_file::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+    pub fn set_requested_files(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::code_generator_request::requested_file::Owned>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
     }
     #[inline]
-    pub fn init_requested_files(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::code_generator_request::requested_file::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), size)
+    pub fn init_requested_files(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::code_generator_request::requested_file::Owned> {
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), size)
     }
     #[inline]
     pub fn has_requested_files(&self) -> bool {
       !self.builder.get_pointer_field(1).is_null()
     }
     #[inline]
-    pub fn get_capnp_version(self) -> ::capnp::Result<crate::schema_capnp::capnp_version::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
+    pub fn get_capnp_version(self) -> capnp::Result<crate::schema_capnp::capnp_version::Builder<'a>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), core::option::Option::None)
     }
     #[inline]
-    pub fn set_capnp_version(&mut self, value: crate::schema_capnp::capnp_version::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
+    pub fn set_capnp_version(&mut self, value: crate::schema_capnp::capnp_version::Reader<'_>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
     }
     #[inline]
     pub fn init_capnp_version(self, ) -> crate::schema_capnp::capnp_version::Builder<'a> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
     }
     #[inline]
     pub fn has_capnp_version(&self) -> bool {
       !self.builder.get_pointer_field(2).is_null()
     }
     #[inline]
-    pub fn get_source_info(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::node::source_info::Owned>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
+    pub fn get_source_info(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::node::source_info::Owned>> {
+      capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), core::option::Option::None)
     }
     #[inline]
-    pub fn set_source_info(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::node::source_info::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+    pub fn set_source_info(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::node::source_info::Owned>) -> capnp::Result<()> {
+      capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
     }
     #[inline]
-    pub fn init_source_info(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::node::source_info::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), size)
+    pub fn init_source_info(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::node::source_info::Owned> {
+      capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), size)
     }
     #[inline]
     pub fn has_source_info(&self) -> bool {
@@ -6350,15 +6350,15 @@ pub mod code_generator_request {
     }
   }
 
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+  pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+  impl capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
       Pipeline { _typeless: typeless,  }
     }
   }
   impl Pipeline  {
     pub fn get_capnp_version(&self) -> crate::schema_capnp::capnp_version::Pipeline {
-      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
+      capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
     }
   }
   mod _private {
@@ -6368,36 +6368,36 @@ pub mod code_generator_request {
   pub mod requested_file {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+    impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
         Reader { reader,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+    impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
         self.reader
       }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
         self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
       }
     }
@@ -6407,7 +6407,7 @@ pub mod code_generator_request {
         Reader { .. *self }
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.reader.total_size()
       }
       #[inline]
@@ -6415,16 +6415,16 @@ pub mod code_generator_request {
         self.reader.get_data_field::<u64>(0)
       }
       #[inline]
-      pub fn get_filename(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_filename(self) -> capnp::Result<capnp::text::Reader<'a>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
       pub fn has_filename(&self) -> bool {
         !self.reader.get_pointer_field(0).is_null()
       }
       #[inline]
-      pub fn get_imports(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::code_generator_request::requested_file::import::Owned>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
+      pub fn get_imports(self) -> capnp::Result<capnp::struct_list::Reader<'a,crate::schema_capnp::code_generator_request::requested_file::import::Owned>> {
+        capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), core::option::Option::None)
       }
       #[inline]
       pub fn has_imports(&self) -> bool {
@@ -6432,50 +6432,50 @@ pub mod code_generator_request {
       }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 2 };
+    pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+      const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 1, pointers: 2 };
     }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+    impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
         Builder { builder,  }
       }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+    impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
         self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
       }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+    impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
       }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+      fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+        core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
       }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
       pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
         Builder { .. *self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
         self.builder.into_reader().total_size()
       }
       #[inline]
@@ -6487,15 +6487,15 @@ pub mod code_generator_request {
         self.builder.set_data_field::<u64>(0, value);
       }
       #[inline]
-      pub fn get_filename(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+      pub fn get_filename(self) -> capnp::Result<capnp::text::Builder<'a>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
       }
       #[inline]
-      pub fn set_filename(&mut self, value: ::capnp::text::Reader<'_>)  {
+      pub fn set_filename(&mut self, value: capnp::text::Reader<'_>)  {
         self.builder.get_pointer_field(0).set_text(value);
       }
       #[inline]
-      pub fn init_filename(self, size: u32) -> ::capnp::text::Builder<'a> {
+      pub fn init_filename(self, size: u32) -> capnp::text::Builder<'a> {
         self.builder.get_pointer_field(0).init_text(size)
       }
       #[inline]
@@ -6503,16 +6503,16 @@ pub mod code_generator_request {
         !self.builder.get_pointer_field(0).is_null()
       }
       #[inline]
-      pub fn get_imports(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::code_generator_request::requested_file::import::Owned>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
+      pub fn get_imports(self) -> capnp::Result<capnp::struct_list::Builder<'a,crate::schema_capnp::code_generator_request::requested_file::import::Owned>> {
+        capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), core::option::Option::None)
       }
       #[inline]
-      pub fn set_imports(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::code_generator_request::requested_file::import::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+      pub fn set_imports(&mut self, value: capnp::struct_list::Reader<'a,crate::schema_capnp::code_generator_request::requested_file::import::Owned>) -> capnp::Result<()> {
+        capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
       }
       #[inline]
-      pub fn init_imports(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::code_generator_request::requested_file::import::Owned> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), size)
+      pub fn init_imports(self, size: u32) -> capnp::struct_list::Builder<'a,crate::schema_capnp::code_generator_request::requested_file::import::Owned> {
+        capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), size)
       }
       #[inline]
       pub fn has_imports(&self) -> bool {
@@ -6520,9 +6520,9 @@ pub mod code_generator_request {
       }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+    pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+    impl capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
         Pipeline { _typeless: typeless,  }
       }
     }
@@ -6535,36 +6535,36 @@ pub mod code_generator_request {
     pub mod import {
       #[derive(Copy, Clone)]
       pub struct Owned(());
-      impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+      impl capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+      impl capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+      impl capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
 
       #[derive(Clone, Copy)]
-      pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+      pub struct Reader<'a> { reader: capnp::private::layout::StructReader<'a> }
 
-      impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+      impl <'a,> capnp::traits::HasTypeId for Reader<'a,>  {
         const TYPE_ID: u64 = _private::TYPE_ID;
       }
-      impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-        fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+      impl <'a,> capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+        fn new(reader: capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
           Reader { reader,  }
         }
       }
 
-      impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-          ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+      impl <'a,> capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Reader<'a,>> {
+          core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
         }
       }
 
-      impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+      impl <'a,> capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+        fn into_internal_struct_reader(self) -> capnp::private::layout::StructReader<'a> {
           self.reader
         }
       }
 
-      impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+      impl <'a,> capnp::traits::Imbue<'a> for Reader<'a,>  {
+        fn imbue(&mut self, cap_table: &'a capnp::private::layout::CapTable) {
           self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
         }
       }
@@ -6574,7 +6574,7 @@ pub mod code_generator_request {
           Reader { .. *self }
         }
 
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
           self.reader.total_size()
         }
         #[inline]
@@ -6582,8 +6582,8 @@ pub mod code_generator_request {
           self.reader.get_data_field::<u64>(0)
         }
         #[inline]
-        pub fn get_name(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-          ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+        pub fn get_name(self) -> capnp::Result<capnp::text::Reader<'a>> {
+          capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), core::option::Option::None)
         }
         #[inline]
         pub fn has_name(&self) -> bool {
@@ -6591,50 +6591,50 @@ pub mod code_generator_request {
         }
       }
 
-      pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-      impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-        const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 1 };
+      pub struct Builder<'a> { builder: capnp::private::layout::StructBuilder<'a> }
+      impl <'a,> capnp::traits::HasStructSize for Builder<'a,>  {
+        const STRUCT_SIZE: capnp::private::layout::StructSize = capnp::private::layout::StructSize { data: 1, pointers: 1 };
       }
-      impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+      impl <'a,> capnp::traits::HasTypeId for Builder<'a,>  {
         const TYPE_ID: u64 = _private::TYPE_ID;
       }
-      impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-        fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+      impl <'a,> capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+        fn new(builder: capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
           Builder { builder,  }
         }
       }
 
-      impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+      impl <'a,> capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+        fn imbue_mut(&mut self, cap_table: &'a mut capnp::private::layout::CapTable) {
           self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
         }
       }
 
-      impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-        fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-          ::capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE))
+      impl <'a,> capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+        fn init_pointer(builder: capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+          capnp::traits::FromStructBuilder::new(builder.init_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE))
         }
-        fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-          ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
+        fn get_from_pointer(builder: capnp::private::layout::PointerBuilder<'a>, default: core::option::Option<&'a [capnp::Word]>) -> capnp::Result<Builder<'a,>> {
+          core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(<Self as capnp::traits::HasStructSize>::STRUCT_SIZE, default)?))
         }
       }
 
-      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      impl <'a,> capnp::traits::SetPointerBuilder for Reader<'a,>  {
+        fn set_pointer_builder<'b>(pointer: capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
       }
 
       impl <'a,> Builder<'a,>  {
         pub fn into_reader(self) -> Reader<'a,> {
-          ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+          capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
         pub fn reborrow(&mut self) -> Builder<'_,> {
           Builder { .. *self }
         }
         pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+          capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
 
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        pub fn total_size(&self) -> capnp::Result<capnp::MessageSize> {
           self.builder.into_reader().total_size()
         }
         #[inline]
@@ -6646,15 +6646,15 @@ pub mod code_generator_request {
           self.builder.set_data_field::<u64>(0, value);
         }
         #[inline]
-        pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-          ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+        pub fn get_name(self) -> capnp::Result<capnp::text::Builder<'a>> {
+          capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), core::option::Option::None)
         }
         #[inline]
-        pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
+        pub fn set_name(&mut self, value: capnp::text::Reader<'_>)  {
           self.builder.get_pointer_field(0).set_text(value);
         }
         #[inline]
-        pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
+        pub fn init_name(self, size: u32) -> capnp::text::Builder<'a> {
           self.builder.get_pointer_field(0).init_text(size)
         }
         #[inline]
@@ -6663,9 +6663,9 @@ pub mod code_generator_request {
         }
       }
 
-      pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-      impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+      pub struct Pipeline { _typeless: capnp::any_pointer::Pipeline }
+      impl capnp::capability::FromTypelessPipeline for Pipeline {
+        fn new(typeless: capnp::any_pointer::Pipeline) -> Pipeline {
           Pipeline { _typeless: typeless,  }
         }
       }

--- a/capnpc/test-edition-2015/test.rs
+++ b/capnpc/test-edition-2015/test.rs
@@ -1,6 +1,3 @@
-extern crate core;
-extern crate capnp;
-
 pub mod test_capnp {
     include!(concat!(env!("OUT_DIR"), "/test_capnp.rs"));
 }

--- a/example/addressbook_send/addressbook_send.rs
+++ b/example/addressbook_send/addressbook_send.rs
@@ -19,9 +19,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-extern crate capnp;
-extern crate core;
-
 pub mod addressbook_capnp {
   include!(concat!(env!("OUT_DIR"), "/addressbook_capnp.rs"));
 }

--- a/example/addressbook_send/build.rs
+++ b/example/addressbook_send/build.rs
@@ -1,7 +1,5 @@
-extern crate capnpc;
-
 fn main() {
-    ::capnpc::CompilerCommand::new()
+    capnpc::CompilerCommand::new()
         .file("addressbook.capnp")
         .run()
         .expect("compiling schema");

--- a/example/wasm-hello-world/wasm-app/src/lib.rs
+++ b/example/wasm-hello-world/wasm-app/src/lib.rs
@@ -2,8 +2,6 @@
 
 #![feature(core_intrinsics, alloc_error_handler)]
 
-extern crate alloc;
-
 use alloc::alloc::{GlobalAlloc, Layout};
 use core::panic::PanicInfo;
 


### PR DESCRIPTION
I'll leave this as a draft. I don't *believe* these are required, but i'm not 100% sure there isn't some `no-std`/`alloc` weirdness