### PR TITLE
use built-in 'Default' trait

### DIFF
--- a/capnp-futures/test/test.rs
+++ b/capnp-futures/test/test.rs
@@ -114,7 +114,7 @@ mod tests {
 
         let io = futures::future::join(done_reading, write_queue.map(|_| ()));
 
-        let mut m = capnp::message::Builder::new_default();
+        let mut m = capnp::message::Builder::default();
         populate_address_book(m.init_root());
 
         spawner.spawn_local(sender.send(m).map(|_| ())).unwrap();
@@ -153,7 +153,7 @@ mod tests {
 
     #[test]
     fn single_segment() {
-        fill_and_send_message(capnp::message::Builder::new_default());
+        fill_and_send_message(capnp::message::Builder::default());
     }
 
     #[test]
@@ -169,7 +169,7 @@ mod tests {
     fn static_lifetime_not_required_funcs() {
         let (mut write, mut read) = async_byte_channel::channel();
         let _ = serialize::try_read_message(&mut read, message::ReaderOptions::default());
-        let _ = serialize::write_message(&mut write, message::Builder::new_default());
+        let _ = serialize::write_message(&mut write, message::Builder::default());
     }
 
     #[test]

--- a/capnp-rpc/src/broken.rs
+++ b/capnp-rpc/src/broken.rs
@@ -59,7 +59,7 @@ impl Request {
     pub fn new(error: Error, _size_hint: Option<::capnp::MessageSize>) -> Self {
         Self {
             error,
-            message: ::capnp::message::Builder::new_default(),
+            message: ::capnp::message::Builder::default(),
             cap_table: Vec::new(),
         }
     }

--- a/capnp-rpc/src/local.rs
+++ b/capnp-rpc/src/local.rs
@@ -90,7 +90,7 @@ struct Results {
 impl Results {
     fn new(fulfiller: oneshot::Sender<Box<dyn ResultsDoneHook>>) -> Self {
         Self {
-            message: Some(::capnp::message::Builder::new_default()),
+            message: Some(::capnp::message::Builder::default()),
             cap_table: Vec::new(),
             results_done_fulfiller: Some(fulfiller),
         }
@@ -191,7 +191,7 @@ impl Request {
         client: Box<dyn ClientHook>,
     ) -> Self {
         Self {
-            message: message::Builder::new_default(),
+            message: message::Builder::default(),
             cap_table: Vec::new(),
             interface_id,
             method_id,

--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -2209,7 +2209,7 @@ where
                 }
                 _ => {
                     self.variant = Some(ResultsVariant::LocallyRedirected(
-                        ::capnp::message::Builder::new_default(),
+                        ::capnp::message::Builder::default(),
                         Vec::new(),
                     ));
                 }

--- a/capnp-rpc/src/twoparty.rs
+++ b/capnp-rpc/src/twoparty.rs
@@ -151,7 +151,7 @@ where
         _first_segment_word_size: u32,
     ) -> Box<dyn crate::OutgoingMessage> {
         Box::new(OutgoingMessage {
-            message: ::capnp::message::Builder::new_default(),
+            message: ::capnp::message::Builder::default(),
             sender: self.inner.borrow().sender.clone(),
         })
     }

--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -352,7 +352,7 @@ fn pipelining_return_null() {
 
 #[test]
 fn null_capability() {
-    let mut message = ::capnp::message::Builder::new_default();
+    let mut message = ::capnp::message::Builder::default();
     let root: crate::test_capnp::test_all_types::Builder = message.get_root().unwrap();
 
     // In capnproto-c++, this would return a BrokenCap. Here, it returns a decode error.

--- a/capnp/fuzz/fuzzers/test_all_types.rs
+++ b/capnp/fuzz/fuzzers/test_all_types.rs
@@ -129,7 +129,7 @@ fn try_go(mut data: &[u8]) -> ::capnp::Result<()> {
     root.total_size()?;
     traverse(root)?;
 
-    let mut message = message::Builder::new_default();
+    let mut message = message::Builder::default();
     message.set_root(root)?;
 
     assert_equal(

--- a/capnp/src/any_pointer.rs
+++ b/capnp/src/any_pointer.rs
@@ -292,7 +292,7 @@ impl<'a> From<Builder<'a>> for crate::dynamic_value::Builder<'a> {
 #[cfg(feature = "alloc")]
 #[test]
 fn init_clears_value() {
-    let mut message = crate::message::Builder::new_default();
+    let mut message = crate::message::Builder::default();
     {
         let root: crate::any_pointer::Builder = message.init_root();
         let mut list: crate::primitive_list::Builder<u16> = root.initn_as(10);

--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -51,7 +51,7 @@
 //! use capnp::message::{self, TypedBuilder, TypedReader};
 //!
 //! fn main() {
-//!     let mut builder = TypedBuilder::<simple_struct::Owned>::new_default();
+//!     let mut builder = TypedBuilder::<simple_struct::Owned>::default();
 //!     let mut builder_root = builder.init_root();
 //!     builder_root.set_x(10);
 //!     builder_root.set_y(20);
@@ -462,7 +462,7 @@ where
 
     pub fn get_root_as_reader<'a, T: FromPointerReader<'a>>(&'a self) -> Result<T> {
         if self.arena.is_empty() {
-            any_pointer::Reader::new(layout::PointerReader::new_default()).get_as()
+            any_pointer::Reader::new(layout::PointerReader::default()).get_as()
         } else {
             let (segment_start, _segment_len) = self.arena.get_segment(0)?;
             let pointer_reader = layout::PointerReader::get_root(
@@ -571,8 +571,19 @@ impl<T> TypedBuilder<T, HeapAllocator>
 where
     T: Owned,
 {
+    #[deprecated(since = "0.18.7", note = "use `TypedBuilder::default()`")]
     pub fn new_default() -> Self {
-        Self::new(Builder::new_default())
+        Self::default()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T> Default for TypedBuilder<T, HeapAllocator>
+where
+    T: Owned,
+{
+    fn default() -> Self {
+        Self::new(Builder::default())
     }
 }
 
@@ -764,7 +775,17 @@ fn test_allocate_max() {
 impl Builder<HeapAllocator> {
     /// Constructs a new `message::Builder<HeapAllocator>` whose first segment has length
     /// `SUGGESTED_FIRST_SEGMENT_WORDS`.
+    #[deprecated(since = "0.18.7", note = "use `Builder::default()`")]
     pub fn new_default() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl Default for Builder<HeapAllocator> {
+    /// Constructs a new `message::Builder<HeapAllocator>` whose first segment has length
+    /// `SUGGESTED_FIRST_SEGMENT_WORDS`.
+    fn default() -> Self {
         Self::new(HeapAllocator::new())
     }
 }

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -1348,7 +1348,7 @@ mod wire_helpers {
 
         if (*orig_ref).is_null() {
             if default_value.is_null() || (*(default_value as *const WirePointer)).is_null() {
-                return Ok(ListBuilder::new_default(arena));
+                return Ok(ListBuilder::new(arena));
             }
             let (new_orig_ref_target, new_orig_ref, new_orig_segment_id) = copy_message(
                 arena,
@@ -1478,7 +1478,7 @@ mod wire_helpers {
 
         if (*orig_ref).is_null() {
             if default_value.is_null() || (*(default_value as *const WirePointer)).is_null() {
-                return Ok(ListBuilder::new_default(arena));
+                return Ok(ListBuilder::new(arena));
             }
             let (new_orig_ref_target, new_orig_ref, new_orig_segment_id) = copy_message(
                 arena,
@@ -2352,9 +2352,9 @@ mod wire_helpers {
     ) -> Result<StructReader<'a>> {
         if (*reff).is_null() {
             match default {
-                None => return Ok(StructReader::new_default()),
+                None => return Ok(StructReader::default()),
                 Some(d) if (*(d.as_ptr() as *const WirePointer)).is_null() => {
-                    return Ok(StructReader::new_default())
+                    return Ok(StructReader::default())
                 }
                 Some(d) => {
                     reff = d.as_ptr() as *const _;
@@ -2440,7 +2440,7 @@ mod wire_helpers {
     ) -> Result<ListReader<'_>> {
         if (*reff).is_null() {
             if default_value.is_null() || (*(default_value as *const WirePointer)).is_null() {
-                return Ok(ListReader::new_default());
+                return Ok(ListReader::default());
             }
             reff = default_value as *const _;
             arena = &super::NULL_ARENA;
@@ -2842,15 +2842,22 @@ pub struct PointerReader<'a> {
     nesting_limit: i32,
 }
 
-impl<'a> PointerReader<'a> {
-    pub fn new_default<'b>() -> PointerReader<'b> {
-        PointerReader {
+impl<'a> Default for PointerReader<'a> {
+    fn default() -> Self {
+        Self {
             arena: &NULL_ARENA,
             segment_id: 0,
             cap_table: Default::default(),
             pointer: ptr::null(),
             nesting_limit: 0x7fffffff,
         }
+    }
+}
+
+impl<'a> PointerReader<'a> {
+    #[deprecated(since = "0.18.7", note = "use `PointerReader::default()`")]
+    pub fn new_default() -> Self {
+        Self::default()
     }
 
     pub fn get_root(
@@ -3375,9 +3382,9 @@ pub struct StructReader<'a> {
     nesting_limit: i32,
 }
 
-impl<'a> StructReader<'a> {
-    pub fn new_default<'b>() -> StructReader<'b> {
-        StructReader {
+impl<'a> Default for StructReader<'a> {
+    fn default() -> Self {
+        Self {
             arena: &NULL_ARENA,
             segment_id: 0,
             cap_table: Default::default(),
@@ -3387,6 +3394,13 @@ impl<'a> StructReader<'a> {
             pointer_count: 0,
             nesting_limit: 0x7fffffff,
         }
+    }
+}
+
+impl<'a> StructReader<'a> {
+    #[deprecated(since = "0.18.7", note = "use `StructReader::default()`")]
+    pub fn new_default() -> Self {
+        Self::default()
     }
 
     pub fn imbue(&mut self, cap_table: CapTableReader) {
@@ -3479,7 +3493,7 @@ impl<'a> StructReader<'a> {
                 nesting_limit: self.nesting_limit,
             }
         } else {
-            PointerReader::new_default()
+            PointerReader::default()
         }
     }
 
@@ -3786,9 +3800,9 @@ pub struct ListReader<'a> {
     element_size: ElementSize,
 }
 
-impl<'a> ListReader<'a> {
-    pub fn new_default<'b>() -> ListReader<'b> {
-        ListReader {
+impl<'a> Default for ListReader<'a> {
+    fn default() -> Self {
+        Self {
             arena: &NULL_ARENA,
             segment_id: 0,
             cap_table: Default::default(),
@@ -3800,6 +3814,13 @@ impl<'a> ListReader<'a> {
             struct_pointer_count: 0,
             nesting_limit: 0x7fffffff,
         }
+    }
+}
+
+impl<'a> ListReader<'a> {
+    #[deprecated(since = "0.18.7", note = "use `ListReader::default()`")]
+    pub fn new_default() -> Self {
+        Self::default()
     }
 
     pub fn imbue(&mut self, cap_table: CapTableReader) {
@@ -3996,8 +4017,14 @@ pub struct ListBuilder<'a> {
 
 impl<'a> ListBuilder<'a> {
     #[inline]
-    pub fn new_default(arena: &mut dyn BuilderArena) -> ListBuilder<'_> {
-        ListBuilder {
+    #[deprecated(since = "0.18.7", note = "use `ListBuilder::new()`")]
+    pub fn new_default(arena: &'a mut dyn BuilderArena) -> Self {
+        Self::new(arena)
+    }
+
+    #[inline]
+    pub fn new(arena: &'a mut dyn BuilderArena) -> Self {
+        Self {
             arena,
             segment_id: 0,
             cap_table: Default::default(),

--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -1073,7 +1073,7 @@ pub mod test {
     #[test]
     fn compute_serialized_size() {
         const LIST_LENGTH_IN_WORDS: u32 = 5;
-        let mut m = message::Builder::new_default();
+        let mut m = message::Builder::default();
         {
             let root: crate::any_pointer::Builder = m.init_root();
             let _list_builder: crate::primitive_list::Builder<u64> =

--- a/capnpc/test/dynamic.rs
+++ b/capnpc/test/dynamic.rs
@@ -5,7 +5,7 @@ use capnp::{dynamic_list, dynamic_struct, dynamic_value};
 
 #[test]
 fn test_dynamic_reader() {
-    let mut builder = message::Builder::new_default();
+    let mut builder = message::Builder::default();
     let root: test_all_types::Builder<'_> = builder.init_root();
     let mut root: dynamic_value::Builder<'_> = root.into();
 
@@ -18,7 +18,7 @@ fn test_dynamic_reader() {
 
 #[test]
 fn test_dynamic_builder() {
-    let mut builder = message::Builder::new_default();
+    let mut builder = message::Builder::default();
     let root: test_all_types::Builder<'_> = builder.init_root();
     let mut root: dynamic_value::Builder<'_> = root.into();
     test_util::dynamic_init_test_message(root.reborrow().downcast());
@@ -32,7 +32,7 @@ fn test_dynamic_builder() {
 fn test_defaults() {
     use crate::test_capnp::test_defaults;
 
-    let message = message::Builder::new_default();
+    let message = message::Builder::default();
     let test_defaults = message
         .get_root_as_reader::<test_defaults::Reader<'_>>()
         .expect("get_root_as_reader()");
@@ -44,7 +44,7 @@ fn test_defaults() {
 fn test_defaults_builder() {
     use crate::test_capnp::test_defaults;
 
-    let mut message = message::Builder::new_default();
+    let mut message = message::Builder::default();
     let test_defaults = message.get_root::<test_defaults::Builder<'_>>().unwrap();
     let root: dynamic_value::Builder<'_> = test_defaults.into();
     test_util::dynamic_check_test_message_builder(root.downcast());
@@ -54,7 +54,7 @@ fn test_defaults_builder() {
 fn test_unions() {
     use crate::test_capnp::test_union;
     use capnp::{dynamic_struct, dynamic_value};
-    let mut message = message::Builder::new_default();
+    let mut message = message::Builder::default();
     let mut root: test_union::Builder<'_> = message.init_root();
     root.reborrow().get_union0().set_u0f1s32(1234567);
     root.reborrow().get_union1().set_u1f1sp("foo");
@@ -150,7 +150,7 @@ fn test_unions() {
 fn test_generics() {
     use crate::test_capnp::{test_all_types, test_generics};
     use capnp::text;
-    let mut message = message::Builder::new_default();
+    let mut message = message::Builder::default();
     let root: test_generics::Builder<'_, test_all_types::Owned, text::Owned> = message.init_root();
 
     let root: dynamic_value::Builder<'_> = root.into();
@@ -179,7 +179,7 @@ fn test_generics() {
 #[test]
 fn test_generic_annotation() -> ::capnp::Result<()> {
     use crate::test_capnp::{test_generics, test_use_generics};
-    let mut message = message::Builder::new_default();
+    let mut message = message::Builder::default();
     let root: test_use_generics::Builder<'_> = message.init_root();
     let root: dynamic_value::Builder<'_> = root.into();
     let root: dynamic_struct::Builder<'_> = root.downcast();
@@ -198,7 +198,7 @@ fn test_generic_annotation() -> ::capnp::Result<()> {
 fn test_complex_list() {
     use crate::test_capnp::test_complex_list;
 
-    let mut message = message::Builder::new_default();
+    let mut message = message::Builder::default();
     let root = message.init_root::<test_complex_list::Builder<'_>>();
     let root: dynamic_value::Builder<'_> = root.into();
     let mut root: dynamic_struct::Builder<'_> = root.downcast();
@@ -237,7 +237,7 @@ fn test_complex_list() {
 #[test]
 fn test_stringify() {
     use crate::test_capnp::{test_all_types, TestEnum};
-    let mut message = message::Builder::new_default();
+    let mut message = message::Builder::default();
     let mut root: test_all_types::Builder<'_> = message.init_root();
     root.set_int8_field(3);
     root.set_enum_field(TestEnum::Bar);

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -340,7 +340,7 @@ mod tests {
     fn test_complex_list() {
         use crate::test_capnp::{test_complex_list, AnEnum};
 
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
 
         let mut test_complex_list = message.init_root::<test_complex_list::Builder<'_>>();
 
@@ -504,8 +504,8 @@ mod tests {
     fn test_list_list_set_elem() {
         use crate::test_capnp::test_complex_list;
 
-        let mut message1 = message::Builder::new_default();
-        let mut message2 = message::Builder::new_default();
+        let mut message1 = message::Builder::default();
+        let mut message2 = message::Builder::default();
 
         let mut test_complex_list1 = message1.init_root::<test_complex_list::Builder<'_>>();
         let mut test_complex_list2 = message2.init_root::<test_complex_list::Builder<'_>>();
@@ -538,7 +538,7 @@ mod tests {
         use crate::test_capnp::{test_defaults, TestEnum};
 
         {
-            let message = message::Builder::new_default();
+            let message = message::Builder::default();
             let test_defaults = message
                 .get_root_as_reader::<test_defaults::Reader<'_>>()
                 .expect("get_root_as_reader()");
@@ -546,13 +546,13 @@ mod tests {
         }
 
         {
-            let mut message = message::Builder::new_default();
+            let mut message = message::Builder::default();
             let test_defaults = message.init_root::<test_defaults::Builder<'_>>();
             CheckTestMessage::check_test_message(test_defaults);
         }
 
         {
-            let mut message = message::Builder::new_default();
+            let mut message = message::Builder::default();
             let mut test_defaults = message
                 .get_root::<test_defaults::Builder<'_>>()
                 .expect("get_root()");
@@ -615,7 +615,7 @@ mod tests {
     fn test_any_pointer() {
         use crate::test_capnp::{test_any_pointer, test_big_struct, test_empty_struct};
 
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         let mut test_any_pointer = message.init_root::<test_any_pointer::Builder<'_>>();
 
         test_any_pointer
@@ -654,7 +654,7 @@ mod tests {
         }
 
         {
-            let mut message = message::Builder::new_default();
+            let mut message = message::Builder::default();
             let mut test_big_struct = message.init_root::<test_big_struct::Builder<'_>>();
             test_big_struct.set_int32_field(-12345);
             test_any_pointer
@@ -664,7 +664,7 @@ mod tests {
         }
 
         fn _test_lifetimes(body: test_big_struct::Reader<'_>) {
-            let mut message = message::Builder::new_default();
+            let mut message = message::Builder::default();
             message.set_root(body).unwrap();
         }
     }
@@ -673,7 +673,7 @@ mod tests {
     fn test_writable_struct_pointer() {
         use crate::test_capnp::test_big_struct;
 
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         let mut big_struct = message.init_root::<test_big_struct::Builder<'_>>();
 
         let neg_seven: u64 = (-7i64) as u64;
@@ -715,7 +715,7 @@ mod tests {
                 .set_uint32_field(4294967265);
 
             // Alas, we need to make a copy to appease the reborrow checker.
-            let mut other_message = message::Builder::new_default();
+            let mut other_message = message::Builder::default();
             other_message
                 .set_root(
                     big_struct
@@ -770,8 +770,8 @@ mod tests {
     fn test_field_get_option() -> capnp::Result<()> {
         use crate::test_capnp::test_field_get_option as subject;
 
-        let mut message_set = message::Builder::new_default();
-        let mut message_unset = message::Builder::new_default();
+        let mut message_set = message::Builder::default();
+        let mut message_unset = message::Builder::default();
 
         let mut test_set = message_set.init_root::<subject::Builder<'_>>();
         let mut test_unset = message_unset.init_root::<subject::Builder<'_>>();
@@ -853,7 +853,7 @@ mod tests {
     fn test_generic_one_parameter() {
         use crate::test_capnp::brand_once;
 
-        let mut message_for_brand = message::Builder::new_default();
+        let mut message_for_brand = message::Builder::default();
         let mut branded = message_for_brand.init_root::<brand_once::Builder<'_>>();
         {
             let branded_field = branded.reborrow().init_branded_field();
@@ -878,7 +878,7 @@ mod tests {
     fn test_generic_two_parameter() {
         use crate::test_capnp::brand_twice;
 
-        let mut message_for_brand = message::Builder::new_default();
+        let mut message_for_brand = message::Builder::default();
         let mut branded = message_for_brand.init_root::<brand_twice::Builder<'_>>();
         {
             let mut baz = branded.reborrow().init_baz_field();
@@ -919,7 +919,7 @@ mod tests {
     fn test_generics() {
         use crate::test_capnp::{test_all_types, test_generics};
         use capnp::text;
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         let mut root: test_generics::Builder<'_, test_all_types::Owned, text::Owned> =
             message.init_root();
         init_test_message(root.reborrow().get_foo().unwrap());
@@ -953,7 +953,7 @@ mod tests {
     fn test_generic_union() {
         use crate::test_capnp::{test_all_types, test_generics_union};
         use capnp::primitive_list;
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         {
             let mut root: test_generics_union::Builder<
                 '_,
@@ -1001,7 +1001,7 @@ mod tests {
         use crate::test_capnp::{test_all_types, test_generics_groups};
         use capnp::primitive_list;
         {
-            let mut message = message::Builder::new_default();
+            let mut message = message::Builder::default();
             {
                 let mut root: test_generics_groups::Builder<
                     '_,
@@ -1027,7 +1027,7 @@ mod tests {
         }
 
         {
-            let mut message = message::Builder::new_default();
+            let mut message = message::Builder::default();
             {
                 let mut root: test_generics_groups::inner::Builder<
                     '_,
@@ -1065,7 +1065,7 @@ mod tests {
     fn test_union() {
         use crate::test_capnp::test_union;
 
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         let mut union_struct = message.init_root::<test_union::Builder<'_>>();
 
         union_struct.reborrow().get_union0().set_u0f0s0(());
@@ -1094,7 +1094,7 @@ mod tests {
         use crate::test_capnp::{test_union, test_union_defaults};
 
         {
-            let message = message::Builder::new_default();
+            let message = message::Builder::default();
             let reader = message
                 .get_root_as_reader::<test_union_defaults::Reader<'_>>()
                 .expect("get_root_as_reader()");
@@ -1198,8 +1198,8 @@ mod tests {
     fn test_set_root() {
         use crate::test_capnp::test_big_struct;
 
-        let mut message1 = message::Builder::new_default();
-        let mut message2 = message::Builder::new_default();
+        let mut message1 = message::Builder::default();
+        let mut message2 = message::Builder::default();
         let mut struct1 = message1.init_root::<test_big_struct::Builder<'_>>();
         struct1.set_uint8_field(3);
         message2.set_root(struct1.into_reader()).unwrap();
@@ -1212,7 +1212,7 @@ mod tests {
     fn upgrade_struct() {
         use crate::test_capnp::{test_new_version, test_old_version};
 
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         {
             let mut old_version = message.init_root::<test_old_version::Builder<'_>>();
             old_version.set_old1(123);
@@ -1256,7 +1256,7 @@ mod tests {
     fn upgraded_struct_read_as_old() {
         use crate::test_capnp::{test_new_version, test_old_version};
 
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         {
             let mut new_version = message.init_root::<test_new_version::Builder<'_>>();
             new_version.set_old1(123);
@@ -1288,7 +1288,7 @@ mod tests {
     fn upgrade_union() {
         use crate::test_capnp::{test_new_union_version, test_old_union_version};
         // This tests for a specific case that was broken originally.
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         {
             let mut old_version = message.init_root::<test_old_union_version::Builder<'_>>();
             old_version.set_b(123);
@@ -1310,7 +1310,7 @@ mod tests {
         use crate::test_capnp::{test_any_pointer, test_lists};
 
         {
-            let mut builder = message::Builder::new_default();
+            let mut builder = message::Builder::default();
             let mut root = builder.init_root::<test_any_pointer::Builder<'_>>();
             {
                 let mut list = root
@@ -1334,7 +1334,7 @@ mod tests {
         }
 
         {
-            let mut builder = message::Builder::new_default();
+            let mut builder = message::Builder::default();
             let mut root = builder.init_root::<test_any_pointer::Builder<'_>>();
             {
                 let mut list = root
@@ -1433,7 +1433,7 @@ mod tests {
         let segment0 = &segment0_outer[..7]; // everything except the trailing 3 words
 
         {
-            let mut message_builder = capnp::message::Builder::new_default();
+            let mut message_builder = capnp::message::Builder::default();
 
             let segment_array = &[capnp::Word::words_to_bytes(segment0)];
             let message_reader = message::Reader::new(
@@ -1458,7 +1458,7 @@ mod tests {
     fn all_types() {
         use crate::test_capnp::test_all_types;
 
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         init_test_message(message.init_root());
         let mut root = message.get_root::<test_all_types::Builder<'_>>().unwrap();
         CheckTestMessage::check_test_message(root.reborrow());
@@ -1483,11 +1483,11 @@ mod tests {
         use crate::test_capnp::test_all_types;
 
         {
-            let mut message = message::Builder::new_default();
+            let mut message = message::Builder::default();
 
             init_test_message(message.init_root::<test_all_types::Builder<'_>>());
 
-            let mut message2 = message::Builder::new_default();
+            let mut message2 = message::Builder::default();
             let mut all_types2 = message2.init_root::<test_all_types::Builder<'_>>();
 
             all_types2
@@ -1656,7 +1656,7 @@ mod tests {
             .get_root::<test_all_types::Reader<'_>>()
             .unwrap();
         assert!(reader.total_size().is_err());
-        let mut builder = ::capnp::message::Builder::new_default();
+        let mut builder = ::capnp::message::Builder::default();
         assert!(builder.set_root(reader).is_err());
     }
 
@@ -1664,7 +1664,7 @@ mod tests {
     fn text_builder_int_underflow() {
         use crate::test_capnp::test_any_pointer;
 
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         {
             let mut root = message.init_root::<test_any_pointer::Builder<'_>>();
             let _: ::capnp::data::Builder<'_> = root.reborrow().get_any_pointer_field().initn_as(0);
@@ -1709,7 +1709,7 @@ mod tests {
             assert!(result.is_err());
         }
 
-        let mut message_builder = message::Builder::new_default();
+        let mut message_builder = message::Builder::default();
         let builder_root =
             message_builder.init_root::<crate::test_capnp::test_any_pointer::Builder<'_>>();
         match builder_root.get_any_pointer_field().set_as(root) {
@@ -1729,7 +1729,7 @@ mod tests {
         let length: u32 = 1 << 27;
         let step_exponent = 18;
 
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         {
             let root: test_all_types::Builder<'_> = message.init_root();
             let mut list = root.init_u_int64_list(length);
@@ -1743,7 +1743,7 @@ mod tests {
             }
         }
 
-        let mut message2 = message::Builder::new_default();
+        let mut message2 = message::Builder::default();
         {
             let root: test_all_types::Reader<'_> = message.get_root_as_reader().unwrap();
             let mut root2: test_all_types::Builder<'_> = message2.init_root();
@@ -1772,7 +1772,7 @@ mod tests {
         let length: u32 = 1 << 27;
         let step_exponent = 18;
 
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         {
             let root: test_lists::Builder<'_> = message.init_root();
             let mut list = root.init_list64(length);
@@ -1802,7 +1802,7 @@ mod tests {
         let length: u32 = 1 << 27;
         let step_exponent = 18;
 
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         {
             let root: test_lists::Builder<'_> = message.init_root();
             let mut list = root.init_int32_list_list(length);
@@ -1832,7 +1832,7 @@ mod tests {
     fn traversal_limit_exceeded() {
         use crate::test_capnp::test_all_types;
 
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         init_test_message(message.init_root());
 
         let segments = message.get_segments_for_output();
@@ -1850,7 +1850,7 @@ mod tests {
     fn void_list_amplification() {
         use crate::test_capnp::{test_all_types, test_any_pointer};
 
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         {
             let root = message.init_root::<test_any_pointer::Builder<'_>>();
             let _: ::capnp::primitive_list::Builder<'_, ()> =
@@ -1873,7 +1873,7 @@ mod tests {
     fn empty_struct_list_amplification() {
         use crate::test_capnp::{test_all_types, test_any_pointer, test_empty_struct};
 
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         {
             let root = message.init_root::<test_any_pointer::Builder<'_>>();
             let _: ::capnp::struct_list::Builder<'_, test_empty_struct::Owned> =
@@ -1920,14 +1920,14 @@ mod tests {
             .unwrap();
         reader.total_size().unwrap();
 
-        let mut builder = ::capnp::message::Builder::new_default();
+        let mut builder = ::capnp::message::Builder::default();
         assert!(builder.set_root(reader).is_err()); // read limit exceeded
     }
 
     #[test]
     fn null_struct_fields() {
         use crate::test_capnp::test_all_types;
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         {
             let mut test = message.init_root::<test_all_types::Builder<'_>>();
             test.set_text_field("Hello");
@@ -1959,17 +1959,17 @@ mod tests {
     #[test]
     fn set_with_caveats() {
         use crate::test_capnp::test_all_types;
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         let root: test_all_types::Builder<'_> = message.init_root();
         let mut list = root.init_struct_list(2);
         {
-            let mut message1 = message::Builder::new_default();
+            let mut message1 = message::Builder::default();
             let mut root1: test_all_types::Builder<'_> = message1.init_root();
             root1.set_int8_field(11);
             list.set_with_caveats(0, root1.into_reader()).unwrap();
         }
         {
-            let mut message2 = message::Builder::new_default();
+            let mut message2 = message::Builder::default();
             let mut root2: test_all_types::Builder<'_> = message2.init_root();
             init_test_message(root2.reborrow());
             list.set_with_caveats(1, root2.into_reader()).unwrap();
@@ -1984,7 +1984,7 @@ mod tests {
     fn get_raw_struct_data() {
         use crate::test_capnp::test_all_types;
         use capnp::traits::HasStructSize;
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         let mut root: test_all_types::Builder<'_> = message.init_root();
         root.set_int8_field(3);
         root.set_int16_field(0x0abb);
@@ -2002,7 +2002,7 @@ mod tests {
     #[test]
     fn get_raw_list_data() {
         use crate::test_capnp::test_all_types;
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         let mut root: test_all_types::Builder<'_> = message.init_root();
         {
             let mut uint16_list = root.reborrow().init_u_int16_list(5);
@@ -2031,7 +2031,7 @@ mod tests {
     #[test]
     fn get_struct_pointer_section() {
         use crate::test_capnp::test_all_types;
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         let mut root: test_all_types::Builder<'_> = message.init_root();
         init_test_message(root.reborrow().init_struct_field());
         let pointers = ::capnp::raw::get_struct_pointer_section(root.into_reader());
@@ -2042,7 +2042,7 @@ mod tests {
     #[test]
     fn struct_list_iterator() {
         use crate::test_capnp::test_all_types;
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         {
             let root: test_all_types::Builder<'_> = message.init_root();
             let mut struct_list = root.init_struct_list(6);
@@ -2096,7 +2096,7 @@ mod tests {
     #[test]
     fn name_annotation() {
         use crate::test_capnp::renamed_struct;
-        let mut message = message::Builder::new_default();
+        let mut message = message::Builder::default();
         {
             let mut root: renamed_struct::Builder<'_> = message.init_root();
             root.set_good_field_name(true);
@@ -2126,7 +2126,7 @@ mod tests {
     fn test_typed_builder_reader() {
         use crate::test_capnp::test_all_types;
 
-        let mut typed_builder = TypedBuilder::<test_all_types::Owned>::new_default();
+        let mut typed_builder = TypedBuilder::<test_all_types::Owned>::default();
         init_test_message(typed_builder.init_root());
 
         CheckTestMessage::check_test_message(typed_builder.get_root().unwrap());
@@ -2145,7 +2145,7 @@ mod tests {
     fn test_slice_segments() {
         use crate::test_capnp::test_all_types;
 
-        let mut typed_builder = TypedBuilder::<test_all_types::Owned>::new_default();
+        let mut typed_builder = TypedBuilder::<test_all_types::Owned>::default();
         init_test_message(typed_builder.init_root());
 
         CheckTestMessage::check_test_message(typed_builder.get_root().unwrap());
@@ -2172,7 +2172,7 @@ mod tests {
     fn test_no_alloc_slice_segments() {
         use crate::test_capnp::test_all_types;
 
-        let mut typed_builder = TypedBuilder::<test_all_types::Owned>::new_default();
+        let mut typed_builder = TypedBuilder::<test_all_types::Owned>::default();
         init_test_message(typed_builder.init_root());
 
         CheckTestMessage::check_test_message(typed_builder.get_root().unwrap());
@@ -2199,7 +2199,7 @@ mod tests {
     fn test_read_message_no_alloc() {
         use crate::test_capnp::test_all_types;
 
-        let mut typed_builder = TypedBuilder::<test_all_types::Owned>::new_default();
+        let mut typed_builder = TypedBuilder::<test_all_types::Owned>::default();
         init_test_message(typed_builder.init_root());
 
         CheckTestMessage::check_test_message(typed_builder.get_root().unwrap());

--- a/example/addressbook/addressbook.rs
+++ b/example/addressbook/addressbook.rs
@@ -28,7 +28,7 @@ pub mod addressbook {
     use capnp::serialize_packed;
 
     pub fn write_address_book() -> ::capnp::Result<()> {
-        let mut message = ::capnp::message::Builder::new_default();
+        let mut message = ::capnp::message::Builder::default();
         {
             let address_book = message.init_root::<address_book::Builder>();
 

--- a/example/addressbook_send/addressbook_send.rs
+++ b/example/addressbook_send/addressbook_send.rs
@@ -32,7 +32,7 @@ pub mod addressbook {
     use capnp::message::{Builder, HeapAllocator, TypedBuilder, TypedReader};
 
     pub fn build_address_book() -> TypedReader<Builder<HeapAllocator>, address_book::Owned> {
-        let mut message = TypedBuilder::<address_book::Owned>::new_default();
+        let mut message = TypedBuilder::<address_book::Owned>::default();
         {
             let address_book = message.init_root();
 

--- a/example/fill_random_values/fill_addressbook.rs
+++ b/example/fill_random_values/fill_addressbook.rs
@@ -10,7 +10,7 @@ pub mod fill_capnp {
 }
 
 pub fn main() {
-    let mut message = ::capnp::message::Builder::new_default();
+    let mut message = ::capnp::message::Builder::default();
     let mut addressbook = message.init_root::<addressbook_capnp::address_book::Builder>();
 
     let mut filler = Filler::new(::rand::thread_rng(), 10);

--- a/example/fill_random_values/fill_shapes.rs
+++ b/example/fill_random_values/fill_shapes.rs
@@ -141,7 +141,7 @@ impl SvgBuilder {
 }
 
 pub fn main() {
-    let mut message = ::capnp::message::Builder::new_default();
+    let mut message = ::capnp::message::Builder::default();
     let mut canvas = message.init_root::<shapes_capnp::canvas::Builder>();
 
     let mut filler = Filler::new(::rand::thread_rng(), 10);

--- a/example/wasm-hello-world/src/main.rs
+++ b/example/wasm-hello-world/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let memory = instance.exports.get_memory("memory")?;
 
     let mut expected_total: i32 = 0;
-    let mut message = capnp::message::Builder::new_default();
+    let mut message = capnp::message::Builder::default();
     {
         let root: wasm_hello_world_capnp::foo::Builder = message.init_root();
         let mut numbers = root.init_numbers(10);


### PR DESCRIPTION
- use the built-in `Default` trait for constructing structs with no arguments
- use idiomatic `new` method for constructing structs with arguments