### PR TITLE
Add annotation for getting field as Rust Option

### DIFF
--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -3479,6 +3479,11 @@ impl<'a> StructReader<'a> {
         }
     }
 
+    #[inline]
+    pub fn is_pointer_field_null(&self, ptr_index: WirePointerCount) -> bool {
+        unsafe { (*self.pointers.add(ptr_index)).is_null() }
+    }
+
     pub fn total_size(&self) -> Result<MessageSize> {
         let mut result = MessageSize {
             word_count: u64::from(wire_helpers::round_bits_up_to_words(u64::from(

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -3481,7 +3481,11 @@ impl<'a> StructReader<'a> {
 
     #[inline]
     pub fn is_pointer_field_null(&self, ptr_index: WirePointerCount) -> bool {
-        unsafe { (*self.pointers.add(ptr_index)).is_null() }
+        if ptr_index < self.pointer_count as WirePointerCount {
+            unsafe { (*self.pointers.add(ptr_index)).is_null() }
+        } else {
+            true
+        }
     }
 
     pub fn total_size(&self) -> Result<MessageSize> {

--- a/capnpc/rust.capnp
+++ b/capnpc/rust.capnp
@@ -26,3 +26,20 @@ annotation parentModule @0xabee386cd1450364 (file) :Text;
 #      }
 #    }
 #  }
+
+annotation getOption @0xabfef22c4ee1964e (field) :Void;
+# Whether the generated code should return an Option. Supported on Text, Data,
+# List, and struct fields.
+#
+# Given
+#
+#     struct Test {
+#         field @0 :Text $Rust.getOption;
+#     }
+#
+# you get getters like so
+#
+#     assert_eq!(struct_with.get_field(), Some("foo"));
+#     assert_eq!(struct_without.get_field(), None));
+#
+# The setters are unchanged to match the Rust convention.

--- a/capnpc/rust.capnp
+++ b/capnpc/rust.capnp
@@ -28,8 +28,8 @@ annotation parentModule @0xabee386cd1450364 (file) :Text;
 #  }
 
 annotation getOption @0xabfef22c4ee1964e (field) :Void;
-# Whether the generated code should return an Option. Supported on Text, Data,
-# List, and struct fields.
+# Whether the generated code should return an Option. Supported on pointer
+# fields.
 #
 # Given
 #

--- a/capnpc/rust.capnp
+++ b/capnpc/rust.capnp
@@ -27,14 +27,18 @@ annotation parentModule @0xabee386cd1450364 (file) :Text;
 #    }
 #  }
 
-annotation getOption @0xabfef22c4ee1964e (field) :Void;
-# Whether the generated code should return an Option. Supported on pointer
-# fields.
+annotation option @0xabfef22c4ee1964e (field) :Void;
+# Make the generated getters return Option<T> instead of T. Supported on
+# pointer types (e.g. structs, lists, and blobs).
+#
+# Capnp pointer types are nullable. Normally get_field will return the default
+# value if the field isn't set. With this annotation you get Some(...) when
+# the field is set and None when it isn't.
 #
 # Given
 #
 #     struct Test {
-#         field @0 :Text $Rust.getOption;
+#         field @0 :Text $Rust.option;
 #     }
 #
 # you get getters like so
@@ -43,3 +47,5 @@ annotation getOption @0xabfef22c4ee1964e (field) :Void;
 #     assert_eq!(struct_without.get_field(), None));
 #
 # The setters are unchanged to match the Rust convention.
+#
+# Note: Support for this annotation on interfaces isn't implemented yet.

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -797,9 +797,9 @@ pub fn getter_text(
                             ::capnp::raw::get_struct_pointer_section(default_value).get(0),
                             crate::pointer_constants::WordArrayDeclarationOptions { public: true },
                         )?);
-                        format!("Some(&_private::{default_name}[..])")
+                        format!("::core::option::Option::Some(&_private::{default_name}[..])")
                     } else {
-                        "None".to_string()
+                        "::core::option::Option::None".to_string()
                     };
 
                     if is_reader {
@@ -831,13 +831,18 @@ pub fn getter_text(
                         "if self.{member}.is_pointer_field_null({offset}) {{"
                     )),
                     Indent(Box::new(Line(
-                        if is_fallible { "Ok(None)" } else { "None" }.to_string(),
+                        if is_fallible {
+                            "core::result::Result::Ok(core::option::Option::None)"
+                        } else {
+                            "::core::option::Option::None"
+                        }
+                        .to_string(),
                     ))),
                     Line("} else {".to_string()),
                     Indent(Box::new(Line(if is_fallible {
-                        format!("{getter_fragment}.map(Some)")
+                        format!("{getter_fragment}.map(::core::option::Option::Some)")
                     } else {
-                        format!("Some({getter_fragment})")
+                        format!("::core::option::Option::Some({getter_fragment})")
                     }))),
                     Line("}".to_string()),
                 ])
@@ -2519,7 +2524,7 @@ fn generate_node(
                 )));
 
                 client_impl_interior.push(Indent(Box::new(Line(format!(
-                    "self.client.new_call(_private::TYPE_ID, {ordinal}, None)"
+                    "self.client.new_call(_private::TYPE_ID, {ordinal}, ::core::option::Option::None)"
                 )))));
                 client_impl_interior.push(Line("}".to_string()));
 

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -565,17 +565,14 @@ fn should_get_option(field: schema_capnp::field::Reader) -> capnp::Result<bool> 
     if enabled {
         let supported = match field.which()? {
             field::Which::Group(_) => false,
-            field::Which::Slot(reg_field) => {
-                matches!(
-                    reg_field.get_type()?.which()?,
-                    type_::Text(()) | type_::Data(()) | type_::List(_) | type_::Struct(_),
-                )
+            field::Which::Slot(field) => {
+                let ty = field.get_type()?;
+                ty.is_pointer()? && !matches!(ty.which()?, type_::Interface(_))
             }
         };
         if !supported {
             return Err(capnp::Error::failed(
-                "rust.getOption annotation is only supported on Text, Data, List, and struct fields"
-                    .to_string(),
+                "rust.getOption annotation is only supported on pointer fields (support for optional interfaces isn't implemented yet)".to_string(),
             ));
         }
     }
@@ -695,13 +692,11 @@ pub fn getter_text(
                 offset: usize,
                 default: T,
                 zero: T,
-            ) -> FormattedText {
+            ) -> String {
                 if default == zero {
-                    Line(format!("self.{member}.get_data_field::<{typ}>({offset})"))
+                    format!("self.{member}.get_data_field::<{typ}>({offset})")
                 } else {
-                    Line(format!(
-                        "self.{member}.get_data_field_mask::<{typ}>({offset}, {default})"
-                    ))
+                    format!("self.{member}.get_data_field_mask::<{typ}>({offset}, {default})")
                 }
             }
 
@@ -721,18 +716,22 @@ pub fn getter_text(
                 inner_type
             };
 
-            let mut result_type = match raw_type.which()? {
-                type_::Enum(_) => fmt!(ctx, "::core::result::Result<{typ},{capnp}::NotInSchema>"),
-                type_::AnyPointer(_) if !raw_type.is_parameter()? => typ.clone(),
-                type_::Interface(_) => {
+            let (is_fallible, mut result_type) = match raw_type.which()? {
+                type_::Enum(_) => (
+                    true,
+                    fmt!(ctx, "::core::result::Result<{typ},{capnp}::NotInSchema>"),
+                ),
+                type_::AnyPointer(_) if !raw_type.is_parameter()? => (false, typ.clone()),
+                type_::Interface(_) => (
+                    true,
                     fmt!(
                         ctx,
                         "{capnp}::Result<{}>",
                         raw_type.type_string(ctx, Leaf::Client)?
-                    )
-                }
-                _ if raw_type.is_prim()? => typ.clone(),
-                _ => fmt!(ctx, "{capnp}::Result<{typ}>"),
+                    ),
+                ),
+                _ if raw_type.is_prim()? => (false, typ.clone()),
+                _ => (true, fmt!(ctx, "{capnp}::Result<{typ}>")),
             };
 
             if is_fn {
@@ -743,19 +742,19 @@ pub fn getter_text(
                 }
             }
 
-            let getter_code = match (raw_type.which()?, default) {
+            let getter_fragment = match (raw_type.which()?, default) {
                 (type_::Void(()), value::Void(())) => {
                     if is_fn {
-                        Line("".to_string())
+                        "".to_string()
                     } else {
-                        Line("()".to_string())
+                        "()".to_string()
                     }
-                },
+                }
                 (type_::Bool(()), value::Bool(b)) => {
                     if b {
-                        Line(format!("self.{member}.get_bool_field_mask({offset}, true)"))
+                        format!("self.{member}.get_bool_field_mask({offset}, true)")
                     } else {
-                        Line(format!("self.{member}.get_bool_field({offset})"))
+                        format!("self.{member}.get_bool_field({offset})")
                     }
                 }
                 (type_::Int8(()), value::Int8(i)) => primitive_case(&typ, &member, offset, i, 0),
@@ -763,73 +762,87 @@ pub fn getter_text(
                 (type_::Int32(()), value::Int32(i)) => primitive_case(&typ, &member, offset, i, 0),
                 (type_::Int64(()), value::Int64(i)) => primitive_case(&typ, &member, offset, i, 0),
                 (type_::Uint8(()), value::Uint8(i)) => primitive_case(&typ, &member, offset, i, 0),
-                (type_::Uint16(()), value::Uint16(i)) => primitive_case(&typ, &member, offset, i, 0),
-                (type_::Uint32(()), value::Uint32(i)) => primitive_case(&typ, &member, offset, i, 0),
-                (type_::Uint64(()), value::Uint64(i)) => primitive_case(&typ, &member, offset, i, 0),
-                (type_::Float32(()), value::Float32(f)) =>
-                    primitive_case(&typ, &member, offset, f.to_bits(), 0),
-                (type_::Float64(()), value::Float64(f)) =>
-                    primitive_case(&typ, &member, offset, f.to_bits(), 0),
+                (type_::Uint16(()), value::Uint16(i)) => {
+                    primitive_case(&typ, &member, offset, i, 0)
+                }
+                (type_::Uint32(()), value::Uint32(i)) => {
+                    primitive_case(&typ, &member, offset, i, 0)
+                }
+                (type_::Uint64(()), value::Uint64(i)) => {
+                    primitive_case(&typ, &member, offset, i, 0)
+                }
+                (type_::Float32(()), value::Float32(f)) => {
+                    primitive_case(&typ, &member, offset, f.to_bits(), 0)
+                }
+                (type_::Float64(()), value::Float64(f)) => {
+                    primitive_case(&typ, &member, offset, f.to_bits(), 0)
+                }
                 (type_::Enum(_), value::Enum(d)) => {
                     if d == 0 {
-                        Line(format!("::core::convert::TryInto::try_into(self.{member}.get_data_field::<u16>({offset}))"))
+                        format!("::core::convert::TryInto::try_into(self.{member}.get_data_field::<u16>({offset}))")
                     } else {
-                        Line(
-                            format!(
-                                "::core::convert::TryInto::try_into(self.{member}.get_data_field_mask::<u16>({offset}, {d}))"))
+                        format!(
+                                "::core::convert::TryInto::try_into(self.{member}.get_data_field_mask::<u16>({offset}, {d}))")
                     }
                 }
 
-                (type_::Text(()), value::Text(_)) |
-                (type_::Data(()), value::Data(_)) |
-                (type_::List(_), value::List(_)) |
-                (type_::Struct(_), value::Struct(_)) => {
+                (type_::Text(()), value::Text(_))
+                | (type_::Data(()), value::Data(_))
+                | (type_::List(_), value::List(_))
+                | (type_::Struct(_), value::Struct(_)) => {
                     let default = if reg_field.get_had_explicit_default() {
                         default_decl = Some(crate::pointer_constants::word_array_declaration(
                             ctx,
                             &default_name,
                             ::capnp::raw::get_struct_pointer_section(default_value).get(0),
-                            crate::pointer_constants::WordArrayDeclarationOptions {public: true})?);
+                            crate::pointer_constants::WordArrayDeclarationOptions { public: true },
+                        )?);
                         format!("Some(&_private::{default_name}[..])")
                     } else {
-                        "::core::option::Option::None".to_string()
+                        "None".to_string()
                     };
 
                     if is_reader {
-                        if should_get_option {
-                            let mut interior = Vec::new();
-                            interior.push(Line(format!("let ptr = self.{member}.get_pointer_field({offset});")));
-                            interior.push(Line("if ptr.is_null() {".to_string()));
-                            interior.push(Indent(Box::new(Line("Ok(None)".to_string()))));
-                            interior.push(Line("} else {".to_string()));
-                            interior.push(Indent(
-                                Box::new(Line(fmt!(ctx,
-                                    "{capnp}::traits::FromPointerReader::get_from_pointer(&ptr, None).map(Some)")))
-                            ));
-                            interior.push(Line("}".to_string()));
-                            Branch(interior)
-                        } else {
-                        Line(fmt!(ctx,
-                            "{capnp}::traits::FromPointerReader::get_from_pointer(&self.{member}.get_pointer_field({offset}), {default})"))
-                        }
+                        fmt!(ctx,
+                            "{capnp}::traits::FromPointerReader::get_from_pointer(&self.{member}.get_pointer_field({offset}), {default})")
                     } else {
-                        Line(fmt!(ctx,"{capnp}::traits::FromPointerBuilder::get_from_pointer(self.{member}.get_pointer_field({offset}), {default})"))
+                        fmt!(ctx,"{capnp}::traits::FromPointerBuilder::get_from_pointer(self.{member}.get_pointer_field({offset}), {default})")
                     }
                 }
 
                 (type_::Interface(_), value::Interface(_)) => {
-                    Line(fmt!(ctx,"match self.{member}.get_pointer_field({offset}).get_capability() {{ ::core::result::Result::Ok(c) => ::core::result::Result::Ok({capnp}::capability::FromClientHook::new(c)), ::core::result::Result::Err(e) => ::core::result::Result::Err(e)}}"))
+                    fmt!(ctx,"match self.{member}.get_pointer_field({offset}).get_capability() {{ ::core::result::Result::Ok(c) => ::core::result::Result::Ok({capnp}::capability::FromClientHook::new(c)), ::core::result::Result::Err(e) => ::core::result::Result::Err(e)}}")
                 }
                 (type_::AnyPointer(_), value::AnyPointer(_)) => {
                     if !raw_type.is_parameter()? {
-                        Line(fmt!(ctx,"{capnp}::any_pointer::{module_string}::new(self.{member}.get_pointer_field({offset}))"))
+                        fmt!(ctx,"{capnp}::any_pointer::{module_string}::new(self.{member}.get_pointer_field({offset}))")
                     } else if is_reader {
-                        Line(fmt!(ctx,"{capnp}::traits::FromPointerReader::get_from_pointer(&self.{member}.get_pointer_field({offset}), ::core::option::Option::None)"))
+                        fmt!(ctx,"{capnp}::traits::FromPointerReader::get_from_pointer(&self.{member}.get_pointer_field({offset}), ::core::option::Option::None)")
                     } else {
-                        Line(fmt!(ctx,"{capnp}::traits::FromPointerBuilder::get_from_pointer(self.{member}.get_pointer_field({offset}), ::core::option::Option::None)"))
+                        fmt!(ctx,"{capnp}::traits::FromPointerBuilder::get_from_pointer(self.{member}.get_pointer_field({offset}), ::core::option::Option::None)")
                     }
                 }
                 _ => return Err(Error::failed("default value was of wrong type".to_string())),
+            };
+
+            let getter_code = if should_get_option && is_reader {
+                Branch(vec![
+                    Line(format!(
+                        "if self.{member}.get_pointer_field({offset}).is_null() {{"
+                    )),
+                    Indent(Box::new(Line(
+                        if is_fallible { "Ok(None)" } else { "None" }.to_string(),
+                    ))),
+                    Line("} else {".to_string()),
+                    Indent(Box::new(Line(if is_fallible {
+                        format!("{getter_fragment}.map(Some)")
+                    } else {
+                        format!("Some({getter_fragment})")
+                    }))),
+                    Line("}".to_string()),
+                ])
+            } else {
+                Line(getter_fragment)
             };
 
             Ok((result_type, getter_code, default_decl))

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -489,7 +489,7 @@ fn module_name(camel_case: &str) -> String {
 // Annotation IDs, as defined in rust.capnp.
 const NAME_ANNOTATION_ID: u64 = 0xc2fe4c6d100166d0;
 const PARENT_MODULE_ANNOTATION_ID: u64 = 0xabee386cd1450364;
-const GET_OPTION_ANNOTATION_ID: u64 = 0xabfef22c4ee1964e;
+const OPTION_ANNOTATION_ID: u64 = 0xabfef22c4ee1964e;
 
 fn name_annotation_value(annotation: schema_capnp::annotation::Reader) -> capnp::Result<&str> {
     if let schema_capnp::value::Text(t) = annotation.get_value()?.which()? {
@@ -554,13 +554,13 @@ fn capnp_name_to_rust_name(capnp_name: &str, name_kind: NameKind) -> String {
     }
 }
 
-fn should_get_option(field: schema_capnp::field::Reader) -> capnp::Result<bool> {
+fn is_option_field(field: schema_capnp::field::Reader) -> capnp::Result<bool> {
     use capnp::schema_capnp::*;
 
     let enabled = field
         .get_annotations()?
         .iter()
-        .any(|a| a.get_id() == GET_OPTION_ANNOTATION_ID);
+        .any(|a| a.get_id() == OPTION_ANNOTATION_ID);
 
     if enabled {
         let supported = match field.which()? {
@@ -572,7 +572,7 @@ fn should_get_option(field: schema_capnp::field::Reader) -> capnp::Result<bool> 
         };
         if !supported {
             return Err(capnp::Error::failed(
-                "rust.getOption annotation is only supported on pointer fields (support for optional interfaces isn't implemented yet)".to_string(),
+                "$Rust.option annotation only supported on pointer fields (support for optional interfaces isn't implemented yet)".to_string(),
             ));
         }
     }
@@ -708,7 +708,7 @@ pub fn getter_text(
                 "DEFAULT_{}",
                 snake_to_upper_case(&camel_to_snake_case(get_field_name(*field)?))
             );
-            let should_get_option = should_get_option(*field)?;
+            let should_get_option = is_option_field(*field)?;
 
             let typ = if should_get_option {
                 format!("Option<{}>", inner_type)

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -828,7 +828,7 @@ pub fn getter_text(
             let getter_code = if should_get_option && is_reader {
                 Branch(vec![
                     Line(format!(
-                        "if self.{member}.get_pointer_field({offset}).is_null() {{"
+                        "if self.{member}.is_pointer_field_null({offset}) {{"
                     )),
                     Indent(Box::new(Line(
                         if is_fallible { "Ok(None)" } else { "None" }.to_string(),

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -710,7 +710,7 @@ pub fn getter_text(
             );
             let should_get_option = should_get_option(*field)?;
 
-            let typ = if should_get_option && is_reader {
+            let typ = if should_get_option {
                 format!("Option<{}>", inner_type)
             } else {
                 inner_type
@@ -825,7 +825,7 @@ pub fn getter_text(
                 _ => return Err(Error::failed("default value was of wrong type".to_string())),
             };
 
-            let getter_code = if should_get_option && is_reader {
+            let getter_code = if should_get_option {
                 Branch(vec![
                     Line(format!(
                         "if self.{member}.is_pointer_field_null({offset}) {{"

--- a/capnpc/src/codegen_types.rs
+++ b/capnpc/src/codegen_types.rs
@@ -97,6 +97,7 @@ pub trait RustNodeInfo {
 // this is a collection of helpers acting on a "Type" (someplace where a Type is used, not defined)
 pub trait RustTypeInfo {
     fn is_prim(&self) -> Result<bool, Error>;
+    fn is_pointer(&self) -> Result<bool, Error>;
     fn is_parameter(&self) -> Result<bool, Error>;
     fn is_branded(&self) -> Result<bool, Error>;
     fn type_string(&self, ctx: &GeneratorContext, module: Leaf) -> Result<String, Error>;
@@ -329,6 +330,19 @@ impl<'a> RustTypeInfo for type_::Reader<'a> {
             | type_::Bool(()) => Ok(true),
             _ => Ok(false),
         }
+    }
+
+    #[inline(always)]
+    fn is_pointer(&self) -> Result<bool, Error> {
+        Ok(matches!(
+            self.which()?,
+            type_::Text(())
+                | type_::Data(())
+                | type_::List(_)
+                | type_::Struct(_)
+                | type_::Interface(_)
+                | type_::AnyPointer(_)
+        ))
     }
 }
 

--- a/capnpc/test/test.capnp
+++ b/capnpc/test/test.capnp
@@ -452,6 +452,7 @@ struct TestFieldGetOption {
   list @2 :List(UInt8) $Rust.getOption;
   emptyStruct @3 :EmptyStruct $Rust.getOption;
   simpleStruct @4 :SimpleStruct $Rust.getOption;
+  any @5 :AnyPointer $Rust.getOption;
 
   struct EmptyStruct {}
   struct SimpleStruct {

--- a/capnpc/test/test.capnp
+++ b/capnpc/test/test.capnp
@@ -447,16 +447,16 @@ struct TestNewUnionVersion {
 }
 
 struct TestFieldGetOption {
-  text @0 :Text $Rust.getOption;
-  data @1 :Data $Rust.getOption;
-  list @2 :List(UInt8) $Rust.getOption;
-  emptyStruct @3 :EmptyStruct $Rust.getOption;
-  simpleStruct @4 :SimpleStruct $Rust.getOption;
-  any @5 :AnyPointer $Rust.getOption;
+  text @0 :Text $Rust.option;
+  data @1 :Data $Rust.option;
+  list @2 :List(UInt8) $Rust.option;
+  emptyStruct @3 :EmptyStruct $Rust.option;
+  simpleStruct @4 :SimpleStruct $Rust.option;
+  any @5 :AnyPointer $Rust.option;
 
   struct EmptyStruct {}
   struct SimpleStruct {
-    field @0 :Text $Rust.getOption;
+    field @0 :Text $Rust.option;
   }
 }
 

--- a/capnpc/test/test.capnp
+++ b/capnpc/test/test.capnp
@@ -446,6 +446,19 @@ struct TestNewUnionVersion {
   }
 }
 
+struct TestFieldGetOption {
+  text @0 :Text $Rust.getOption;
+  data @1 :Data $Rust.getOption;
+  list @2 :List(UInt8) $Rust.getOption;
+  emptyStruct @3 :EmptyStruct $Rust.getOption;
+  simpleStruct @4 :SimpleStruct $Rust.getOption;
+
+  struct EmptyStruct {}
+  struct SimpleStruct {
+    field @0 :Text $Rust.getOption;
+  }
+}
+
 struct TestGenerics(Foo, Bar) {
   foo @0 :Foo;
   bar @1 :Bar;

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -724,7 +724,7 @@ mod tests {
     }
 
     #[test]
-    fn test_field_as_option() -> capnp::Result<()> {
+    fn test_field_get_option() -> capnp::Result<()> {
         use crate::test_capnp::test_field_get_option as subject;
 
         let mut message_set = message::Builder::new_default();

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -743,6 +743,10 @@ mod tests {
         }
         test_set.reborrow().init_empty_struct();
         test_set.reborrow().init_simple_struct().set_field("buzz");
+        {
+            let mut b = test_set.reborrow().init_any();
+            b.set_as("dyn")?;
+        }
 
         let set_reader = test_set.into_reader();
         let unset_reader = test_unset.into_reader();
@@ -765,6 +769,9 @@ mod tests {
         assert!(unset_reader.get_simple_struct()?.is_none());
         let r = set_reader.get_simple_struct()?.expect("is some");
         assert_eq!(r.get_field()?, Some("buzz"));
+
+        assert!(unset_reader.get_any().is_none());
+        assert!(set_reader.get_any().is_some());
 
         Ok(())
     }


### PR DESCRIPTION
Given

```capnp
struct Test {
    field @0 :Text $Rust.option;
}
```

you get getters like so

```rust
assert_eq!(struct_with.get_field(), Some("foo"));
assert_eq!(struct_without.get_field(), None));
```

The setters are unchanged to match the Rust convention.

Fixes #249.