### PR TITLE
use 'cast'

### DIFF
--- a/capnp/src/lib.rs
+++ b/capnp/src/lib.rs
@@ -83,11 +83,11 @@ impl Word {
     }
 
     pub fn words_to_bytes(words: &[Word]) -> &[u8] {
-        unsafe { core::slice::from_raw_parts(words.as_ptr() as *const u8, words.len() * 8) }
+        unsafe { core::slice::from_raw_parts(words.as_ptr().cast(), words.len() * 8) }
     }
 
     pub fn words_to_bytes_mut(words: &mut [Word]) -> &mut [u8] {
-        unsafe { core::slice::from_raw_parts_mut(words.as_mut_ptr() as *mut u8, words.len() * 8) }
+        unsafe { core::slice::from_raw_parts_mut(words.as_mut_ptr().cast(), words.len() * 8) }
     }
 }
 

--- a/capnp/src/private/arena.rs
+++ b/capnp/src/private/arena.rs
@@ -217,7 +217,7 @@ where
             // No such borrow will be possible while `self` is still immutably borrowed from this method,
             // so returning this slice is safe.
             let slice = unsafe {
-                slice::from_raw_parts(seg.ptr as *const _, seg.allocated as usize * BYTES_PER_WORD)
+                slice::from_raw_parts(seg.ptr.cast(), seg.allocated as usize * BYTES_PER_WORD)
             };
             OutputSegments::SingleSegment([slice])
         } else {
@@ -225,10 +225,7 @@ where
             for seg in &reff.segments {
                 // See safety argument in above branch.
                 let slice = unsafe {
-                    slice::from_raw_parts(
-                        seg.ptr as *const _,
-                        seg.allocated as usize * BYTES_PER_WORD,
-                    )
+                    slice::from_raw_parts(seg.ptr.cast(), seg.allocated as usize * BYTES_PER_WORD)
                 };
                 v.push(slice);
             }

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -2718,7 +2718,7 @@ mod wire_helpers {
             WirePointerKind::List,
         )?;
 
-        Ok(data::reader_from_raw_parts(ptr as *const _, size))
+        Ok(data::reader_from_raw_parts(ptr.cast(), size))
     }
 }
 
@@ -2883,7 +2883,7 @@ impl<'a> PointerReader<'a> {
             arena: &NULL_ARENA,
             segment_id: 0,
             cap_table: CapTableReader::Plain(ptr::null()),
-            pointer: location as *const _,
+            pointer: location.cast(),
             nesting_limit: 0x7fffffff,
         }
     }
@@ -3050,7 +3050,7 @@ impl<'a> PointerReader<'a> {
                 let mut ptr_trunc = false;
                 let st = self.get_struct(None)?;
                 if st.get_data_section_size() == 0 && st.get_pointer_section_size() == 0 {
-                    Ok(self.pointer as *const _ == st.get_location())
+                    Ok(self.pointer.cast() == st.get_location())
                 } else {
                     let result =
                         st.is_canonical(read_head, read_head, &mut data_trunc, &mut ptr_trunc)?;
@@ -3080,7 +3080,7 @@ impl<'a> PointerBuilder<'a> {
             arena,
             cap_table: CapTableBuilder::Plain(ptr::null_mut()),
             segment_id,
-            pointer: location as *mut _,
+            pointer: location.cast(),
         }
     }
 
@@ -3124,7 +3124,7 @@ impl<'a> PointerBuilder<'a> {
     ) -> Result<ListBuilder<'a>> {
         let default_value: *const u8 = match default {
             None => core::ptr::null(),
-            Some(d) => d.as_ptr() as *const u8,
+            Some(d) => d.as_ptr().cast(),
         };
         unsafe {
             wire_helpers::get_writable_list_pointer(
@@ -3389,7 +3389,7 @@ impl<'a> StructReader<'a> {
             arena: self.arena,
             segment_id: self.segment_id,
             cap_table: self.cap_table,
-            ptr: self.pointers as *const _,
+            ptr: self.pointers.cast(),
             element_count: u32::from(self.pointer_count),
             element_size: ElementSize::Pointer,
             step: BITS_PER_WORD as BitCount32,
@@ -3577,7 +3577,7 @@ impl<'a> StructBuilder<'a> {
 
     #[inline]
     pub fn set_data_field<T: Primitive>(&self, offset: ElementCount, value: T) {
-        let ptr: *mut <T as Primitive>::Raw = self.data as *mut _;
+        let ptr: *mut <T as Primitive>::Raw = self.data.cast();
         unsafe { <T as Primitive>::set(&mut *ptr.add(offset), value) }
     }
 

--- a/capnp/src/private/layout_test.rs
+++ b/capnp/src/private/layout_test.rs
@@ -24,9 +24,7 @@
 use crate::private::layout::PointerReader;
 
 fn test_at_alignments(words: &[crate::Word], verify: &dyn Fn(PointerReader)) {
-    verify(PointerReader::get_root_unchecked(
-        words.as_ptr() as *const u8
-    ));
+    verify(PointerReader::get_root_unchecked(words.as_ptr().cast()));
 
     #[cfg(feature = "unaligned")]
     {

--- a/capnp/src/serialize_packed.rs
+++ b/capnp/src/serialize_packed.rs
@@ -339,8 +339,8 @@ where
                     //# consecutive zero words (not including the first
                     //# one).
 
-                    let mut in_word: *const [u8; 8] = in_ptr as *const [u8; 8];
-                    let mut limit: *const [u8; 8] = in_end as *const [u8; 8];
+                    let mut in_word: *const [u8; 8] = in_ptr.cast();
+                    let mut limit: *const [u8; 8] = in_end.cast();
                     if ptr_sub(limit, in_word) > 255 {
                         limit = in_word.offset(255);
                     }

--- a/capnp/src/serialize_packed.rs
+++ b/capnp/src/serialize_packed.rs
@@ -348,10 +348,9 @@ where
                         in_word = in_word.offset(1);
                     }
 
-                    *buf.get_unchecked_mut(buf_idx) =
-                        ptr_sub(in_word, in_ptr as *const [u8; 8]) as u8;
+                    *buf.get_unchecked_mut(buf_idx) = ptr_sub(in_word, in_ptr.cast()) as u8;
                     buf_idx += 1;
-                    in_ptr = in_word as *const u8;
+                    in_ptr = in_word.cast();
                 } else if tag == 0xff {
                     //# An all-nonzero word is followed by a count of
                     //# consecutive uncompressed words, followed by the


### PR DESCRIPTION
from the clippy docs - https://rust-lang.github.io/rust-clippy/master/#ptr_as_ptr

> Why is this bad?
> Though as casts between raw pointers is not terrible, pointer::cast is safer because it cannot accidentally change the pointer’s mutability nor cast the pointer to other types like usize.