### PR TITLE
use lossless conversions where available

### DIFF
--- a/capnp-futures/src/serialize_packed.rs
+++ b/capnp-futures/src/serialize_packed.rs
@@ -135,9 +135,9 @@ impl <R> AsyncRead for PackedRead<R> where R: AsyncRead + Unpin {
                     while ii < outbuf.len() && bitnum < 8
                     {
                         let is_nonzero = (buf[0] & (1u8 << bitnum)) != 0;
-                        outbuf[ii] = buf[*buf_pos] & ((-(is_nonzero as i8)) as u8);
+                        outbuf[ii] = buf[*buf_pos] & ((-i8::from(is_nonzero)) as u8);
                         ii += 1;
-                        *buf_pos += is_nonzero as usize;
+                        *buf_pos += usize::from(is_nonzero);
                         bitnum += 1;
                     }
                     if bitnum == 8 {

--- a/capnp/src/private/arena.rs
+++ b/capnp/src/private/arena.rs
@@ -103,7 +103,7 @@ impl <S> ReaderArena for ReaderArenaImpl<S> where S: ReaderSegments {
         let (segment_start, segment_len) = self.get_segment(segment_id)?;
         let this_start: usize = segment_start as usize;
         let this_size: usize = segment_len as usize * BYTES_PER_WORD;
-        let offset: i64 = offset_in_words as i64 * BYTES_PER_WORD as i64;
+        let offset: i64 = i64::from(offset_in_words) * BYTES_PER_WORD as i64;
         let start_idx = start as usize;
         if start_idx < this_start || ((start_idx - this_start) as i64 + offset) as usize > this_size {
             Err(Error::failed(String::from("message contained out-of-bounds pointer")))
@@ -219,7 +219,7 @@ impl <A> ReaderArena for BuilderArenaImpl<A> where A: Allocator {
     }
 
     fn check_offset(&self, _segment_id: u32, start: *const u8, offset_in_words: i32) -> Result<*const u8> {
-        unsafe { Ok(start.offset((offset_in_words as i64 * BYTES_PER_WORD as i64) as isize)) }
+        unsafe { Ok(start.offset((i64::from(offset_in_words) * BYTES_PER_WORD as i64) as isize)) }
     }
 
     fn contains_interval(&self, _id: u32, _start: *const u8, _size: usize) -> Result<()> {

--- a/capnp/src/serialize_packed.rs
+++ b/capnp/src/serialize_packed.rs
@@ -129,9 +129,9 @@ impl <R> Read for PackedRead<R> where R: BufRead {
 
                     for n in 0..8 {
                         let is_nonzero = (tag & (1u8 << n)) != 0;
-                        *out = (*in_ptr) & ((-(is_nonzero as i8)) as u8);
+                        *out = (*in_ptr) & ((-i8::from(is_nonzero)) as u8);
                         out = out.offset(1);
-                        in_ptr = in_ptr.offset(is_nonzero as isize);
+                        in_ptr = in_ptr.offset(isize::from(is_nonzero));
                     }
                 }
                 if tag == 0 {
@@ -247,42 +247,42 @@ impl <W> Write for PackedWrite<W> where W: Write {
                 let tag_pos = buf_idx;
                 buf_idx += 1;
 
-                let bit0 = (*in_ptr != 0) as u8;
+                let bit0 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit0 as usize;
                 in_ptr = in_ptr.offset(1);
 
-                let bit1 = (*in_ptr != 0) as u8;
+                let bit1 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit1 as usize;
                 in_ptr = in_ptr.offset(1);
 
-                let bit2 = (*in_ptr != 0) as u8;
+                let bit2 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit2 as usize;
                 in_ptr = in_ptr.offset(1);
 
-                let bit3 = (*in_ptr != 0) as u8;
+                let bit3 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit3 as usize;
                 in_ptr = in_ptr.offset(1);
 
-                let bit4 = (*in_ptr != 0) as u8;
+                let bit4 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit4 as usize;
                 in_ptr = in_ptr.offset(1);
 
-                let bit5 = (*in_ptr != 0) as u8;
+                let bit5 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit5 as usize;
                 in_ptr = in_ptr.offset(1);
 
-                let bit6 = (*in_ptr != 0) as u8;
+                let bit6 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit6 as usize;
                 in_ptr = in_ptr.offset(1);
 
-                let bit7 = (*in_ptr != 0) as u8;
+                let bit7 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit7 as usize;
                 in_ptr = in_ptr.offset(1);
@@ -329,7 +329,7 @@ impl <W> Write for PackedWrite<W> where W: Write {
                         let mut c = 0;
 
                         for _ in 0..8 {
-                            c += (*in_ptr == 0) as u8;
+                            c += u8::from(*in_ptr == 0);
                             in_ptr = in_ptr.offset(1);
                         }
 

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1020,7 +1020,7 @@ fn used_params_of_type(gen: &GeneratorContext,
                 type_::any_pointer::Parameter(def) => {
                     let the_struct = &gen.node_map[&def.get_scope_id()];
                     let parameters = the_struct.get_parameters()?;
-                    let parameter = parameters.get(def.get_parameter_index() as u32);
+                    let parameter = parameters.get(u32::from(def.get_parameter_index()));
                     let parameter_name = parameter.get_name()?;
                     used_params.insert(parameter_name.to_string());
                 }
@@ -1313,7 +1313,7 @@ fn get_ty_params_of_brand(gen: &GeneratorContext,
     let mut result = String::new();
     for (scope_id, parameter_index) in acc.into_iter() {
         let node = gen.node_map[&scope_id];
-        let p = node.get_parameters()?.get(parameter_index as u32);
+        let p = node.get_parameters()?.get(u32::from(parameter_index));
         result.push_str(p.get_name()?);
         result.push_str(",");
     }
@@ -2146,7 +2146,7 @@ fn generate_node(gen: &GeneratorContext,
                         match node.which()? {
                             node::Enum(e) => {
                                 let enumerants = e.get_enumerants()?;
-                                if let Some(enumerant) = enumerants.try_get(v as u32) {
+                                if let Some(enumerant) = enumerants.try_get(u32::from(v)) {
                                     let variant =
                                         capitalize_first_letter(get_enumerant_name(enumerant)?);
                                     let type_string = typ.type_string(gen, Leaf::Owned)?;

--- a/capnpc/src/codegen_types.rs
+++ b/capnpc/src/codegen_types.rs
@@ -223,7 +223,7 @@ impl <'a> RustTypeInfo for type_::Reader<'a> {
                     type_::any_pointer::Parameter(def) => {
                         let the_struct = &gen.node_map[&def.get_scope_id()];
                         let parameters = the_struct.get_parameters()?;
-                        let parameter = parameters.get(def.get_parameter_index() as u32);
+                        let parameter = parameters.get(u32::from(def.get_parameter_index()));
                         let parameter_name = parameter.get_name()?;
                         match module {
                             Leaf::Owned => Ok(parameter_name.to_string()),


### PR DESCRIPTION
using lossless conversions instead of casts is preferred since if the type is later changed and the conversion becomes lossy, the compiler will catch this.