### PR TITLE
[RFC] Remove `RefCell` from builder arena

### DIFF
--- a/capnp-rpc/src/rpc_capnp.rs
+++ b/capnp-rpc/src/rpc_capnp.rs
@@ -227,7 +227,7 @@ pub mod message {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -235,19 +235,19 @@ pub mod message {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn set_unimplemented(&mut self, value: crate::rpc_capnp::message::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(0, 0);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_unimplemented(self, ) -> crate::rpc_capnp::message::Builder<'a> {
@@ -257,12 +257,12 @@ pub mod message {
     #[inline]
     pub fn has_unimplemented(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 0 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_abort(&mut self, value: crate::rpc_capnp::exception::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(0, 1);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_abort(self, ) -> crate::rpc_capnp::exception::Builder<'a> {
@@ -272,12 +272,12 @@ pub mod message {
     #[inline]
     pub fn has_abort(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 1 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_call(&mut self, value: crate::rpc_capnp::call::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(0, 2);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_call(self, ) -> crate::rpc_capnp::call::Builder<'a> {
@@ -287,12 +287,12 @@ pub mod message {
     #[inline]
     pub fn has_call(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 2 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_return(&mut self, value: crate::rpc_capnp::return_::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(0, 3);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_return(self, ) -> crate::rpc_capnp::return_::Builder<'a> {
@@ -302,12 +302,12 @@ pub mod message {
     #[inline]
     pub fn has_return(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 3 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_finish(&mut self, value: crate::rpc_capnp::finish::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(0, 4);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_finish(self, ) -> crate::rpc_capnp::finish::Builder<'a> {
@@ -317,12 +317,12 @@ pub mod message {
     #[inline]
     pub fn has_finish(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 4 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_resolve(&mut self, value: crate::rpc_capnp::resolve::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(0, 5);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_resolve(self, ) -> crate::rpc_capnp::resolve::Builder<'a> {
@@ -332,12 +332,12 @@ pub mod message {
     #[inline]
     pub fn has_resolve(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 5 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_release(&mut self, value: crate::rpc_capnp::release::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(0, 6);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_release(self, ) -> crate::rpc_capnp::release::Builder<'a> {
@@ -347,7 +347,7 @@ pub mod message {
     #[inline]
     pub fn has_release(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 6 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn init_obsolete_save(self, ) -> ::capnp::any_pointer::Builder<'a> {
@@ -359,12 +359,12 @@ pub mod message {
     #[inline]
     pub fn has_obsolete_save(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 7 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_bootstrap(&mut self, value: crate::rpc_capnp::bootstrap::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(0, 8);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_bootstrap(self, ) -> crate::rpc_capnp::bootstrap::Builder<'a> {
@@ -374,7 +374,7 @@ pub mod message {
     #[inline]
     pub fn has_bootstrap(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 8 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn init_obsolete_delete(self, ) -> ::capnp::any_pointer::Builder<'a> {
@@ -386,12 +386,12 @@ pub mod message {
     #[inline]
     pub fn has_obsolete_delete(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 9 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_provide(&mut self, value: crate::rpc_capnp::provide::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(0, 10);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_provide(self, ) -> crate::rpc_capnp::provide::Builder<'a> {
@@ -401,12 +401,12 @@ pub mod message {
     #[inline]
     pub fn has_provide(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 10 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_accept(&mut self, value: crate::rpc_capnp::accept::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(0, 11);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_accept(self, ) -> crate::rpc_capnp::accept::Builder<'a> {
@@ -416,12 +416,12 @@ pub mod message {
     #[inline]
     pub fn has_accept(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 11 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_join(&mut self, value: crate::rpc_capnp::join::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(0, 12);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_join(self, ) -> crate::rpc_capnp::join::Builder<'a> {
@@ -431,12 +431,12 @@ pub mod message {
     #[inline]
     pub fn has_join(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 12 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_disembargo(&mut self, value: crate::rpc_capnp::disembargo::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(0, 13);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_disembargo(self, ) -> crate::rpc_capnp::disembargo::Builder<'a> {
@@ -446,7 +446,7 @@ pub mod message {
     #[inline]
     pub fn has_disembargo(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 13 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
@@ -645,7 +645,7 @@ pub mod bootstrap {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -653,14 +653,14 @@ pub mod bootstrap {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_question_id(self) -> u32 {
@@ -682,7 +682,7 @@ pub mod bootstrap {
     }
     #[inline]
     pub fn has_deprecated_object_id(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
   }
 
@@ -814,7 +814,7 @@ pub mod call {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -822,14 +822,14 @@ pub mod call {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_question_id(self) -> u32 {
@@ -845,7 +845,7 @@ pub mod call {
     }
     #[inline]
     pub fn set_target(&mut self, value: crate::rpc_capnp::message_target::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_target(self, ) -> crate::rpc_capnp::message_target::Builder<'a> {
@@ -853,7 +853,7 @@ pub mod call {
     }
     #[inline]
     pub fn has_target(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn get_interface_id(self) -> u64 {
@@ -877,7 +877,7 @@ pub mod call {
     }
     #[inline]
     pub fn set_params(&mut self, value: crate::rpc_capnp::payload::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(1), value, false)
     }
     #[inline]
     pub fn init_params(self, ) -> crate::rpc_capnp::payload::Builder<'a> {
@@ -885,16 +885,16 @@ pub mod call {
     }
     #[inline]
     pub fn has_params(&self) -> bool {
-      !self.builder.get_pointer_field(1).is_null()
+      !self.builder.is_pointer_field_null(1)
     }
     #[inline]
     pub fn get_send_results_to(self) -> crate::rpc_capnp::call::send_results_to::Builder<'a> {
       ::capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_send_results_to(self, ) -> crate::rpc_capnp::call::send_results_to::Builder<'a> {
+    pub fn init_send_results_to(mut self, ) -> crate::rpc_capnp::call::send_results_to::Builder<'a> {
       self.builder.set_data_field::<u16>(3, 0);
-      self.builder.get_pointer_field(2).clear();
+      self.builder.get_pointer_field_mut(2).clear();
       ::capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
@@ -1032,7 +1032,7 @@ pub mod call {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -1040,14 +1040,14 @@ pub mod call {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn set_caller(&mut self, _value: ())  {
@@ -1067,7 +1067,7 @@ pub mod call {
       #[inline]
       pub fn has_third_party(&self) -> bool {
         if self.builder.get_data_field::<u16>(3) != 2 { return false; }
-        !self.builder.get_pointer_field(2).is_null()
+        !self.builder.is_pointer_field_null(2)
       }
       #[inline]
       pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
@@ -1250,7 +1250,7 @@ pub mod return_ {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -1258,14 +1258,14 @@ pub mod return_ {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_answer_id(self) -> u32 {
@@ -1286,7 +1286,7 @@ pub mod return_ {
     #[inline]
     pub fn set_results(&mut self, value: crate::rpc_capnp::payload::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(3, 0);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_results(self, ) -> crate::rpc_capnp::payload::Builder<'a> {
@@ -1296,12 +1296,12 @@ pub mod return_ {
     #[inline]
     pub fn has_results(&self) -> bool {
       if self.builder.get_data_field::<u16>(3) != 0 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_exception(&mut self, value: crate::rpc_capnp::exception::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(3, 1);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_exception(self, ) -> crate::rpc_capnp::exception::Builder<'a> {
@@ -1311,7 +1311,7 @@ pub mod return_ {
     #[inline]
     pub fn has_exception(&self) -> bool {
       if self.builder.get_data_field::<u16>(3) != 1 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_canceled(&mut self, _value: ())  {
@@ -1336,7 +1336,7 @@ pub mod return_ {
     #[inline]
     pub fn has_accept_from_third_party(&self) -> bool {
       if self.builder.get_data_field::<u16>(3) != 5 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
@@ -1483,7 +1483,7 @@ pub mod finish {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -1491,14 +1491,14 @@ pub mod finish {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_question_id(self) -> u32 {
@@ -1639,7 +1639,7 @@ pub mod resolve {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -1647,14 +1647,14 @@ pub mod resolve {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_promise_id(self) -> u32 {
@@ -1667,7 +1667,7 @@ pub mod resolve {
     #[inline]
     pub fn set_cap(&mut self, value: crate::rpc_capnp::cap_descriptor::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(2, 0);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_cap(self, ) -> crate::rpc_capnp::cap_descriptor::Builder<'a> {
@@ -1677,12 +1677,12 @@ pub mod resolve {
     #[inline]
     pub fn has_cap(&self) -> bool {
       if self.builder.get_data_field::<u16>(2) != 0 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_exception(&mut self, value: crate::rpc_capnp::exception::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(2, 1);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_exception(self, ) -> crate::rpc_capnp::exception::Builder<'a> {
@@ -1692,7 +1692,7 @@ pub mod resolve {
     #[inline]
     pub fn has_exception(&self) -> bool {
       if self.builder.get_data_field::<u16>(2) != 1 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
@@ -1815,7 +1815,7 @@ pub mod release {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -1823,14 +1823,14 @@ pub mod release {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_id(self) -> u32 {
@@ -1951,7 +1951,7 @@ pub mod disembargo {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -1959,14 +1959,14 @@ pub mod disembargo {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_target(self) -> ::capnp::Result<crate::rpc_capnp::message_target::Builder<'a>> {
@@ -1974,7 +1974,7 @@ pub mod disembargo {
     }
     #[inline]
     pub fn set_target(&mut self, value: crate::rpc_capnp::message_target::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_target(self, ) -> crate::rpc_capnp::message_target::Builder<'a> {
@@ -1982,7 +1982,7 @@ pub mod disembargo {
     }
     #[inline]
     pub fn has_target(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn get_context(self) -> crate::rpc_capnp::disembargo::context::Builder<'a> {
@@ -2118,7 +2118,7 @@ pub mod disembargo {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -2126,14 +2126,14 @@ pub mod disembargo {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn set_sender_loopback(&mut self, value: u32)  {
@@ -2300,7 +2300,7 @@ pub mod provide {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -2308,14 +2308,14 @@ pub mod provide {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_question_id(self) -> u32 {
@@ -2331,7 +2331,7 @@ pub mod provide {
     }
     #[inline]
     pub fn set_target(&mut self, value: crate::rpc_capnp::message_target::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_target(self, ) -> crate::rpc_capnp::message_target::Builder<'a> {
@@ -2339,7 +2339,7 @@ pub mod provide {
     }
     #[inline]
     pub fn has_target(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn get_recipient(self) -> ::capnp::any_pointer::Builder<'a> {
@@ -2353,7 +2353,7 @@ pub mod provide {
     }
     #[inline]
     pub fn has_recipient(&self) -> bool {
-      !self.builder.get_pointer_field(1).is_null()
+      !self.builder.is_pointer_field_null(1)
     }
   }
 
@@ -2468,7 +2468,7 @@ pub mod accept {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -2476,14 +2476,14 @@ pub mod accept {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_question_id(self) -> u32 {
@@ -2505,7 +2505,7 @@ pub mod accept {
     }
     #[inline]
     pub fn has_provision(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn get_embargo(self) -> bool {
@@ -2629,7 +2629,7 @@ pub mod join {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -2637,14 +2637,14 @@ pub mod join {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_question_id(self) -> u32 {
@@ -2660,7 +2660,7 @@ pub mod join {
     }
     #[inline]
     pub fn set_target(&mut self, value: crate::rpc_capnp::message_target::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_target(self, ) -> crate::rpc_capnp::message_target::Builder<'a> {
@@ -2668,7 +2668,7 @@ pub mod join {
     }
     #[inline]
     pub fn has_target(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn get_key_part(self) -> ::capnp::any_pointer::Builder<'a> {
@@ -2682,7 +2682,7 @@ pub mod join {
     }
     #[inline]
     pub fn has_key_part(&self) -> bool {
-      !self.builder.get_pointer_field(1).is_null()
+      !self.builder.is_pointer_field_null(1)
     }
   }
 
@@ -2804,7 +2804,7 @@ pub mod message_target {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -2812,14 +2812,14 @@ pub mod message_target {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn set_imported_cap(&mut self, value: u32)  {
@@ -2829,7 +2829,7 @@ pub mod message_target {
     #[inline]
     pub fn set_promised_answer(&mut self, value: crate::rpc_capnp::promised_answer::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(2, 1);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_promised_answer(self, ) -> crate::rpc_capnp::promised_answer::Builder<'a> {
@@ -2839,7 +2839,7 @@ pub mod message_target {
     #[inline]
     pub fn has_promised_answer(&self) -> bool {
       if self.builder.get_data_field::<u16>(2) != 1 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
@@ -2970,7 +2970,7 @@ pub mod payload {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -2978,14 +2978,14 @@ pub mod payload {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_content(self) -> ::capnp::any_pointer::Builder<'a> {
@@ -2999,7 +2999,7 @@ pub mod payload {
     }
     #[inline]
     pub fn has_content(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn get_cap_table(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::rpc_capnp::cap_descriptor::Owned>> {
@@ -3007,7 +3007,7 @@ pub mod payload {
     }
     #[inline]
     pub fn set_cap_table(&mut self, value: ::capnp::struct_list::Reader<'a,crate::rpc_capnp::cap_descriptor::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(1), value, false)
     }
     #[inline]
     pub fn init_cap_table(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::rpc_capnp::cap_descriptor::Owned> {
@@ -3015,7 +3015,7 @@ pub mod payload {
     }
     #[inline]
     pub fn has_cap_table(&self) -> bool {
-      !self.builder.get_pointer_field(1).is_null()
+      !self.builder.is_pointer_field_null(1)
     }
   }
 
@@ -3163,7 +3163,7 @@ pub mod cap_descriptor {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -3171,14 +3171,14 @@ pub mod cap_descriptor {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn set_none(&mut self, _value: ())  {
@@ -3202,7 +3202,7 @@ pub mod cap_descriptor {
     #[inline]
     pub fn set_receiver_answer(&mut self, value: crate::rpc_capnp::promised_answer::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(0, 4);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_receiver_answer(self, ) -> crate::rpc_capnp::promised_answer::Builder<'a> {
@@ -3212,12 +3212,12 @@ pub mod cap_descriptor {
     #[inline]
     pub fn has_receiver_answer(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 4 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_third_party_hosted(&mut self, value: crate::rpc_capnp::third_party_cap_descriptor::Reader<'_>) -> ::capnp::Result<()> {
       self.builder.set_data_field::<u16>(0, 5);
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_third_party_hosted(self, ) -> crate::rpc_capnp::third_party_cap_descriptor::Builder<'a> {
@@ -3227,7 +3227,7 @@ pub mod cap_descriptor {
     #[inline]
     pub fn has_third_party_hosted(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 5 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn get_attached_fd(self) -> u8 {
@@ -3386,7 +3386,7 @@ pub mod promised_answer {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -3394,14 +3394,14 @@ pub mod promised_answer {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_question_id(self) -> u32 {
@@ -3417,7 +3417,7 @@ pub mod promised_answer {
     }
     #[inline]
     pub fn set_transform(&mut self, value: ::capnp::struct_list::Reader<'a,crate::rpc_capnp::promised_answer::op::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_transform(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::rpc_capnp::promised_answer::op::Owned> {
@@ -3425,7 +3425,7 @@ pub mod promised_answer {
     }
     #[inline]
     pub fn has_transform(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
   }
 
@@ -3535,7 +3535,7 @@ pub mod promised_answer {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -3543,14 +3543,14 @@ pub mod promised_answer {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn set_noop(&mut self, _value: ())  {
@@ -3687,7 +3687,7 @@ pub mod third_party_cap_descriptor {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -3695,14 +3695,14 @@ pub mod third_party_cap_descriptor {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_id(self) -> ::capnp::any_pointer::Builder<'a> {
@@ -3716,7 +3716,7 @@ pub mod third_party_cap_descriptor {
     }
     #[inline]
     pub fn has_id(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn get_vine_id(self) -> u32 {
@@ -3848,7 +3848,7 @@ pub mod exception {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -3856,14 +3856,14 @@ pub mod exception {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_reason(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
@@ -3871,7 +3871,7 @@ pub mod exception {
     }
     #[inline]
     pub fn set_reason(&mut self, value: ::capnp::text::Reader<'_>)  {
-      self.builder.get_pointer_field(0).set_text(value);
+      self.builder.get_pointer_field_mut(0).set_text(value);
     }
     #[inline]
     pub fn init_reason(self, size: u32) -> ::capnp::text::Builder<'a> {
@@ -3879,7 +3879,7 @@ pub mod exception {
     }
     #[inline]
     pub fn has_reason(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn get_obsolete_is_callers_fault(self) -> bool {
@@ -3911,7 +3911,7 @@ pub mod exception {
     }
     #[inline]
     pub fn set_trace(&mut self, value: ::capnp::text::Reader<'_>)  {
-      self.builder.get_pointer_field(1).set_text(value);
+      self.builder.get_pointer_field_mut(1).set_text(value);
     }
     #[inline]
     pub fn init_trace(self, size: u32) -> ::capnp::text::Builder<'a> {
@@ -3919,7 +3919,7 @@ pub mod exception {
     }
     #[inline]
     pub fn has_trace(&self) -> bool {
-      !self.builder.get_pointer_field(1).is_null()
+      !self.builder.is_pointer_field_null(1)
     }
   }
 

--- a/capnp-rpc/src/rpc_twoparty_capnp.rs
+++ b/capnp-rpc/src/rpc_twoparty_capnp.rs
@@ -107,7 +107,7 @@ pub mod vat_id {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -115,14 +115,14 @@ pub mod vat_id {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_side(self) -> ::core::result::Result<crate::rpc_twoparty_capnp::Side,::capnp::NotInSchema> {
@@ -227,7 +227,7 @@ pub mod provision_id {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -235,14 +235,14 @@ pub mod provision_id {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_join_id(self) -> u32 {
@@ -343,7 +343,7 @@ pub mod recipient_id {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -351,14 +351,14 @@ pub mod recipient_id {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
   }
 
@@ -451,7 +451,7 @@ pub mod third_party_cap_id {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -459,14 +459,14 @@ pub mod third_party_cap_id {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
   }
 
@@ -571,7 +571,7 @@ pub mod join_key_part {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -579,14 +579,14 @@ pub mod join_key_part {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_join_id(self) -> u32 {
@@ -719,7 +719,7 @@ pub mod join_result {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -727,14 +727,14 @@ pub mod join_result {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_join_id(self) -> u32 {
@@ -764,7 +764,7 @@ pub mod join_result {
     }
     #[inline]
     pub fn has_cap(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
   }
 

--- a/capnp/src/any_pointer.rs
+++ b/capnp/src/any_pointer.rs
@@ -139,7 +139,7 @@ impl<'a> Builder<'a> {
 
     /// Gets the total size of the target and all of its children. Does not count far pointer overhead.
     pub fn target_size(&self) -> Result<crate::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
     }
 
     pub fn get_as<T: FromPointerBuilder<'a>>(self) -> Result<T> {

--- a/capnp/src/any_pointer_list.rs
+++ b/capnp/src/any_pointer_list.rs
@@ -165,7 +165,7 @@ impl<'a> FromPointerBuilder<'a> for Builder<'a> {
 
 impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
     fn set_pointer_builder<'b>(
-        pointer: PointerBuilder<'b>,
+        mut pointer: PointerBuilder<'b>,
         value: Reader<'a>,
         canonicalize: bool,
     ) -> Result<()> {

--- a/capnp/src/capability_list.rs
+++ b/capnp/src/capability_list.rs
@@ -190,7 +190,7 @@ where
 {
     pub fn reborrow(&mut self) -> Builder<'_, T> {
         Builder {
-            builder: self.builder,
+            builder: self.builder.reborrow(),
             marker: PhantomData,
         }
     }
@@ -251,7 +251,7 @@ where
     T: FromClientHook,
 {
     fn set_pointer_builder<'b>(
-        pointer: crate::private::layout::PointerBuilder<'b>,
+        mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: Reader<'a, T>,
         canonicalize: bool,
     ) -> Result<()> {

--- a/capnp/src/data.rs
+++ b/capnp/src/data.rs
@@ -67,7 +67,7 @@ impl<'a> crate::traits::FromPointerBuilder<'a> for Builder<'a> {
 
 impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
     fn set_pointer_builder<'b>(
-        pointer: PointerBuilder<'b>,
+        mut pointer: PointerBuilder<'b>,
         value: Reader<'a>,
         _canonicalize: bool,
     ) -> Result<()> {

--- a/capnp/src/data_list.rs
+++ b/capnp/src/data_list.rs
@@ -175,7 +175,7 @@ impl<'a> Builder<'a> {
 
 impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
     fn set_pointer_builder<'b>(
-        pointer: crate::private::layout::PointerBuilder<'b>,
+        mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: Reader<'a>,
         canonicalize: bool,
     ) -> Result<()> {

--- a/capnp/src/enum_list.rs
+++ b/capnp/src/enum_list.rs
@@ -176,14 +176,17 @@ impl<'a, T: ToU16 + FromU16> Builder<'a, T> {
         }
     }
 
-    pub fn reborrow(&self) -> Builder<'_, T> {
-        Builder { ..*self }
+    pub fn reborrow(&mut self) -> Builder<'_, T> {
+        Builder {
+            builder: self.builder.reborrow(),
+            marker: PhantomData,
+        }
     }
 }
 
 impl<'a, T> crate::traits::SetPointerBuilder for Reader<'a, T> {
     fn set_pointer_builder<'b>(
-        pointer: crate::private::layout::PointerBuilder<'b>,
+        mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: Reader<'a, T>,
         canonicalize: bool,
     ) -> Result<()> {

--- a/capnp/src/list_list.rs
+++ b/capnp/src/list_list.rs
@@ -232,14 +232,14 @@ where
         }
     }
 
-    pub fn set<'b>(&self, index: u32, value: T::Reader<'a>) -> Result<()>
+    pub fn set<'b>(&mut self, index: u32, value: T::Reader<'a>) -> Result<()>
     where
         T::Reader<'a>: crate::traits::IntoInternalListReader<'b>,
     {
         use crate::traits::IntoInternalListReader;
         assert!(index < self.len());
         self.builder
-            .get_pointer_element(index)
+            .get_pointer_element_mut(index)
             .set_list(&value.into_internal_list_reader(), false)
     }
 }
@@ -249,7 +249,7 @@ where
     T: crate::traits::Owned,
 {
     fn set_pointer_builder<'b>(
-        pointer: crate::private::layout::PointerBuilder<'b>,
+        mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: Reader<'a, T>,
         canonicalize: bool,
     ) -> Result<()> {

--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -413,7 +413,6 @@ where
     fn get_root_internal(&mut self) -> any_pointer::Builder<'_> {
         if self.arena.is_empty() {
             self.arena.allocate_segment(1);
-            self.arena.allocate(0, 1).expect("allocate root pointer");
         }
         let (seg_start, _seg_len) = self.arena.get_segment_mut(0);
         let location: *mut u8 = seg_start;
@@ -462,7 +461,6 @@ where
     pub fn set_root_canonical<From: SetPointerBuilder>(&mut self, value: From) -> Result<()> {
         if self.arena.is_empty() {
             self.arena.allocate_segment(1);
-            self.arena.allocate(0, 1).expect("allocate root pointer");
         }
         let (seg_start, _seg_len) = self.arena.get_segment_mut(0);
         let pointer = layout::PointerBuilder::get_root(&self.arena, 0, seg_start);

--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -412,9 +412,7 @@ where
 
     fn get_root_internal(&mut self) -> any_pointer::Builder<'_> {
         if self.arena.is_empty() {
-            self.arena
-                .allocate_segment(1)
-                .expect("allocate root pointer");
+            self.arena.allocate_segment(1);
             self.arena.allocate(0, 1).expect("allocate root pointer");
         }
         let (seg_start, _seg_len) = self.arena.get_segment_mut(0);
@@ -463,9 +461,7 @@ where
     /// a single segment, containing the full canonicalized message.
     pub fn set_root_canonical<From: SetPointerBuilder>(&mut self, value: From) -> Result<()> {
         if self.arena.is_empty() {
-            self.arena
-                .allocate_segment(1)
-                .expect("allocate root pointer");
+            self.arena.allocate_segment(1);
             self.arena.allocate(0, 1).expect("allocate root pointer");
         }
         let (seg_start, _seg_len) = self.arena.get_segment_mut(0);

--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -463,7 +463,7 @@ where
             self.arena.allocate_segment(1);
         }
         let (seg_start, _seg_len) = self.arena.get_segment_mut(0);
-        let pointer = layout::PointerBuilder::get_root(&self.arena, 0, seg_start);
+        let pointer = layout::PointerBuilder::get_root(&mut self.arena, 0, seg_start);
         SetPointerBuilder::set_pointer_builder(pointer, value, true)?;
         assert_eq!(self.get_segments_for_output().len(), 1);
         Ok(())

--- a/capnp/src/private/arena.rs
+++ b/capnp/src/private/arena.rs
@@ -312,7 +312,7 @@ where
         self.segments.push(BuilderSegment {
             ptr: seg.0,
             capacity: seg.1,
-            allocated: 0,
+            allocated: minimum_size,
         });
     }
 
@@ -332,11 +332,7 @@ where
 
         let segment_id = self.segments.len() as u32;
         self.allocate_segment(amount);
-        (
-            segment_id,
-            self.allocate(segment_id, amount)
-                .expect("use freshly-allocated segment"),
-        )
+        (segment_id, 0)
     }
 
     fn deallocate_all(&mut self) {

--- a/capnp/src/private/arena.rs
+++ b/capnp/src/private/arena.rs
@@ -206,7 +206,7 @@ where
     }
 
     /// Allocates a new segment with capacity for at least `minimum_size` words.
-    pub fn allocate_segment(&self, minimum_size: u32) -> Result<()> {
+    pub fn allocate_segment(&self, minimum_size: u32) {
         self.inner.borrow_mut().allocate_segment(minimum_size)
     }
 
@@ -295,14 +295,13 @@ where
     A: Allocator,
 {
     /// Allocates a new segment with capacity for at least `minimum_size` words.
-    fn allocate_segment(&mut self, minimum_size: WordCount32) -> Result<()> {
+    fn allocate_segment(&mut self, minimum_size: WordCount32) {
         let seg = self.allocator.allocate_segment(minimum_size);
         self.segments.push(BuilderSegment {
             ptr: seg.0,
             capacity: seg.1,
             allocated: 0,
         });
-        Ok(())
     }
 
     fn allocate(&mut self, segment_id: u32, amount: WordCount32) -> Option<u32> {
@@ -327,7 +326,7 @@ where
 
         // Need to allocate a new segment.
 
-        self.allocate_segment(amount).expect("allocate new segment");
+        self.allocate_segment(amount);
         (
             allocated_len,
             self.allocate(allocated_len, amount)

--- a/capnp/src/private/arena.rs
+++ b/capnp/src/private/arena.rs
@@ -219,7 +219,7 @@ where
 
     /// Allocates a new segment with capacity for at least `minimum_size` words.
     pub fn allocate_segment(&self, minimum_size: u32) {
-        self.inner.borrow_mut().allocate_segment(minimum_size)
+        self.inner.borrow_mut().allocate_segment(minimum_size);
     }
 
     pub fn get_segments_for_output(&self) -> OutputSegments {
@@ -307,13 +307,15 @@ where
     A: Allocator,
 {
     /// Allocates a new segment with capacity for at least `minimum_size` words.
-    fn allocate_segment(&mut self, minimum_size: WordCount32) {
+    fn allocate_segment(&mut self, minimum_size: WordCount32) -> SegmentId {
         let seg = self.allocator.allocate_segment(minimum_size);
+        let segment_id = self.segments.len() as u32;
         self.segments.push(BuilderSegment {
             ptr: seg.0,
             capacity: seg.1,
             allocated: minimum_size,
         });
+        segment_id
     }
 
     fn allocate(&mut self, segment_id: u32, amount: WordCount32) -> Option<u32> {
@@ -329,10 +331,7 @@ where
         }
 
         // Need to allocate a new segment.
-
-        let segment_id = self.segments.len() as u32;
-        self.allocate_segment(amount);
-        (segment_id, 0)
+        (self.allocate_segment(amount), 0)
     }
 
     fn deallocate_all(&mut self) {

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -399,7 +399,7 @@ mod wire_helpers {
 
     #[inline]
     pub unsafe fn allocate(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         reff: *mut WirePointer,
         segment_id: u32,
         amount: WordCount32,
@@ -450,7 +450,7 @@ mod wire_helpers {
 
     #[inline]
     pub unsafe fn follow_builder_fars(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         reff: *mut WirePointer,
         ref_target: *mut u8,
         segment_id: u32,
@@ -535,7 +535,11 @@ mod wire_helpers {
         }
     }
 
-    pub unsafe fn zero_object(arena: &dyn BuilderArena, segment_id: u32, reff: *mut WirePointer) {
+    pub unsafe fn zero_object(
+        arena: &mut dyn BuilderArena,
+        segment_id: u32,
+        reff: *mut WirePointer,
+    ) {
         //# Zero out the pointed-to object. Use when the pointer is
         //# about to be overwritten making the target object no longer
         //# reachable.
@@ -569,7 +573,7 @@ mod wire_helpers {
     }
 
     pub unsafe fn zero_object_helper(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         segment_id: u32,
         tag: *mut WirePointer,
         ptr: *mut u8,
@@ -651,7 +655,7 @@ mod wire_helpers {
 
     #[inline]
     pub unsafe fn zero_pointer_and_fars(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         _segment_id: u32,
         reff: *mut WirePointer,
     ) -> Result<()> {
@@ -822,7 +826,7 @@ mod wire_helpers {
 
     // Helper for copy_message().
     unsafe fn copy_struct(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         segment_id: u32,
         cap_table: CapTableBuilder,
         dst: *mut u8,
@@ -849,7 +853,7 @@ mod wire_helpers {
     // Copies from a trusted message.
     // Returns (new_dst_ptr, new_dst, new_segment_id).
     pub unsafe fn copy_message(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         segment_id: u32,
         cap_table: CapTableBuilder,
         dst: *mut WirePointer,
@@ -984,7 +988,7 @@ mod wire_helpers {
     }
 
     pub unsafe fn transfer_pointer(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         dst_segment_id: u32,
         dst: *mut WirePointer,
         src_segment_id: u32,
@@ -1020,7 +1024,7 @@ mod wire_helpers {
     }
 
     pub unsafe fn transfer_pointer_split(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         dst_segment_id: u32,
         dst: *mut WirePointer,
         src_segment_id: u32,
@@ -1094,7 +1098,7 @@ mod wire_helpers {
 
     #[inline]
     pub unsafe fn init_struct_pointer(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         reff: *mut WirePointer,
         segment_id: u32,
         cap_table: CapTableBuilder,
@@ -1122,7 +1126,7 @@ mod wire_helpers {
 
     #[inline]
     pub unsafe fn get_writable_struct_pointer<'a>(
-        arena: &'a dyn BuilderArena,
+        arena: &'a mut dyn BuilderArena,
         mut reff: *mut WirePointer,
         mut segment_id: u32,
         cap_table: CapTableBuilder,
@@ -1238,7 +1242,7 @@ mod wire_helpers {
 
     #[inline]
     pub unsafe fn init_list_pointer(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         reff: *mut WirePointer,
         segment_id: u32,
         cap_table: CapTableBuilder,
@@ -1274,7 +1278,7 @@ mod wire_helpers {
 
     #[inline]
     pub unsafe fn init_struct_list_pointer(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         reff: *mut WirePointer,
         segment_id: u32,
         cap_table: CapTableBuilder,
@@ -1319,7 +1323,7 @@ mod wire_helpers {
 
     #[inline]
     pub unsafe fn get_writable_list_pointer(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         mut orig_ref: *mut WirePointer,
         mut orig_segment_id: u32,
         cap_table: CapTableBuilder,
@@ -1335,7 +1339,7 @@ mod wire_helpers {
 
         if (*orig_ref).is_null() {
             if default_value.is_null() || (*(default_value as *const WirePointer)).is_null() {
-                return Ok(ListBuilder::new_default());
+                return Ok(ListBuilder::new_default(arena));
             }
             let (new_orig_ref_target, new_orig_ref, new_orig_segment_id) = copy_message(
                 arena,
@@ -1457,7 +1461,7 @@ mod wire_helpers {
 
     #[inline]
     pub unsafe fn get_writable_struct_list_pointer(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         mut orig_ref: *mut WirePointer,
         mut orig_segment_id: u32,
         cap_table: CapTableBuilder,
@@ -1468,7 +1472,7 @@ mod wire_helpers {
 
         if (*orig_ref).is_null() {
             if default_value.is_null() || (*(default_value as *const WirePointer)).is_null() {
-                return Ok(ListBuilder::new_default());
+                return Ok(ListBuilder::new_default(arena));
             }
             let (new_orig_ref_target, new_orig_ref, new_orig_segment_id) = copy_message(
                 arena,
@@ -1703,7 +1707,7 @@ mod wire_helpers {
 
     #[inline]
     pub unsafe fn init_text_pointer(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         reff: *mut WirePointer,
         segment_id: u32,
         size: ByteCount32,
@@ -1732,7 +1736,7 @@ mod wire_helpers {
 
     #[inline]
     pub unsafe fn set_text_pointer<'a>(
-        arena: &'a dyn BuilderArena,
+        arena: &'a mut dyn BuilderArena,
         reff: *mut WirePointer,
         segment_id: u32,
         value: &str,
@@ -1746,7 +1750,7 @@ mod wire_helpers {
 
     #[inline]
     pub unsafe fn get_writable_text_pointer<'a>(
-        arena: &'a dyn BuilderArena,
+        arena: &'a mut dyn BuilderArena,
         mut reff: *mut WirePointer,
         mut segment_id: u32,
         default: Option<&'a [crate::Word]>,
@@ -1802,7 +1806,7 @@ mod wire_helpers {
 
     #[inline]
     pub unsafe fn init_data_pointer(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         reff: *mut WirePointer,
         segment_id: u32,
         size: ByteCount32,
@@ -1827,7 +1831,7 @@ mod wire_helpers {
 
     #[inline]
     pub unsafe fn set_data_pointer<'a>(
-        arena: &'a dyn BuilderArena,
+        arena: &'a mut dyn BuilderArena,
         reff: *mut WirePointer,
         segment_id: u32,
         value: &[u8],
@@ -1839,7 +1843,7 @@ mod wire_helpers {
 
     #[inline]
     pub unsafe fn get_writable_data_pointer<'a>(
-        arena: &'a dyn BuilderArena,
+        arena: &'a mut dyn BuilderArena,
         mut reff: *mut WirePointer,
         mut segment_id: u32,
         default: Option<&'a [crate::Word]>,
@@ -1886,7 +1890,7 @@ mod wire_helpers {
     }
 
     pub unsafe fn set_struct_pointer(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         segment_id: u32,
         cap_table: CapTableBuilder,
         reff: *mut WirePointer,
@@ -1983,7 +1987,7 @@ mod wire_helpers {
     }
 
     pub unsafe fn set_list_pointer(
-        arena: &dyn BuilderArena,
+        arena: &mut dyn BuilderArena,
         segment_id: u32,
         cap_table: CapTableBuilder,
         reff: *mut WirePointer,
@@ -2152,7 +2156,7 @@ mod wire_helpers {
     }
 
     pub unsafe fn copy_pointer(
-        dst_arena: &dyn BuilderArena,
+        dst_arena: &mut dyn BuilderArena,
         dst_segment_id: u32,
         dst_cap_table: CapTableBuilder,
         dst: *mut WirePointer,
@@ -3054,9 +3058,8 @@ impl<'a> PointerReader<'a> {
     }
 }
 
-#[derive(Clone, Copy)]
 pub struct PointerBuilder<'a> {
-    arena: &'a dyn BuilderArena,
+    arena: &'a mut dyn BuilderArena,
     segment_id: u32,
     cap_table: CapTableBuilder,
     pointer: *mut WirePointer,
@@ -3064,7 +3067,7 @@ pub struct PointerBuilder<'a> {
 
 impl<'a> PointerBuilder<'a> {
     #[inline]
-    pub fn get_root(arena: &'a dyn BuilderArena, segment_id: u32, location: *mut u8) -> Self {
+    pub fn get_root(arena: &'a mut dyn BuilderArena, segment_id: u32, location: *mut u8) -> Self {
         PointerBuilder {
             arena,
             cap_table: CapTableBuilder::Plain(ptr::null_mut()),
@@ -3073,6 +3076,7 @@ impl<'a> PointerBuilder<'a> {
         }
     }
 
+    #[inline]
     pub fn reborrow(&mut self) -> PointerBuilder<'_> {
         PointerBuilder {
             arena: self.arena,
@@ -3240,7 +3244,7 @@ impl<'a> PointerBuilder<'a> {
         }
     }
 
-    pub fn set_struct(&self, value: &StructReader, canonicalize: bool) -> Result<()> {
+    pub fn set_struct(&mut self, value: &StructReader, canonicalize: bool) -> Result<()> {
         unsafe {
             wire_helpers::set_struct_pointer(
                 self.arena,
@@ -3254,7 +3258,7 @@ impl<'a> PointerBuilder<'a> {
         }
     }
 
-    pub fn set_list(&self, value: &ListReader, canonicalize: bool) -> Result<()> {
+    pub fn set_list(&mut self, value: &ListReader, canonicalize: bool) -> Result<()> {
         unsafe {
             wire_helpers::set_list_pointer(
                 self.arena,
@@ -3268,13 +3272,13 @@ impl<'a> PointerBuilder<'a> {
         }
     }
 
-    pub fn set_text(&self, value: &str) {
+    pub fn set_text(&mut self, value: &str) {
         unsafe {
             wire_helpers::set_text_pointer(self.arena, self.pointer, self.segment_id, value);
         }
     }
 
-    pub fn set_data(&self, value: &[u8]) {
+    pub fn set_data(&mut self, value: &[u8]) {
         unsafe {
             wire_helpers::set_data_pointer(self.arena, self.pointer, self.segment_id, value);
         }
@@ -3321,6 +3325,16 @@ impl<'a> PointerBuilder<'a> {
         unsafe {
             wire_helpers::zero_object(self.arena, self.segment_id, self.pointer);
             ptr::write_bytes(self.pointer, 0, 1);
+        }
+    }
+
+    pub fn as_reader(&self) -> PointerReader<'_> {
+        PointerReader {
+            arena: self.arena.as_reader(),
+            segment_id: self.segment_id,
+            cap_table: self.cap_table.into_reader(),
+            pointer: self.pointer,
+            nesting_limit: 0x7fffffff,
         }
     }
 
@@ -3535,9 +3549,8 @@ impl<'a> StructReader<'a> {
     }
 }
 
-#[derive(Clone, Copy)]
 pub struct StructBuilder<'a> {
-    arena: &'a dyn BuilderArena,
+    arena: &'a mut dyn BuilderArena,
     cap_table: CapTableBuilder,
     data: *mut u8,
     pointers: *mut WirePointer,
@@ -3547,6 +3560,27 @@ pub struct StructBuilder<'a> {
 }
 
 impl<'a> StructBuilder<'a> {
+    #[inline]
+    pub fn reborrow(&mut self) -> StructBuilder<'_> {
+        StructBuilder {
+            arena: self.arena,
+            ..*self
+        }
+    }
+
+    pub fn as_reader(&self) -> StructReader<'_> {
+        StructReader {
+            arena: self.arena.as_reader(),
+            cap_table: self.cap_table.into_reader(),
+            data: self.data,
+            pointers: self.pointers,
+            pointer_count: self.pointer_count,
+            segment_id: self.segment_id,
+            data_size: self.data_size,
+            nesting_limit: 0x7fffffff,
+        }
+    }
+
     pub fn into_reader(self) -> StructReader<'a> {
         StructReader {
             arena: self.arena.as_reader(),
@@ -3630,6 +3664,21 @@ impl<'a> StructBuilder<'a> {
             cap_table: self.cap_table,
             pointer: unsafe { self.pointers.add(ptr_index) },
         }
+    }
+
+    #[inline]
+    pub fn get_pointer_field_mut(&mut self, ptr_index: WirePointerCount) -> PointerBuilder<'_> {
+        PointerBuilder {
+            arena: self.arena,
+            segment_id: self.segment_id,
+            cap_table: self.cap_table,
+            pointer: unsafe { self.pointers.add(ptr_index) },
+        }
+    }
+
+    #[inline]
+    pub fn is_pointer_field_null(&self, ptr_index: WirePointerCount) -> bool {
+        unsafe { (*self.pointers.add(ptr_index)).is_null() }
     }
 
     pub fn copy_content_from(&mut self, other: &StructReader) -> Result<()> {
@@ -3924,9 +3973,8 @@ impl<'a> ListReader<'a> {
     }
 }
 
-#[derive(Clone, Copy)]
 pub struct ListBuilder<'a> {
-    arena: &'a dyn BuilderArena,
+    arena: &'a mut dyn BuilderArena,
     cap_table: CapTableBuilder,
     ptr: *mut u8,
     segment_id: u32,
@@ -3939,9 +3987,9 @@ pub struct ListBuilder<'a> {
 
 impl<'a> ListBuilder<'a> {
     #[inline]
-    pub fn new_default<'b>() -> ListBuilder<'b> {
+    pub fn new_default<'b>(arena: &'b mut dyn BuilderArena) -> ListBuilder<'b> {
         ListBuilder {
-            arena: &NULL_ARENA,
+            arena,
             segment_id: 0,
             cap_table: CapTableBuilder::Plain(ptr::null_mut()),
             ptr: ptr::null_mut(),
@@ -3968,6 +4016,7 @@ impl<'a> ListBuilder<'a> {
         }
     }
 
+    #[inline]
     pub fn reborrow(&mut self) -> ListBuilder<'_> {
         ListBuilder {
             arena: self.arena,
@@ -4005,6 +4054,23 @@ impl<'a> ListBuilder<'a> {
         }
     }
 
+    #[inline]
+    pub fn get_struct_element_mut(&mut self, index: ElementCount32) -> StructBuilder<'_> {
+        let index_byte = ((u64::from(index) * u64::from(self.step)) / BITS_PER_BYTE as u64) as u32;
+        let struct_data = unsafe { self.ptr.offset(index_byte as isize) };
+        let struct_pointers =
+            unsafe { struct_data.add((self.struct_data_size as usize) / BITS_PER_BYTE) as *mut _ };
+        StructBuilder {
+            arena: self.arena,
+            segment_id: self.segment_id,
+            cap_table: self.cap_table,
+            data: struct_data,
+            pointers: struct_pointers,
+            data_size: self.struct_data_size,
+            pointer_count: self.struct_pointer_count,
+        }
+    }
+
     pub(crate) fn get_element_size(&self) -> ElementSize {
         self.element_size
     }
@@ -4020,7 +4086,18 @@ impl<'a> ListBuilder<'a> {
         }
     }
 
-    pub(crate) fn into_raw_bytes(self) -> &'a mut [u8] {
+    #[inline]
+    pub fn get_pointer_element_mut(&mut self, index: ElementCount32) -> PointerBuilder<'_> {
+        let offset = (u64::from(index) * u64::from(self.step) / BITS_PER_BYTE as u64) as u32;
+        PointerBuilder {
+            arena: self.arena,
+            segment_id: self.segment_id,
+            cap_table: self.cap_table,
+            pointer: unsafe { self.ptr.offset(offset as isize) } as *mut _,
+        }
+    }
+
+    pub(crate) fn as_raw_bytes(&self) -> &'_ [u8] {
         if self.element_count == 0 {
             // Explictly handle this case to avoid forming a slice to a null pointer,
             // which would be undefined behavior.
@@ -4029,7 +4106,7 @@ impl<'a> ListBuilder<'a> {
             let num_bytes = wire_helpers::round_bits_up_to_bytes(
                 u64::from(self.step) * u64::from(self.element_count),
             ) as usize;
-            unsafe { ::core::slice::from_raw_parts_mut(self.ptr, num_bytes) }
+            unsafe { ::core::slice::from_raw_parts(self.ptr, num_bytes) }
         }
     }
 }

--- a/capnp/src/struct_list.rs
+++ b/capnp/src/struct_list.rs
@@ -184,13 +184,13 @@ where
     /// struct list are allocated inline: if the source struct is larger than the target struct
     /// (as can happen if it was created with a newer version of the schema), then it will be
     /// truncated, losing fields.
-    pub fn set_with_caveats<'b>(&self, index: u32, value: T::Reader<'b>) -> Result<()>
+    pub fn set_with_caveats<'b>(&mut self, index: u32, value: T::Reader<'b>) -> Result<()>
     where
         T::Reader<'b>: crate::traits::IntoInternalStructReader<'b>,
     {
         use crate::traits::IntoInternalStructReader;
         self.builder
-            .get_struct_element(index)
+            .get_struct_element_mut(index)
             .copy_content_from(&value.into_internal_struct_reader())
     }
 }
@@ -201,7 +201,7 @@ where
 {
     pub fn reborrow(&mut self) -> Builder<'_, T> {
         Builder {
-            builder: self.builder,
+            builder: self.builder.reborrow(),
             marker: PhantomData,
         }
     }
@@ -257,7 +257,7 @@ where
     T: crate::traits::OwnedStruct,
 {
     fn set_pointer_builder<'b>(
-        pointer: crate::private::layout::PointerBuilder<'b>,
+        mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: Reader<'a, T>,
         canonicalize: bool,
     ) -> Result<()> {

--- a/capnp/src/text.rs
+++ b/capnp/src/text.rs
@@ -125,7 +125,7 @@ impl<'a> crate::traits::FromPointerBuilder<'a> for Builder<'a> {
 
 impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
     fn set_pointer_builder<'b>(
-        pointer: crate::private::layout::PointerBuilder<'b>,
+        mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: Reader<'a>,
         _canonicalize: bool,
     ) -> Result<()> {

--- a/capnp/src/text_list.rs
+++ b/capnp/src/text_list.rs
@@ -174,7 +174,7 @@ impl<'a> Builder<'a> {
 
 impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
     fn set_pointer_builder<'b>(
-        pointer: crate::private::layout::PointerBuilder<'b>,
+        mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: Reader<'a>,
         canonicalize: bool,
     ) -> Result<()> {

--- a/capnpc/src/schema_capnp.rs
+++ b/capnpc/src/schema_capnp.rs
@@ -165,7 +165,7 @@ pub mod node {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -173,14 +173,14 @@ pub mod node {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_id(self) -> u64 {
@@ -196,7 +196,7 @@ pub mod node {
     }
     #[inline]
     pub fn set_display_name(&mut self, value: ::capnp::text::Reader<'_>)  {
-      self.builder.get_pointer_field(0).set_text(value);
+      self.builder.get_pointer_field_mut(0).set_text(value);
     }
     #[inline]
     pub fn init_display_name(self, size: u32) -> ::capnp::text::Builder<'a> {
@@ -204,7 +204,7 @@ pub mod node {
     }
     #[inline]
     pub fn has_display_name(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn get_display_name_prefix_length(self) -> u32 {
@@ -228,7 +228,7 @@ pub mod node {
     }
     #[inline]
     pub fn set_nested_nodes(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::node::nested_node::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(1), value, false)
     }
     #[inline]
     pub fn init_nested_nodes(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::node::nested_node::Owned> {
@@ -236,7 +236,7 @@ pub mod node {
     }
     #[inline]
     pub fn has_nested_nodes(&self) -> bool {
-      !self.builder.get_pointer_field(1).is_null()
+      !self.builder.is_pointer_field_null(1)
     }
     #[inline]
     pub fn get_annotations(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned>> {
@@ -244,7 +244,7 @@ pub mod node {
     }
     #[inline]
     pub fn set_annotations(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(2), value, false)
     }
     #[inline]
     pub fn init_annotations(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned> {
@@ -252,14 +252,14 @@ pub mod node {
     }
     #[inline]
     pub fn has_annotations(&self) -> bool {
-      !self.builder.get_pointer_field(2).is_null()
+      !self.builder.is_pointer_field_null(2)
     }
     #[inline]
     pub fn set_file(&mut self, _value: ())  {
       self.builder.set_data_field::<u16>(6, 0);
     }
     #[inline]
-    pub fn init_struct(self, ) -> crate::schema_capnp::node::struct_::Builder<'a> {
+    pub fn init_struct(mut self, ) -> crate::schema_capnp::node::struct_::Builder<'a> {
       self.builder.set_data_field::<u16>(6, 1);
       self.builder.set_data_field::<u16>(7, 0u16);
       self.builder.set_data_field::<u16>(12, 0u16);
@@ -267,33 +267,33 @@ pub mod node {
       self.builder.set_bool_field(224, false);
       self.builder.set_data_field::<u16>(15, 0u16);
       self.builder.set_data_field::<u32>(8, 0u32);
-      self.builder.get_pointer_field(3).clear();
+      self.builder.get_pointer_field_mut(3).clear();
       ::capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_enum(self, ) -> crate::schema_capnp::node::enum_::Builder<'a> {
+    pub fn init_enum(mut self, ) -> crate::schema_capnp::node::enum_::Builder<'a> {
       self.builder.set_data_field::<u16>(6, 2);
-      self.builder.get_pointer_field(3).clear();
+      self.builder.get_pointer_field_mut(3).clear();
       ::capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_interface(self, ) -> crate::schema_capnp::node::interface::Builder<'a> {
+    pub fn init_interface(mut self, ) -> crate::schema_capnp::node::interface::Builder<'a> {
       self.builder.set_data_field::<u16>(6, 3);
-      self.builder.get_pointer_field(3).clear();
-      self.builder.get_pointer_field(4).clear();
+      self.builder.get_pointer_field_mut(3).clear();
+      self.builder.get_pointer_field_mut(4).clear();
       ::capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_const(self, ) -> crate::schema_capnp::node::const_::Builder<'a> {
+    pub fn init_const(mut self, ) -> crate::schema_capnp::node::const_::Builder<'a> {
       self.builder.set_data_field::<u16>(6, 4);
-      self.builder.get_pointer_field(3).clear();
-      self.builder.get_pointer_field(4).clear();
+      self.builder.get_pointer_field_mut(3).clear();
+      self.builder.get_pointer_field_mut(4).clear();
       ::capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_annotation(self, ) -> crate::schema_capnp::node::annotation::Builder<'a> {
+    pub fn init_annotation(mut self, ) -> crate::schema_capnp::node::annotation::Builder<'a> {
       self.builder.set_data_field::<u16>(6, 5);
-      self.builder.get_pointer_field(3).clear();
+      self.builder.get_pointer_field_mut(3).clear();
       self.builder.set_bool_field(112, false);
       self.builder.set_bool_field(113, false);
       self.builder.set_bool_field(114, false);
@@ -314,7 +314,7 @@ pub mod node {
     }
     #[inline]
     pub fn set_parameters(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::node::parameter::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(5), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(5), value, false)
     }
     #[inline]
     pub fn init_parameters(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::node::parameter::Owned> {
@@ -322,7 +322,7 @@ pub mod node {
     }
     #[inline]
     pub fn has_parameters(&self) -> bool {
-      !self.builder.get_pointer_field(5).is_null()
+      !self.builder.is_pointer_field_null(5)
     }
     #[inline]
     pub fn get_is_generic(self) -> bool {
@@ -476,7 +476,7 @@ pub mod node {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -484,14 +484,14 @@ pub mod node {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
@@ -499,7 +499,7 @@ pub mod node {
       }
       #[inline]
       pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.get_pointer_field(0).set_text(value);
+        self.builder.get_pointer_field_mut(0).set_text(value);
       }
       #[inline]
       pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
@@ -507,7 +507,7 @@ pub mod node {
       }
       #[inline]
       pub fn has_name(&self) -> bool {
-        !self.builder.get_pointer_field(0).is_null()
+        !self.builder.is_pointer_field_null(0)
       }
     }
 
@@ -612,7 +612,7 @@ pub mod node {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -620,14 +620,14 @@ pub mod node {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
@@ -635,7 +635,7 @@ pub mod node {
       }
       #[inline]
       pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.get_pointer_field(0).set_text(value);
+        self.builder.get_pointer_field_mut(0).set_text(value);
       }
       #[inline]
       pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
@@ -643,7 +643,7 @@ pub mod node {
       }
       #[inline]
       pub fn has_name(&self) -> bool {
-        !self.builder.get_pointer_field(0).is_null()
+        !self.builder.is_pointer_field_null(0)
       }
       #[inline]
       pub fn get_id(self) -> u64 {
@@ -764,7 +764,7 @@ pub mod node {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -772,14 +772,14 @@ pub mod node {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_id(self) -> u64 {
@@ -795,7 +795,7 @@ pub mod node {
       }
       #[inline]
       pub fn set_doc_comment(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.get_pointer_field(0).set_text(value);
+        self.builder.get_pointer_field_mut(0).set_text(value);
       }
       #[inline]
       pub fn init_doc_comment(self, size: u32) -> ::capnp::text::Builder<'a> {
@@ -803,7 +803,7 @@ pub mod node {
       }
       #[inline]
       pub fn has_doc_comment(&self) -> bool {
-        !self.builder.get_pointer_field(0).is_null()
+        !self.builder.is_pointer_field_null(0)
       }
       #[inline]
       pub fn get_members(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::node::source_info::member::Owned>> {
@@ -811,7 +811,7 @@ pub mod node {
       }
       #[inline]
       pub fn set_members(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::node::source_info::member::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(1), value, false)
       }
       #[inline]
       pub fn init_members(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::node::source_info::member::Owned> {
@@ -819,7 +819,7 @@ pub mod node {
       }
       #[inline]
       pub fn has_members(&self) -> bool {
-        !self.builder.get_pointer_field(1).is_null()
+        !self.builder.is_pointer_field_null(1)
       }
     }
 
@@ -919,7 +919,7 @@ pub mod node {
       }
 
       impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+        fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
       }
 
       impl <'a,> Builder<'a,>  {
@@ -927,14 +927,14 @@ pub mod node {
           ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
         pub fn reborrow(&mut self) -> Builder<'_,> {
-          Builder { .. *self }
+          Builder { builder: self.builder.reborrow(), ..*self }
         }
         pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+          ::capnp::traits::FromStructReader::new(self.builder.as_reader())
         }
 
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.builder.into_reader().total_size()
+          self.builder.as_reader().total_size()
         }
         #[inline]
         pub fn get_doc_comment(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
@@ -942,7 +942,7 @@ pub mod node {
         }
         #[inline]
         pub fn set_doc_comment(&mut self, value: ::capnp::text::Reader<'_>)  {
-          self.builder.get_pointer_field(0).set_text(value);
+          self.builder.get_pointer_field_mut(0).set_text(value);
         }
         #[inline]
         pub fn init_doc_comment(self, size: u32) -> ::capnp::text::Builder<'a> {
@@ -950,7 +950,7 @@ pub mod node {
         }
         #[inline]
         pub fn has_doc_comment(&self) -> bool {
-          !self.builder.get_pointer_field(0).is_null()
+          !self.builder.is_pointer_field_null(0)
         }
       }
 
@@ -1076,7 +1076,7 @@ pub mod node {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -1084,14 +1084,14 @@ pub mod node {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_data_word_count(self) -> u16 {
@@ -1147,7 +1147,7 @@ pub mod node {
       }
       #[inline]
       pub fn set_fields(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::field::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(3), value, false)
       }
       #[inline]
       pub fn init_fields(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::field::Owned> {
@@ -1155,7 +1155,7 @@ pub mod node {
       }
       #[inline]
       pub fn has_fields(&self) -> bool {
-        !self.builder.get_pointer_field(3).is_null()
+        !self.builder.is_pointer_field_null(3)
       }
     }
 
@@ -1256,7 +1256,7 @@ pub mod node {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -1264,14 +1264,14 @@ pub mod node {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_enumerants(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::enumerant::Owned>> {
@@ -1279,7 +1279,7 @@ pub mod node {
       }
       #[inline]
       pub fn set_enumerants(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::enumerant::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(3), value, false)
       }
       #[inline]
       pub fn init_enumerants(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::enumerant::Owned> {
@@ -1287,7 +1287,7 @@ pub mod node {
       }
       #[inline]
       pub fn has_enumerants(&self) -> bool {
-        !self.builder.get_pointer_field(3).is_null()
+        !self.builder.is_pointer_field_null(3)
       }
     }
 
@@ -1396,7 +1396,7 @@ pub mod node {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -1404,14 +1404,14 @@ pub mod node {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_methods(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::method::Owned>> {
@@ -1419,7 +1419,7 @@ pub mod node {
       }
       #[inline]
       pub fn set_methods(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::method::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(3), value, false)
       }
       #[inline]
       pub fn init_methods(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::method::Owned> {
@@ -1427,7 +1427,7 @@ pub mod node {
       }
       #[inline]
       pub fn has_methods(&self) -> bool {
-        !self.builder.get_pointer_field(3).is_null()
+        !self.builder.is_pointer_field_null(3)
       }
       #[inline]
       pub fn get_superclasses(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::superclass::Owned>> {
@@ -1435,7 +1435,7 @@ pub mod node {
       }
       #[inline]
       pub fn set_superclasses(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::superclass::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(4), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(4), value, false)
       }
       #[inline]
       pub fn init_superclasses(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::superclass::Owned> {
@@ -1443,7 +1443,7 @@ pub mod node {
       }
       #[inline]
       pub fn has_superclasses(&self) -> bool {
-        !self.builder.get_pointer_field(4).is_null()
+        !self.builder.is_pointer_field_null(4)
       }
     }
 
@@ -1552,7 +1552,7 @@ pub mod node {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -1560,14 +1560,14 @@ pub mod node {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
@@ -1575,7 +1575,7 @@ pub mod node {
       }
       #[inline]
       pub fn set_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(3), value, false)
       }
       #[inline]
       pub fn init_type(self, ) -> crate::schema_capnp::type_::Builder<'a> {
@@ -1583,7 +1583,7 @@ pub mod node {
       }
       #[inline]
       pub fn has_type(&self) -> bool {
-        !self.builder.get_pointer_field(3).is_null()
+        !self.builder.is_pointer_field_null(3)
       }
       #[inline]
       pub fn get_value(self) -> ::capnp::Result<crate::schema_capnp::value::Builder<'a>> {
@@ -1591,7 +1591,7 @@ pub mod node {
       }
       #[inline]
       pub fn set_value(&mut self, value: crate::schema_capnp::value::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(4), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(4), value, false)
       }
       #[inline]
       pub fn init_value(self, ) -> crate::schema_capnp::value::Builder<'a> {
@@ -1599,7 +1599,7 @@ pub mod node {
       }
       #[inline]
       pub fn has_value(&self) -> bool {
-        !self.builder.get_pointer_field(4).is_null()
+        !self.builder.is_pointer_field_null(4)
       }
     }
 
@@ -1754,7 +1754,7 @@ pub mod node {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -1762,14 +1762,14 @@ pub mod node {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
@@ -1777,7 +1777,7 @@ pub mod node {
       }
       #[inline]
       pub fn set_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(3), value, false)
       }
       #[inline]
       pub fn init_type(self, ) -> crate::schema_capnp::type_::Builder<'a> {
@@ -1785,7 +1785,7 @@ pub mod node {
       }
       #[inline]
       pub fn has_type(&self) -> bool {
-        !self.builder.get_pointer_field(3).is_null()
+        !self.builder.is_pointer_field_null(3)
       }
       #[inline]
       pub fn get_targets_file(self) -> bool {
@@ -2024,7 +2024,7 @@ pub mod field {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -2032,14 +2032,14 @@ pub mod field {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
@@ -2047,7 +2047,7 @@ pub mod field {
     }
     #[inline]
     pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
-      self.builder.get_pointer_field(0).set_text(value);
+      self.builder.get_pointer_field_mut(0).set_text(value);
     }
     #[inline]
     pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
@@ -2055,7 +2055,7 @@ pub mod field {
     }
     #[inline]
     pub fn has_name(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn get_code_order(self) -> u16 {
@@ -2071,7 +2071,7 @@ pub mod field {
     }
     #[inline]
     pub fn set_annotations(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(1), value, false)
     }
     #[inline]
     pub fn init_annotations(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned> {
@@ -2079,7 +2079,7 @@ pub mod field {
     }
     #[inline]
     pub fn has_annotations(&self) -> bool {
-      !self.builder.get_pointer_field(1).is_null()
+      !self.builder.is_pointer_field_null(1)
     }
     #[inline]
     pub fn get_discriminant_value(self) -> u16 {
@@ -2090,11 +2090,11 @@ pub mod field {
       self.builder.set_data_field_mask::<u16>(1, value, 65535);
     }
     #[inline]
-    pub fn init_slot(self, ) -> crate::schema_capnp::field::slot::Builder<'a> {
+    pub fn init_slot(mut self, ) -> crate::schema_capnp::field::slot::Builder<'a> {
       self.builder.set_data_field::<u16>(4, 0);
       self.builder.set_data_field::<u32>(1, 0u32);
-      self.builder.get_pointer_field(2).clear();
-      self.builder.get_pointer_field(3).clear();
+      self.builder.get_pointer_field_mut(2).clear();
+      self.builder.get_pointer_field_mut(3).clear();
       self.builder.set_bool_field(128, false);
       ::capnp::traits::FromStructBuilder::new(self.builder)
     }
@@ -2254,7 +2254,7 @@ pub mod field {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -2262,14 +2262,14 @@ pub mod field {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_offset(self) -> u32 {
@@ -2285,7 +2285,7 @@ pub mod field {
       }
       #[inline]
       pub fn set_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(2), value, false)
       }
       #[inline]
       pub fn init_type(self, ) -> crate::schema_capnp::type_::Builder<'a> {
@@ -2293,7 +2293,7 @@ pub mod field {
       }
       #[inline]
       pub fn has_type(&self) -> bool {
-        !self.builder.get_pointer_field(2).is_null()
+        !self.builder.is_pointer_field_null(2)
       }
       #[inline]
       pub fn get_default_value(self) -> ::capnp::Result<crate::schema_capnp::value::Builder<'a>> {
@@ -2301,7 +2301,7 @@ pub mod field {
       }
       #[inline]
       pub fn set_default_value(&mut self, value: crate::schema_capnp::value::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(3), value, false)
       }
       #[inline]
       pub fn init_default_value(self, ) -> crate::schema_capnp::value::Builder<'a> {
@@ -2309,7 +2309,7 @@ pub mod field {
       }
       #[inline]
       pub fn has_default_value(&self) -> bool {
-        !self.builder.get_pointer_field(3).is_null()
+        !self.builder.is_pointer_field_null(3)
       }
       #[inline]
       pub fn get_had_explicit_default(self) -> bool {
@@ -2420,7 +2420,7 @@ pub mod field {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -2428,14 +2428,14 @@ pub mod field {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_type_id(self) -> u64 {
@@ -2554,7 +2554,7 @@ pub mod field {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -2562,14 +2562,14 @@ pub mod field {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn set_implicit(&mut self, _value: ())  {
@@ -2714,7 +2714,7 @@ pub mod enumerant {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -2722,14 +2722,14 @@ pub mod enumerant {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
@@ -2737,7 +2737,7 @@ pub mod enumerant {
     }
     #[inline]
     pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
-      self.builder.get_pointer_field(0).set_text(value);
+      self.builder.get_pointer_field_mut(0).set_text(value);
     }
     #[inline]
     pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
@@ -2745,7 +2745,7 @@ pub mod enumerant {
     }
     #[inline]
     pub fn has_name(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn get_code_order(self) -> u16 {
@@ -2761,7 +2761,7 @@ pub mod enumerant {
     }
     #[inline]
     pub fn set_annotations(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(1), value, false)
     }
     #[inline]
     pub fn init_annotations(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned> {
@@ -2769,7 +2769,7 @@ pub mod enumerant {
     }
     #[inline]
     pub fn has_annotations(&self) -> bool {
-      !self.builder.get_pointer_field(1).is_null()
+      !self.builder.is_pointer_field_null(1)
     }
   }
 
@@ -2874,7 +2874,7 @@ pub mod superclass {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -2882,14 +2882,14 @@ pub mod superclass {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_id(self) -> u64 {
@@ -2905,7 +2905,7 @@ pub mod superclass {
     }
     #[inline]
     pub fn set_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_brand(self, ) -> crate::schema_capnp::brand::Builder<'a> {
@@ -2913,7 +2913,7 @@ pub mod superclass {
     }
     #[inline]
     pub fn has_brand(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
   }
 
@@ -3061,7 +3061,7 @@ pub mod method {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -3069,14 +3069,14 @@ pub mod method {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
@@ -3084,7 +3084,7 @@ pub mod method {
     }
     #[inline]
     pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
-      self.builder.get_pointer_field(0).set_text(value);
+      self.builder.get_pointer_field_mut(0).set_text(value);
     }
     #[inline]
     pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
@@ -3092,7 +3092,7 @@ pub mod method {
     }
     #[inline]
     pub fn has_name(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn get_code_order(self) -> u16 {
@@ -3124,7 +3124,7 @@ pub mod method {
     }
     #[inline]
     pub fn set_annotations(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::annotation::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(1), value, false)
     }
     #[inline]
     pub fn init_annotations(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::annotation::Owned> {
@@ -3132,7 +3132,7 @@ pub mod method {
     }
     #[inline]
     pub fn has_annotations(&self) -> bool {
-      !self.builder.get_pointer_field(1).is_null()
+      !self.builder.is_pointer_field_null(1)
     }
     #[inline]
     pub fn get_param_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
@@ -3140,7 +3140,7 @@ pub mod method {
     }
     #[inline]
     pub fn set_param_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(2), value, false)
     }
     #[inline]
     pub fn init_param_brand(self, ) -> crate::schema_capnp::brand::Builder<'a> {
@@ -3148,7 +3148,7 @@ pub mod method {
     }
     #[inline]
     pub fn has_param_brand(&self) -> bool {
-      !self.builder.get_pointer_field(2).is_null()
+      !self.builder.is_pointer_field_null(2)
     }
     #[inline]
     pub fn get_result_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
@@ -3156,7 +3156,7 @@ pub mod method {
     }
     #[inline]
     pub fn set_result_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(3), value, false)
     }
     #[inline]
     pub fn init_result_brand(self, ) -> crate::schema_capnp::brand::Builder<'a> {
@@ -3164,7 +3164,7 @@ pub mod method {
     }
     #[inline]
     pub fn has_result_brand(&self) -> bool {
-      !self.builder.get_pointer_field(3).is_null()
+      !self.builder.is_pointer_field_null(3)
     }
     #[inline]
     pub fn get_implicit_parameters(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::node::parameter::Owned>> {
@@ -3172,7 +3172,7 @@ pub mod method {
     }
     #[inline]
     pub fn set_implicit_parameters(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::node::parameter::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(4), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(4), value, false)
     }
     #[inline]
     pub fn init_implicit_parameters(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::node::parameter::Owned> {
@@ -3180,7 +3180,7 @@ pub mod method {
     }
     #[inline]
     pub fn has_implicit_parameters(&self) -> bool {
-      !self.builder.get_pointer_field(4).is_null()
+      !self.builder.is_pointer_field_null(4)
     }
   }
 
@@ -3382,7 +3382,7 @@ pub mod type_ {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -3390,14 +3390,14 @@ pub mod type_ {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn set_void(&mut self, _value: ())  {
@@ -3456,30 +3456,30 @@ pub mod type_ {
       self.builder.set_data_field::<u16>(0, 13);
     }
     #[inline]
-    pub fn init_list(self, ) -> crate::schema_capnp::type_::list::Builder<'a> {
+    pub fn init_list(mut self, ) -> crate::schema_capnp::type_::list::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 14);
-      self.builder.get_pointer_field(0).clear();
+      self.builder.get_pointer_field_mut(0).clear();
       ::capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_enum(self, ) -> crate::schema_capnp::type_::enum_::Builder<'a> {
+    pub fn init_enum(mut self, ) -> crate::schema_capnp::type_::enum_::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 15);
       self.builder.set_data_field::<u64>(1, 0u64);
-      self.builder.get_pointer_field(0).clear();
+      self.builder.get_pointer_field_mut(0).clear();
       ::capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_struct(self, ) -> crate::schema_capnp::type_::struct_::Builder<'a> {
+    pub fn init_struct(mut self, ) -> crate::schema_capnp::type_::struct_::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 16);
       self.builder.set_data_field::<u64>(1, 0u64);
-      self.builder.get_pointer_field(0).clear();
+      self.builder.get_pointer_field_mut(0).clear();
       ::capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
-    pub fn init_interface(self, ) -> crate::schema_capnp::type_::interface::Builder<'a> {
+    pub fn init_interface(mut self, ) -> crate::schema_capnp::type_::interface::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 17);
       self.builder.set_data_field::<u64>(1, 0u64);
-      self.builder.get_pointer_field(0).clear();
+      self.builder.get_pointer_field_mut(0).clear();
       ::capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
@@ -3714,7 +3714,7 @@ pub mod type_ {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -3722,14 +3722,14 @@ pub mod type_ {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_element_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
@@ -3737,7 +3737,7 @@ pub mod type_ {
       }
       #[inline]
       pub fn set_element_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
       }
       #[inline]
       pub fn init_element_type(self, ) -> crate::schema_capnp::type_::Builder<'a> {
@@ -3745,7 +3745,7 @@ pub mod type_ {
       }
       #[inline]
       pub fn has_element_type(&self) -> bool {
-        !self.builder.get_pointer_field(0).is_null()
+        !self.builder.is_pointer_field_null(0)
       }
     }
 
@@ -3853,7 +3853,7 @@ pub mod type_ {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -3861,14 +3861,14 @@ pub mod type_ {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_type_id(self) -> u64 {
@@ -3884,7 +3884,7 @@ pub mod type_ {
       }
       #[inline]
       pub fn set_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
       }
       #[inline]
       pub fn init_brand(self, ) -> crate::schema_capnp::brand::Builder<'a> {
@@ -3892,7 +3892,7 @@ pub mod type_ {
       }
       #[inline]
       pub fn has_brand(&self) -> bool {
-        !self.builder.get_pointer_field(0).is_null()
+        !self.builder.is_pointer_field_null(0)
       }
     }
 
@@ -4000,7 +4000,7 @@ pub mod type_ {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -4008,14 +4008,14 @@ pub mod type_ {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_type_id(self) -> u64 {
@@ -4031,7 +4031,7 @@ pub mod type_ {
       }
       #[inline]
       pub fn set_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
       }
       #[inline]
       pub fn init_brand(self, ) -> crate::schema_capnp::brand::Builder<'a> {
@@ -4039,7 +4039,7 @@ pub mod type_ {
       }
       #[inline]
       pub fn has_brand(&self) -> bool {
-        !self.builder.get_pointer_field(0).is_null()
+        !self.builder.is_pointer_field_null(0)
       }
     }
 
@@ -4147,7 +4147,7 @@ pub mod type_ {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -4155,14 +4155,14 @@ pub mod type_ {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_type_id(self) -> u64 {
@@ -4178,7 +4178,7 @@ pub mod type_ {
       }
       #[inline]
       pub fn set_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
       }
       #[inline]
       pub fn init_brand(self, ) -> crate::schema_capnp::brand::Builder<'a> {
@@ -4186,7 +4186,7 @@ pub mod type_ {
       }
       #[inline]
       pub fn has_brand(&self) -> bool {
-        !self.builder.get_pointer_field(0).is_null()
+        !self.builder.is_pointer_field_null(0)
       }
     }
 
@@ -4305,7 +4305,7 @@ pub mod type_ {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -4313,14 +4313,14 @@ pub mod type_ {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn init_unconstrained(self, ) -> crate::schema_capnp::type_::any_pointer::unconstrained::Builder<'a> {
@@ -4487,7 +4487,7 @@ pub mod type_ {
       }
 
       impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+        fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
       }
 
       impl <'a,> Builder<'a,>  {
@@ -4495,14 +4495,14 @@ pub mod type_ {
           ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
         pub fn reborrow(&mut self) -> Builder<'_,> {
-          Builder { .. *self }
+          Builder { builder: self.builder.reborrow(), ..*self }
         }
         pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+          ::capnp::traits::FromStructReader::new(self.builder.as_reader())
         }
 
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.builder.into_reader().total_size()
+          self.builder.as_reader().total_size()
         }
         #[inline]
         pub fn set_any_kind(&mut self, _value: ())  {
@@ -4653,7 +4653,7 @@ pub mod type_ {
       }
 
       impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+        fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
       }
 
       impl <'a,> Builder<'a,>  {
@@ -4661,14 +4661,14 @@ pub mod type_ {
           ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
         pub fn reborrow(&mut self) -> Builder<'_,> {
-          Builder { .. *self }
+          Builder { builder: self.builder.reborrow(), ..*self }
         }
         pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+          ::capnp::traits::FromStructReader::new(self.builder.as_reader())
         }
 
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.builder.into_reader().total_size()
+          self.builder.as_reader().total_size()
         }
         #[inline]
         pub fn get_scope_id(self) -> u64 {
@@ -4781,7 +4781,7 @@ pub mod type_ {
       }
 
       impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+        fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
       }
 
       impl <'a,> Builder<'a,>  {
@@ -4789,14 +4789,14 @@ pub mod type_ {
           ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
         pub fn reborrow(&mut self) -> Builder<'_,> {
-          Builder { .. *self }
+          Builder { builder: self.builder.reborrow(), ..*self }
         }
         pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+          ::capnp::traits::FromStructReader::new(self.builder.as_reader())
         }
 
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.builder.into_reader().total_size()
+          self.builder.as_reader().total_size()
         }
         #[inline]
         pub fn get_parameter_index(self) -> u16 {
@@ -4907,7 +4907,7 @@ pub mod brand {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -4915,14 +4915,14 @@ pub mod brand {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_scopes(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::brand::scope::Owned>> {
@@ -4930,7 +4930,7 @@ pub mod brand {
     }
     #[inline]
     pub fn set_scopes(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::brand::scope::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_scopes(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::brand::scope::Owned> {
@@ -4938,7 +4938,7 @@ pub mod brand {
     }
     #[inline]
     pub fn has_scopes(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
   }
 
@@ -5057,7 +5057,7 @@ pub mod brand {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -5065,14 +5065,14 @@ pub mod brand {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_scope_id(self) -> u64 {
@@ -5085,7 +5085,7 @@ pub mod brand {
       #[inline]
       pub fn set_bind(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::brand::binding::Owned>) -> ::capnp::Result<()> {
         self.builder.set_data_field::<u16>(4, 0);
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
       }
       #[inline]
       pub fn init_bind(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::brand::binding::Owned> {
@@ -5095,7 +5095,7 @@ pub mod brand {
       #[inline]
       pub fn has_bind(&self) -> bool {
         if self.builder.get_data_field::<u16>(4) != 0 { return false; }
-        !self.builder.get_pointer_field(0).is_null()
+        !self.builder.is_pointer_field_null(0)
       }
       #[inline]
       pub fn set_inherit(&mut self, _value: ())  {
@@ -5237,7 +5237,7 @@ pub mod brand {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -5245,14 +5245,14 @@ pub mod brand {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn set_unbound(&mut self, _value: ())  {
@@ -5261,7 +5261,7 @@ pub mod brand {
       #[inline]
       pub fn set_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
         self.builder.set_data_field::<u16>(0, 1);
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
       }
       #[inline]
       pub fn init_type(self, ) -> crate::schema_capnp::type_::Builder<'a> {
@@ -5271,7 +5271,7 @@ pub mod brand {
       #[inline]
       pub fn has_type(&self) -> bool {
         if self.builder.get_data_field::<u16>(0) != 1 { return false; }
-        !self.builder.get_pointer_field(0).is_null()
+        !self.builder.is_pointer_field_null(0)
       }
       #[inline]
       pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
@@ -5515,7 +5515,7 @@ pub mod value {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -5523,14 +5523,14 @@ pub mod value {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn set_void(&mut self, _value: ())  {
@@ -5594,7 +5594,7 @@ pub mod value {
     #[inline]
     pub fn set_text(&mut self, value: ::capnp::text::Reader<'_>)  {
       self.builder.set_data_field::<u16>(0, 12);
-      self.builder.get_pointer_field(0).set_text(value);
+      self.builder.get_pointer_field_mut(0).set_text(value);
     }
     #[inline]
     pub fn init_text(self, size: u32) -> ::capnp::text::Builder<'a> {
@@ -5604,12 +5604,12 @@ pub mod value {
     #[inline]
     pub fn has_text(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 12 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_data(&mut self, value: ::capnp::data::Reader<'_>)  {
       self.builder.set_data_field::<u16>(0, 13);
-      self.builder.get_pointer_field(0).set_data(value);
+      self.builder.get_pointer_field_mut(0).set_data(value);
     }
     #[inline]
     pub fn init_data(self, size: u32) -> ::capnp::data::Builder<'a> {
@@ -5619,7 +5619,7 @@ pub mod value {
     #[inline]
     pub fn has_data(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 13 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn init_list(self, ) -> ::capnp::any_pointer::Builder<'a> {
@@ -5631,7 +5631,7 @@ pub mod value {
     #[inline]
     pub fn has_list(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 14 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_enum(&mut self, value: u16)  {
@@ -5648,7 +5648,7 @@ pub mod value {
     #[inline]
     pub fn has_struct(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 16 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_interface(&mut self, _value: ())  {
@@ -5664,7 +5664,7 @@ pub mod value {
     #[inline]
     pub fn has_any_pointer(&self) -> bool {
       if self.builder.get_data_field::<u16>(0) != 18 { return false; }
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
@@ -5901,7 +5901,7 @@ pub mod annotation {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -5909,14 +5909,14 @@ pub mod annotation {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_id(self) -> u64 {
@@ -5932,7 +5932,7 @@ pub mod annotation {
     }
     #[inline]
     pub fn set_value(&mut self, value: crate::schema_capnp::value::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_value(self, ) -> crate::schema_capnp::value::Builder<'a> {
@@ -5940,7 +5940,7 @@ pub mod annotation {
     }
     #[inline]
     pub fn has_value(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn get_brand(self) -> ::capnp::Result<crate::schema_capnp::brand::Builder<'a>> {
@@ -5948,7 +5948,7 @@ pub mod annotation {
     }
     #[inline]
     pub fn set_brand(&mut self, value: crate::schema_capnp::brand::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(1), value, false)
     }
     #[inline]
     pub fn init_brand(self, ) -> crate::schema_capnp::brand::Builder<'a> {
@@ -5956,7 +5956,7 @@ pub mod annotation {
     }
     #[inline]
     pub fn has_brand(&self) -> bool {
-      !self.builder.get_pointer_field(1).is_null()
+      !self.builder.is_pointer_field_null(1)
     }
   }
 
@@ -6103,7 +6103,7 @@ pub mod capnp_version {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -6111,14 +6111,14 @@ pub mod capnp_version {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_major(self) -> u16 {
@@ -6267,7 +6267,7 @@ pub mod code_generator_request {
   }
 
   impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
   }
 
   impl <'a,> Builder<'a,>  {
@@ -6275,14 +6275,14 @@ pub mod code_generator_request {
       ::capnp::traits::FromStructReader::new(self.builder.into_reader())
     }
     pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { .. *self }
+      Builder { builder: self.builder.reborrow(), ..*self }
     }
     pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      ::capnp::traits::FromStructReader::new(self.builder.as_reader())
     }
 
     pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+      self.builder.as_reader().total_size()
     }
     #[inline]
     pub fn get_nodes(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::node::Owned>> {
@@ -6290,7 +6290,7 @@ pub mod code_generator_request {
     }
     #[inline]
     pub fn set_nodes(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::node::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(0), value, false)
     }
     #[inline]
     pub fn init_nodes(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::node::Owned> {
@@ -6298,7 +6298,7 @@ pub mod code_generator_request {
     }
     #[inline]
     pub fn has_nodes(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
+      !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn get_requested_files(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::code_generator_request::requested_file::Owned>> {
@@ -6306,7 +6306,7 @@ pub mod code_generator_request {
     }
     #[inline]
     pub fn set_requested_files(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::code_generator_request::requested_file::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(1), value, false)
     }
     #[inline]
     pub fn init_requested_files(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::code_generator_request::requested_file::Owned> {
@@ -6314,7 +6314,7 @@ pub mod code_generator_request {
     }
     #[inline]
     pub fn has_requested_files(&self) -> bool {
-      !self.builder.get_pointer_field(1).is_null()
+      !self.builder.is_pointer_field_null(1)
     }
     #[inline]
     pub fn get_capnp_version(self) -> ::capnp::Result<crate::schema_capnp::capnp_version::Builder<'a>> {
@@ -6322,7 +6322,7 @@ pub mod code_generator_request {
     }
     #[inline]
     pub fn set_capnp_version(&mut self, value: crate::schema_capnp::capnp_version::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(2), value, false)
     }
     #[inline]
     pub fn init_capnp_version(self, ) -> crate::schema_capnp::capnp_version::Builder<'a> {
@@ -6330,7 +6330,7 @@ pub mod code_generator_request {
     }
     #[inline]
     pub fn has_capnp_version(&self) -> bool {
-      !self.builder.get_pointer_field(2).is_null()
+      !self.builder.is_pointer_field_null(2)
     }
     #[inline]
     pub fn get_source_info(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::node::source_info::Owned>> {
@@ -6338,7 +6338,7 @@ pub mod code_generator_request {
     }
     #[inline]
     pub fn set_source_info(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::node::source_info::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(3), value, false)
     }
     #[inline]
     pub fn init_source_info(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::node::source_info::Owned> {
@@ -6346,7 +6346,7 @@ pub mod code_generator_request {
     }
     #[inline]
     pub fn has_source_info(&self) -> bool {
-      !self.builder.get_pointer_field(3).is_null()
+      !self.builder.is_pointer_field_null(3)
     }
   }
 
@@ -6461,7 +6461,7 @@ pub mod code_generator_request {
     }
 
     impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
     }
 
     impl <'a,> Builder<'a,>  {
@@ -6469,14 +6469,14 @@ pub mod code_generator_request {
         ::capnp::traits::FromStructReader::new(self.builder.into_reader())
       }
       pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { .. *self }
+        Builder { builder: self.builder.reborrow(), ..*self }
       }
       pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        ::capnp::traits::FromStructReader::new(self.builder.as_reader())
       }
 
       pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
+        self.builder.as_reader().total_size()
       }
       #[inline]
       pub fn get_id(self) -> u64 {
@@ -6492,7 +6492,7 @@ pub mod code_generator_request {
       }
       #[inline]
       pub fn set_filename(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.get_pointer_field(0).set_text(value);
+        self.builder.get_pointer_field_mut(0).set_text(value);
       }
       #[inline]
       pub fn init_filename(self, size: u32) -> ::capnp::text::Builder<'a> {
@@ -6500,7 +6500,7 @@ pub mod code_generator_request {
       }
       #[inline]
       pub fn has_filename(&self) -> bool {
-        !self.builder.get_pointer_field(0).is_null()
+        !self.builder.is_pointer_field_null(0)
       }
       #[inline]
       pub fn get_imports(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::code_generator_request::requested_file::import::Owned>> {
@@ -6508,7 +6508,7 @@ pub mod code_generator_request {
       }
       #[inline]
       pub fn set_imports(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::code_generator_request::requested_file::import::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(1), value, false)
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field_mut(1), value, false)
       }
       #[inline]
       pub fn init_imports(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::code_generator_request::requested_file::import::Owned> {
@@ -6516,7 +6516,7 @@ pub mod code_generator_request {
       }
       #[inline]
       pub fn has_imports(&self) -> bool {
-        !self.builder.get_pointer_field(1).is_null()
+        !self.builder.is_pointer_field_null(1)
       }
     }
 
@@ -6620,7 +6620,7 @@ pub mod code_generator_request {
       }
 
       impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder(pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+        fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
       }
 
       impl <'a,> Builder<'a,>  {
@@ -6628,14 +6628,14 @@ pub mod code_generator_request {
           ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
         pub fn reborrow(&mut self) -> Builder<'_,> {
-          Builder { .. *self }
+          Builder { builder: self.builder.reborrow(), ..*self }
         }
         pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+          ::capnp::traits::FromStructReader::new(self.builder.as_reader())
         }
 
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.builder.into_reader().total_size()
+          self.builder.as_reader().total_size()
         }
         #[inline]
         pub fn get_id(self) -> u64 {
@@ -6651,7 +6651,7 @@ pub mod code_generator_request {
         }
         #[inline]
         pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
-          self.builder.get_pointer_field(0).set_text(value);
+          self.builder.get_pointer_field_mut(0).set_text(value);
         }
         #[inline]
         pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
@@ -6659,7 +6659,7 @@ pub mod code_generator_request {
         }
         #[inline]
         pub fn has_name(&self) -> bool {
-          !self.builder.get_pointer_field(0).is_null()
+          !self.builder.is_pointer_field_null(0)
         }
       }
 

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -466,7 +466,7 @@ mod tests {
 
         {
             let mut prim_list_list1 = test_complex_list1.reborrow().init_prim_list_list(1);
-            let prim_list_list2 = test_complex_list2.reborrow().init_prim_list_list(1);
+            let mut prim_list_list2 = test_complex_list2.reborrow().init_prim_list_list(1);
             {
                 let mut prim_list1 = prim_list_list1.reborrow().init(0, 3);
                 prim_list1.set(0, 7);
@@ -1819,7 +1819,7 @@ mod tests {
         use crate::test_capnp::test_all_types;
         let mut message = message::Builder::new_default();
         let root: test_all_types::Builder<'_> = message.init_root();
-        let list = root.init_struct_list(2);
+        let mut list = root.init_struct_list(2);
         {
             let mut message1 = message::Builder::new_default();
             let mut root1: test_all_types::Builder<'_> = message1.init_root();


### PR DESCRIPTION
Based on https://github.com/capnproto/capnproto-rust/pull/362 so only the last commit is important here.

The usage of `RefCell` was noticeable in production flamegraphs I gathered and since it is not strictly required, this proposal attempts to remove it.

There are probably other ways but this way was pretty straightforward, even though, very invasive.