### PR TITLE
Improve getting started instructions

### DIFF
--- a/capnpc/src/lib.rs
+++ b/capnpc/src/lib.rs
@@ -30,11 +30,23 @@
 //! In your Cargo.toml:
 //!
 //! ```ignore
-//! [package]
-//! build = "build.rs"
+//! [dependencies]
+//! capnp = "0.16" # Note this is a different library than capnp*c*
 //!
 //! [build-dependencies]
 //! capnpc = "0.16"
+//! ```
+//!
+//! In your lib.rs:
+//!
+//! ```ignore
+//! mod foo_schema {
+//!     include!(concat!(env!("OUT_DIR"), "/schema_foo.rs"));
+//! }
+//!
+//! mod bar_schema {
+//!     include!(concat!(env!("OUT_DIR"), "/schema_bar.rs"));
+//! }
 //! ```
 //!
 //! In your build.rs:


### PR DESCRIPTION
I removed the redundant `build = "build.rs"`, added the necessary dependency on `capnp`, and provided examples of including the generated files.

I started using capnproto five minutes ago, this is just a guess at the right getting started instructions. I thought I'd throw together a PR with an incremental improvements because the original issue about better instructions is four years old.

Addresses #145