### PR TITLE
Add WeakCapabilityServerSet

### DIFF
--- a/capnp-rpc/src/lib.rs
+++ b/capnp-rpc/src/lib.rs
@@ -65,7 +65,7 @@ use futures::channel::oneshot;
 use futures::{Future, FutureExt, TryFutureExt};
 use std::cell::RefCell;
 use std::pin::Pin;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 use std::task::{Context, Poll};
 
 pub use crate::rpc::Disconnector;
@@ -380,6 +380,80 @@ where
         let hook = client.as_client_hook();
         let ptr = hook.get_ptr();
         self.caps.get(&ptr)
+    }
+}
+
+/// Allows a server to recognize its own capabilities when passed back to it, and obtain the
+/// underlying Server objects associated with them. Holds only weak references to Server objects
+/// allowing Server objects to be dropped when dropped by the remote client. Call the `gc` method
+/// to reclaim memory used for Server objects that have been dropped.
+pub struct WeakCapabilityServerSet<S, C>
+where
+    C: capnp::capability::FromServer<S>,
+{
+    caps: std::collections::HashMap<usize, Weak<RefCell<C::Dispatch>>>,
+}
+
+impl<S, C> Default for WeakCapabilityServerSet<S, C>
+where
+    C: capnp::capability::FromServer<S>,
+{
+    fn default() -> Self {
+        Self {
+            caps: std::default::Default::default(),
+        }
+    }
+}
+
+impl<S, C> WeakCapabilityServerSet<S, C>
+where
+    C: capnp::capability::FromServer<S>,
+{
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a new capability to the set and returns a client backed by it.
+    pub fn new_client(&mut self, s: S) -> C {
+        let dispatch = <C as capnp::capability::FromServer<S>>::from_server(s);
+        let wrapped = Rc::new(RefCell::new(dispatch));
+        let ptr = wrapped.as_ptr() as usize;
+        self.caps.insert(ptr, Rc::downgrade(&wrapped));
+        capnp::capability::FromClientHook::new(Box::new(local::Client::from_rc(wrapped)))
+    }
+
+    /// Looks up a capability and returns its underlying server object, if found.
+    /// Fully resolves the capability before looking it up.
+    pub async fn get_local_server(&self, client: &C) -> Option<Rc<RefCell<C::Dispatch>>>
+    where
+        C: capnp::capability::FromClientHook,
+    {
+        let resolved: C = capnp::capability::get_resolved_cap(
+            capnp::capability::FromClientHook::new(client.as_client_hook().add_ref()),
+        )
+        .await;
+        let hook = resolved.into_client_hook();
+        let ptr = hook.get_ptr();
+        self.caps.get(&ptr).and_then(|c| c.upgrade())
+    }
+
+    /// Looks up a capability and returns its underlying server object, if found.
+    /// Does *not* attempt to resolve the capability first, so you will usually want
+    /// to call `get_resolved_cap()` before calling this. The advantage of this method
+    /// over `get_local_server()` is that this one is synchronous and borrows `self`
+    /// over a shorter span (which can be very important if `self` is inside a `RefCell`).
+    pub fn get_local_server_of_resolved(&self, client: &C) -> Option<Rc<RefCell<C::Dispatch>>>
+    where
+        C: capnp::capability::FromClientHook,
+    {
+        let hook = client.as_client_hook();
+        let ptr = hook.get_ptr();
+        self.caps.get(&ptr).and_then(|c| c.upgrade())
+    }
+
+    /// Reclaim memory used for Server objects that no longer exist.
+    pub fn gc(&mut self) {
+        self.caps.retain(|_, c| c.strong_count() > 0);
     }
 }
 

--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -916,11 +916,11 @@ fn capability_list() {
 fn capability_server_set() {
     use crate::impls;
     use crate::test_capnp::test_interface;
-    use capnp_rpc::CapabilityServerSet;
-    let mut set1: CapabilityServerSet<impls::TestInterface, test_interface::Client> =
-        CapabilityServerSet::new();
-    let mut set2: CapabilityServerSet<impls::TestInterface, test_interface::Client> =
-        CapabilityServerSet::new();
+    use capnp_rpc::WeakCapabilityServerSet;
+    let mut set1: WeakCapabilityServerSet<impls::TestInterface, test_interface::Client> =
+        WeakCapabilityServerSet::new();
+    let mut set2: WeakCapabilityServerSet<impls::TestInterface, test_interface::Client> =
+        WeakCapabilityServerSet::new();
 
     let client_standalone = capnp_rpc::new_client(impls::TestInterface::new());
 
@@ -931,6 +931,10 @@ fn capability_server_set() {
     let own_server2 = impls::TestInterface::new();
     let own_server2_counter = own_server2.get_call_count();
     let client2 = set2.new_client(own_server2);
+
+    // gc() doesn't remove valid entries
+    set1.gc();
+    set2.gc();
 
     // Getting the local server using the correct set works.
     let own_server1_again = futures::executor::block_on(set1.get_local_server(&client1)).unwrap();


### PR DESCRIPTION
Allow Server objects to be dropped when the remote client drops them. Also adds a `gc` method to reclaim memory used for Server objects that have been dropped.

Fixes #388