### PR TITLE
Specify the minimum supported Rust version for capnp crate

### DIFF
--- a/capnp/Cargo.toml
+++ b/capnp/Cargo.toml
@@ -8,6 +8,7 @@ description = "runtime library for Cap'n Proto data encoding"
 repository = "https://github.com/capnproto/capnproto-rust"
 documentation = "https://docs.capnproto-rust.org/capnp/"
 edition = "2021"
+rust-version = "1.65.0"
 
 readme = "README.md"
 


### PR DESCRIPTION
The MSRV (minimum supported Rust version) is the earliest version capable of building a project. In the case of the capnp crate, the MSRV is 1.65.0, due to the use of GATs.

Having the MSRV in Cargo.toml helps display better error messages when the Rust version is too old to build a project. eg:
> error: package `capnp v0.15.0 (/Users/maxime/Code/capnproto-rust/capnp)`
> cannot be built because it requires rustc 1.65.0 or newer, while the
> currently active rustc version is 1.64.0

Without it, the error messages are more confusing.
> error[E0658]: generic associated types are unstable
>   --> capnp/src/traits.rs:73:5
>    |
> 73 |     type Builder<'a>: FromStructBuilder<'a> + HasStructSize;
>   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   |
>   = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information


Cargo.toml docs: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field


---

I'm only adding this to the `capnp` crate, as `capnpc`/`capnp-rpc`/`capnp-futures` all depend on it.