### PR TITLE
Checkin output of regenerate scripts on HEAD

### DIFF
--- a/capnp-rpc/src/rpc_capnp.rs
+++ b/capnp-rpc/src/rpc_capnp.rs
@@ -6210,7 +6210,7 @@ pub mod exception {
     }
     #[inline]
     pub fn set_type(&mut self, value: crate::rpc_capnp::exception::Type)  {
-      self.builder.set_data_field::<u16>(2, value as u16)
+      self.builder.set_data_field::<u16>(2, value as u16);
     }
     #[inline]
     pub fn get_trace(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {

--- a/capnp-rpc/src/rpc_twoparty_capnp.rs
+++ b/capnp-rpc/src/rpc_twoparty_capnp.rs
@@ -191,7 +191,7 @@ pub mod vat_id {
     }
     #[inline]
     pub fn set_side(&mut self, value: crate::rpc_twoparty_capnp::Side)  {
-      self.builder.set_data_field::<u16>(0, value as u16)
+      self.builder.set_data_field::<u16>(0, value as u16);
     }
   }
 

--- a/capnp/src/schema_capnp.rs
+++ b/capnp/src/schema_capnp.rs
@@ -1765,7 +1765,7 @@ pub mod node {
       }
       #[inline]
       pub fn set_preferred_list_encoding(&mut self, value: crate::schema_capnp::ElementSize)  {
-        self.builder.set_data_field::<u16>(13, value as u16)
+        self.builder.set_data_field::<u16>(13, value as u16);
       }
       #[inline]
       pub fn get_is_group(self) -> bool {


### PR DESCRIPTION
Based on a git bisect I think somone forgot to run the regenerate scripts after dd2f7351fe124cf71a63cb0162f19b876a4f7ef3.

This changes formatting only, the code behaves identically.