### PR TITLE
Ported reconnect API

### DIFF
--- a/capnp-rpc/src/lib.rs
+++ b/capnp-rpc/src/lib.rs
@@ -71,6 +71,8 @@ use std::task::{Context, Poll};
 pub use crate::rpc::Disconnector;
 use crate::task_set::TaskSet;
 
+pub use crate::reconnect::{lazy_auto_reconnect, auto_reconnect, SetTarget};
+
 /// Code generated from
 /// [rpc.capnp](https://github.com/sandstorm-io/capnproto/blob/master/c%2B%2B/src/capnp/rpc.capnp).
 pub mod rpc_capnp;
@@ -103,6 +105,7 @@ mod rpc;
 mod sender_queue;
 mod split;
 mod task_set;
+mod reconnect;
 pub mod twoparty;
 
 pub trait OutgoingMessage {

--- a/capnp-rpc/src/reconnect.rs
+++ b/capnp-rpc/src/reconnect.rs
@@ -1,0 +1,227 @@
+use std::cell::RefCell;
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use capnp::capability::{Promise, FromClientHook};
+use capnp::private::capability::{ClientHook, RequestHook};
+use futures::TryFutureExt;
+
+pub trait SetTarget<C> {
+    fn add_ref(&self) -> Box<dyn SetTarget<C>>;
+    fn set_target(&self, target: C);
+}
+
+impl<C> Clone for Box<dyn SetTarget<C>> {
+    fn clone(&self) -> Self {
+        self.add_ref()
+    }
+}
+
+struct ClientInner<F, C> {
+    connect: F,
+    current: Option<Box<dyn ClientHook>>,
+    generation: usize,
+    marker: PhantomData<C>,
+}
+
+impl<F, C> ClientInner<F, C>
+    where F: FnMut() -> capnp::Result<C>,
+          F: 'static,
+          C: FromClientHook,
+{
+    fn get_current(&mut self) -> Box<dyn ClientHook> {
+        if let Some(hook) = self.current.as_ref() {
+            hook.add_ref()
+        } else {
+            let hook = match (self.connect)() {
+                Ok(hook) => hook.into_client_hook(),
+                Err(err) => {
+                    crate::broken::new_cap(err)
+                }
+            };
+            self.current = Some(hook.add_ref());
+            hook
+        }
+    }
+}
+
+struct Client<F, C> {
+    inner: Rc<RefCell<ClientInner<F, C>>>,
+}
+
+impl<F, C> Client<F, C>
+    where F: FnMut() -> capnp::Result<C>,
+          F: 'static,
+          C: FromClientHook,
+          C: 'static,
+{
+    pub fn new(connect: F) -> Client<F, C> {
+        Client {
+            inner: Rc::new(RefCell::new(ClientInner {
+                connect,
+                generation: 0,
+                current: None,
+                marker: PhantomData,
+            }))
+        }
+    }
+
+    pub fn get_current(&self) -> Box<dyn ClientHook> {
+        self.inner.borrow_mut().get_current()
+    }
+
+    fn wrap<T: 'static>(&self, promise: Promise<T, capnp::Error>) -> Promise<T, capnp::Error>
+    {
+        let c = self.clone();
+        let generation = self.inner.borrow().generation;
+        Promise::from_future(promise.map_err(move |err| {
+            if err.kind == capnp::ErrorKind::Disconnected
+                && generation == c.inner.borrow().generation
+            {
+                let mut inner = c.inner.borrow_mut();
+                inner.generation = generation + 1;
+                match (inner.connect)() {
+                    Ok(hook) => {
+                        inner.current = Some(hook.into_client_hook())
+                    }
+                    Err(err) => inner.current = Some(crate::broken::new_cap(err)),
+                }
+            }
+            err
+        }))
+    }
+}
+
+impl<F: 'static, C> SetTarget<C> for Client<F, C>
+    where F: 'static,
+          C: FromClientHook,
+          C: 'static,
+{
+    fn add_ref(&self) -> Box<dyn SetTarget<C>> {
+        Box::new(self.clone())
+    }
+
+    fn set_target(&self, target: C) {
+        self.inner.borrow_mut().current = Some(target.into_client_hook());
+    }
+}
+
+impl<F, C> Clone for Client<F, C> {
+    fn clone(&self) -> Self {
+        Self { inner: self.inner.clone() }
+    }
+}
+
+impl<F, C> ClientHook for Client<F, C>
+    where F: FnMut() -> capnp::Result<C>,
+          F: 'static,
+          C: FromClientHook,
+          C: 'static,
+{
+    fn add_ref(&self) -> Box<dyn ClientHook> {
+        Box::new(self.clone())
+    }
+
+    fn new_call(&self,
+                interface_id: u64,
+                method_id: u16,
+                size_hint: Option<capnp::MessageSize>)
+                -> capnp::capability::Request<capnp::any_pointer::Owned, capnp::any_pointer::Owned>
+    {
+        let result = self.get_current().new_call(interface_id, method_id, size_hint);
+        let hook = Request::new(self.clone(), result.hook);
+        capnp::capability::Request::new(Box::new(hook))
+    }
+
+    fn call(&self, interface_id: u64, method_id: u16,
+            params: Box<dyn capnp::private::capability::ParamsHook>,
+            results: Box<dyn capnp::private::capability::ResultsHook>)
+            -> Promise<(), capnp::Error>
+    {
+        let result = self.get_current().call(interface_id, method_id, params, results);
+        self.wrap(result)
+    }
+
+    fn get_brand(&self) -> usize {
+        0
+    }
+
+    fn get_ptr(&self) -> usize {
+        (self.inner.as_ref()) as * const _ as usize
+    }
+
+    fn get_resolved(&self) -> Option<Box<dyn ClientHook>> {
+        None
+    }
+
+    fn when_more_resolved(&self) -> Option<Promise<Box<dyn ClientHook>, capnp::Error>> {
+        None
+    }
+
+    fn when_resolved(&self) -> Promise<(), capnp::Error> {
+        Promise::ok(())
+    }
+}
+
+struct Request<F, C> {
+    parent: Client<F, C>,
+    inner: Box<dyn RequestHook>,
+}
+
+impl<F, C> Request<F, C> {
+    fn new(parent: Client<F, C>, inner: Box<dyn RequestHook>) -> Request<F, C> {
+        Request { parent, inner }
+    }
+}
+
+impl<F, C> RequestHook for Request<F, C>
+    where F: FnMut() -> capnp::Result<C>,
+          F: 'static,
+          C: FromClientHook,
+          C: 'static,
+{
+    fn get(&mut self) -> capnp::any_pointer::Builder<'_> {
+        self.inner.get()
+    }
+
+    fn get_brand(&self) -> usize {
+        0
+    }
+
+    fn send(self: Box<Self>) -> capnp::capability::RemotePromise<capnp::any_pointer::Owned> {
+        let parent = self.parent;
+        let mut result = self.inner.send();
+        result.promise = parent.wrap(result.promise);
+        result
+    }
+
+    fn tail_send(self: Box<Self>)
+                 -> Option<(u32, Promise<(), capnp::Error>, Box<dyn capnp::private::capability::PipelineHook>)> {
+        todo!()
+    }
+}
+
+pub fn auto_reconnect<F, C>(mut connect: F) -> capnp::Result<(C, Box<dyn SetTarget<C>>)>
+    where F: FnMut() -> capnp::Result<C>,
+          F: 'static,
+          C: FromClientHook,
+          C: 'static,
+{
+    let current = connect()?;
+    let c = Client::new(connect);
+    c.set_target(current);
+    let hook : Box<dyn ClientHook> = Box::new(c.clone());
+    Ok((FromClientHook::new(hook), Box::new(c)))
+}
+
+
+pub fn lazy_auto_reconnect<F, C>(connect: F) -> (C, Box<dyn SetTarget<C>>)
+    where F: FnMut() -> capnp::Result<C>,
+          F: 'static,
+          C: FromClientHook,
+          C: 'static,
+{
+    let c : Client<F, C> = Client::new(connect);
+    let hook : Box<dyn ClientHook> = Box::new(c.clone());
+    (FromClientHook::new(hook), Box::new(c))
+}

--- a/capnp-rpc/test/reconnect_test.rs
+++ b/capnp-rpc/test/reconnect_test.rs
@@ -1,0 +1,337 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::future::Future;
+
+use capnp::Error;
+use capnp::capability::{Promise, Response};
+use capnp_rpc::{new_client, auto_reconnect, twoparty, RpcSystem, rpc_twoparty_capnp, new_promise_client, lazy_auto_reconnect, pry};
+use futures::FutureExt;
+use futures::channel::oneshot;
+use futures::executor::LocalPool;
+use futures::future::Shared;
+use futures::task::LocalSpawnExt;
+
+use crate::spawn;
+use crate::test_capnp::{test_interface, self};
+
+struct TestInterfaceInner {
+    error: Option<Error>,
+    generation: usize,
+    block: Option<Shared<Promise<(), capnp::Error>>>,
+}
+
+#[derive(Clone)]
+struct TestInterfaceImpl {
+    inner: Rc<RefCell<TestInterfaceInner>>
+}
+
+impl TestInterfaceImpl {
+    fn new(generation: usize) -> TestInterfaceImpl {
+        let inner = TestInterfaceInner {
+            generation,
+            error: None,
+            block: None,
+        };
+        TestInterfaceImpl { inner: Rc::new(RefCell::new(inner)) }
+    }
+
+    fn set_error(&self, err: capnp::Error) {
+        self.inner.borrow_mut().error = Some(err);
+    }
+
+    fn block(&self) -> oneshot::Sender<capnp::Result<()>> {
+        let (s, r) = oneshot::channel();
+        self.inner.borrow_mut().block = Some(
+            Promise::from_future(r.map(|ret| {
+                match ret {
+                    Ok(Ok(_)) => Ok(()),
+                    Ok(Err(err)) => Err(err),
+                    Err(_) => Err(capnp::Error::failed("dropped sender".into()))
+                }
+            })).shared());
+        s
+    }
+}
+
+impl test_interface::Server for TestInterfaceImpl {
+    fn foo(&mut self,
+        params: test_interface::FooParams,
+        mut results: test_interface::FooResults)
+        -> Promise<(), Error>
+    {
+        if let Some(err) = self.inner.borrow().error.as_ref() {
+            return Promise::err(err.clone());
+        }
+        let params = pry!(params.get());
+        let s = format!("{} {} {}", params.get_i(), params.get_j(), self.inner.borrow().generation);
+        {
+            let mut results = results.get();
+            results.set_x(&s);
+        }
+        if let Some(fut) = self.inner.borrow().block.as_ref() {
+            Promise::from_future(fut.clone())
+        } else {
+            Promise::ok(())
+        }
+    }
+}
+
+fn run_until<F>(pool: &mut LocalPool, fut: F) -> Result<String, Error>
+    where F: Future<Output=capnp::Result<Response<test_interface::foo_results::Owned>>>,
+{
+    match pool.run_until(fut) {
+        Ok(resp) => Ok(resp.get()?.get_x()?.to_string()),
+        Err(err) => Err(err)
+    }
+}
+
+macro_rules! assert_err {
+    ($e1:expr, $e2:expr) => {
+        let e1 = $e1;
+        let e2 = $e2;
+        assert_eq!(e1.kind, e2.kind);
+        if !e1.description.ends_with(&e2.description) {
+            assert_eq!(e1.description, e2.description);
+        }
+    };
+}
+
+fn test_promise(client: &test_interface::Client, i: u32, j: bool) -> Promise<Response<test_interface::foo_results::Owned>, Error> {
+    let mut req = client.foo_request();
+    req.get().set_i(i);
+    req.get().set_j(j);
+    req.send().promise
+}
+
+fn test(pool: &mut LocalPool, client: &test_interface::Client, i: u32, j: bool) -> Result<String, Error>
+{
+    let fut = test_promise(client, i, j);
+    run_until(pool, fut)
+}
+
+fn do_autoconnect_test<F>(pool: &mut LocalPool, wrap_client: F) -> capnp::Result<()>
+    where F: Fn(test_interface::Client) -> test_interface::Client
+{
+    let spawner = pool.spawner();
+
+    let (req3, fulfiller, promise1, promise2, promise4) = {
+        let connect_count = Rc::new(RefCell::new(0));
+        let current_server = Rc::new(RefCell::new(TestInterfaceImpl::new(0)));
+
+        let c_server = current_server.clone();
+        let (c, _s) = auto_reconnect(move || {
+            let generation = *connect_count.borrow();
+            {
+                *connect_count.borrow_mut() += 1;
+            }
+            let server = TestInterfaceImpl::new(generation);
+            *c_server.borrow_mut() = server.clone();
+            let client : test_interface::Client = new_client(server);
+            Ok(client)
+        })?;
+        let client = wrap_client(c);
+
+        assert_eq!(test(pool, &client, 123, true).unwrap(), "123 true 0");
+
+        current_server.borrow().set_error(capnp::Error::disconnected("test1 disconnect".into()));
+        assert_err!(test(pool, &client, 456, true).unwrap_err(), Error::disconnected("test1 disconnect".into()));
+
+        assert_eq!(test(pool, &client, 789, false).unwrap(), "789 false 1");
+        assert_eq!(test(pool, &client, 21, true).unwrap(), "21 true 1");
+
+        {
+            // We cause two disconnect promises to be thrown concurrently. This should only cause the
+            // reconnector to reconnect once, not twice.
+            let fulfiller = current_server.borrow().block();
+            let promise1 = test_promise(&client, 32, false);
+            let promise2 = test_promise(&client, 43, true);
+            let promise1 = Promise::from_future(spawner.spawn_local_with_handle(promise1).unwrap());
+            let promise2 = Promise::from_future(spawner.spawn_local_with_handle(promise2).unwrap());
+            pool.run_until_stalled();
+            fulfiller.send(Err(capnp::Error::disconnected("test2 disconnect".into()))).unwrap();
+            assert_err!(run_until(pool, promise1).expect_err("disconnect error"), capnp::Error::disconnected("test2 disconnect".into()));
+            assert_err!(run_until(pool, promise2).expect_err("disconnect error"), capnp::Error::disconnected("test2 disconnect".into()));
+        }
+
+        assert_eq!(test(pool, &client, 43, false).unwrap(), "43 false 2");
+
+        // Start a couple calls that will block at the server end, plus an unsent request.
+        let fulfiller = current_server.borrow().block();
+
+        let promise1 = test_promise(&client, 1212, true);
+        let promise2 = test_promise(&client, 3434, false);
+        let mut req3 = client.foo_request();
+        req3.get().set_i(5656);
+        req3.get().set_j(true);
+        let promise1 = Promise::from_future(spawner.spawn_local_with_handle(promise1).unwrap());
+        let promise2 = Promise::from_future(spawner.spawn_local_with_handle(promise2).unwrap());
+        pool.run_until_stalled();
+
+        // Now force a reconnect.
+        current_server.borrow().set_error(capnp::Error::disconnected("test3 disconnect".into()));
+
+        // Initiate a request that will fail with DISCONNECTED.
+        let promise4 = test_promise(&client, 7878, false);
+
+        // And throw away our capability entirely, just to make sure that anyone who needs it is holding
+        // onto their own ref.
+        //client = nullptr;
+        (req3, fulfiller, promise1, promise2, promise4)
+    };
+
+    // Everything we initiated should still finish.
+    assert_err!(run_until(pool, promise4).expect_err("disconnect error"), capnp::Error::disconnected("test3 disconnect".into()));
+
+    // Send the request which we created before the disconnect. There are two behaviors we accept
+    // as correct here: it may throw the disconnect exception, or it may automatically redirect to
+    // the newly-reconnected destination.
+    match run_until(pool, req3.send().promise) {
+        Ok(resp) => {
+            assert_eq!(resp, "5656 true 3");
+        },
+        Err(err) => {
+            assert_err!(err, capnp::Error::disconnected("test3 disconnect".into()));
+        }
+    }
+
+    //KJ_EXPECT(!promise1.poll(ws));
+    //KJ_EXPECT(!promise2.poll(ws));
+    fulfiller.send(Ok(())).unwrap();
+    assert_eq!(run_until(pool, promise1).unwrap(), "1212 true 2");
+    assert_eq!(run_until(pool, promise2).unwrap(), "3434 false 2");
+
+    Ok(())
+}
+
+
+/// autoReconnect() direct call (exercises newCall() / RequestHook)
+#[test]
+fn auto_reconnect_direct_call() {
+    let mut pool = LocalPool::new();
+
+    do_autoconnect_test(&mut pool, |c| c).unwrap();
+}
+
+#[derive(Clone)]
+struct Bootstrap(Rc<RefCell<Option<test_interface::Client>>>);
+
+impl Bootstrap {
+    fn new() -> Bootstrap {
+        Bootstrap(Rc::new(RefCell::new(None)))
+    }
+
+    fn set_interface(&self, client: test_interface::Client) {
+        *self.0.borrow_mut() = Some(client);
+    }
+}
+
+impl test_capnp::bootstrap::Server for Bootstrap {
+    fn test_interface(&mut self,
+        _params: test_capnp::bootstrap::TestInterfaceParams,
+        mut results: test_capnp::bootstrap::TestInterfaceResults)
+        -> Promise<(), Error>
+    {
+        if let Some(client) = self.0.borrow_mut().take() {
+            results.get().set_cap(client);
+            Promise::ok(())
+        } else {
+            Promise::err(Error::failed("No interface available".into()))
+        }
+    }
+}
+
+/// autoReconnect() through RPC (exercises call() / CallContextHook)
+#[test]
+fn auto_reconnect_rpc_call() {
+    let (client_writer, server_reader) = async_byte_channel::channel();
+    let (server_writer, client_reader) = async_byte_channel::channel();
+    let client_network =
+        Box::new(twoparty::VatNetwork::new(client_reader, client_writer,
+                                           rpc_twoparty_capnp::Side::Client,
+                                           Default::default()));
+
+    let mut client_rpc_system = RpcSystem::new(client_network, None);
+
+    let server_network =
+        Box::new(twoparty::VatNetwork::new(server_reader, server_writer,
+                                           rpc_twoparty_capnp::Side::Server,
+                                           Default::default()));
+
+    let b = Bootstrap::new();
+    let bootstrap: test_capnp::bootstrap::Client = capnp_rpc::new_client(b.clone());
+    let server_rpc_system = RpcSystem::new(server_network, Some(bootstrap.client));
+    let client: test_capnp::bootstrap::Client = client_rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
+    let disconnector: capnp_rpc::Disconnector<capnp_rpc::rpc_twoparty_capnp::Side> = client_rpc_system.get_disconnector();
+
+    let mut pool = LocalPool::new();
+    let mut spawner = pool.spawner();
+    spawn(&mut spawner, client_rpc_system);
+    spawn(&mut spawner, server_rpc_system);
+
+    do_autoconnect_test(&mut pool, |c| {
+        b.set_interface(c);
+        let req = client.test_interface_request();
+        new_promise_client(req.send().promise.map(|resp| {
+            match resp {
+                Ok(resp) => {
+                    Ok(resp.get()?.get_cap()?.client)
+                },
+                Err(err) => Err(err),
+            }
+        }))
+    }).unwrap();
+    pool.run_until(disconnector).unwrap();
+}
+
+/// lazyAutoReconnect() initialies lazily
+#[test]
+fn lazy_auto_reconnect_test() {
+    let mut pool = LocalPool::new();
+
+    let connect_count = Rc::new(RefCell::new(0));
+    let current_server = Rc::new(RefCell::new(TestInterfaceImpl::new(0)));
+
+    let c_server = current_server.clone();
+    let counter = connect_count.clone();
+    let (client, _s) = auto_reconnect(move || {
+        let generation = *counter.borrow();
+        {
+            *counter.borrow_mut() += 1;
+        }
+        let server = TestInterfaceImpl::new(generation);
+        *c_server.borrow_mut() = server.clone();
+        let client : test_interface::Client = new_client(server);
+        Ok(client)
+    }).unwrap();
+
+    assert_eq!(*connect_count.borrow(), 1);
+    assert_eq!(test(&mut pool, &client, 123, true).unwrap(), "123 true 0");
+    assert_eq!(*connect_count.borrow(), 1);
+
+    let c_server = current_server.clone();
+    let counter = connect_count.clone();
+    let (client, _s) = lazy_auto_reconnect(move || {
+        let generation = *counter.borrow();
+        {
+            *counter.borrow_mut() += 1;
+        }
+        let server = TestInterfaceImpl::new(generation);
+        *c_server.borrow_mut() = server.clone();
+        let client : test_interface::Client = new_client(server);
+        Ok(client)
+    });
+
+    assert_eq!(*connect_count.borrow(), 1);
+    assert_eq!(test(&mut pool, &client, 123, true).unwrap(), "123 true 1");
+    assert_eq!(*connect_count.borrow(), 2);
+    assert_eq!(test(&mut pool, &client, 234, false).unwrap(), "234 false 1");
+    assert_eq!(*connect_count.borrow(), 2);
+
+    current_server.borrow().set_error(Error::disconnected("test1 disconnect".into()));
+    assert_err!(test(&mut pool, &client, 345, true).unwrap_err(), Error::disconnected("test1 disconnect".into()));
+
+    // lazyAutoReconnect is only lazy on the first request, not on reconnects.
+    assert_eq!(*connect_count.borrow(), 3);
+    assert_eq!(test(&mut pool, &client, 456, false).unwrap(), "456 false 2");
+    assert_eq!(*connect_count.borrow(), 3);
+}

--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -34,6 +34,7 @@ pub mod test_capnp {
 
 pub mod impls;
 pub mod test_util;
+pub mod reconnect_test;
 
 fn canceled_to_error(_e: futures::channel::oneshot::Canceled) -> Error {
     Error::failed(format!("oneshot was canceled"))


### PR DESCRIPTION
This is more or less a straight port of the reconnect API from capnp-c++.

I say more or less because I also needed the `setTarget` functionality from `CapRedirector` in Sandstorm and so have included that as part of the API.

To keep the API consistent with the existing `new_client` and `new_promise_client` functions the `auto_reconnect` and `lazy_auto_reconnect` functions work with generic clients that implement `FromClientHook`.