### PR TITLE
avoid ambiguous associated item in `TryFrom` implementations

### DIFF
--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1937,7 +1937,7 @@ fn generate_node(
                 ))),
                 Indent(Box::new(Branch(vec![
                     Line(
-                        "fn try_from(value: u16) -> ::core::result::Result<Self, Self::Error> {"
+                        "fn try_from(value: u16) -> ::core::result::Result<Self, <{last_name} as ::core::convert::TryFrom<u16>>::Error> {"
                             .to_string(),
                     ),
                     Indent(Box::new(Branch(vec![


### PR DESCRIPTION
This was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

See also: https://github.com/rust-lang/rust/issues/57644

Without this change, latest versions of cargo would report this:

```
error: ambiguous associated item
   --> src/log_capnp.rs:213:69
    |
213 |             fn try_from(value: u16) -> ::core::result::Result<Self, Self::Error> {
    |                                                                     ^^^^^^^^^^^ help: use fully-qualified syntax: `<Level as TryFrom>::Error`
    |
```