### PR TITLE
re-add MessageSize::plus_eq and deprecate it

### DIFF
--- a/capnp/src/lib.rs
+++ b/capnp/src/lib.rs
@@ -123,6 +123,13 @@ impl core::ops::AddAssign for MessageSize {
     }
 }
 
+impl MessageSize {
+    #[deprecated(since = "0.15.1", note = "use += (AddAssign::add_assign()) instead")]
+    pub fn plus_eq(&mut self, other : MessageSize) {
+        self += other;
+    }
+}
+
 /// An enum value or union discriminant that was not found among those defined in a schema.
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub struct NotInSchema(pub u16);


### PR DESCRIPTION
AddAssign is to be preferred, but just removing `plus_eq` (as we did in #318) would be a breaking change. So instead we deprecate it.