### PR TITLE
Get miri passing again and add to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,39 @@ jobs:
     - name: Run benchmark
       run: ./target/release/run_all_benchmarks target/release/benchmark
 
+  miri:
+    name: "Miri"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: miri
+
+      - name: Setup miri
+        run: cargo miri setup
+
+      - name: Install Cap'n Proto
+        run: |
+            export DEBIAN_FRONTEND=noninteractive
+            sudo apt-get install -y capnproto libcapnp-dev
+
+      - name: Test default features
+        run: cargo miri test --package capnp --package capnpc-test
+
+      - name: Test no default features
+        run: cargo miri test --package capnp --package capnpc-test --no-default-features
+
+      - name: Test sync_reader
+        run: cargo miri test --package capnp --package capnpc-test --features sync_reader
+
+      - name: Test unaligned
+        run: cargo miri test --package capnp --package capnpc-test --features unaligned
+
   minrust:
     name: minrust
     runs-on: ubuntu-latest

--- a/capnp-futures/src/serialize.rs
+++ b/capnp-futures/src/serialize.rs
@@ -640,6 +640,7 @@ pub mod test {
         }
     }
 
+    #[cfg_attr(miri, ignore)] // Miri takes a long time with quickcheck
     #[test]
     fn check_round_trip_async() {
         fn round_trip(

--- a/capnp-futures/src/serialize_packed.rs
+++ b/capnp-futures/src/serialize_packed.rs
@@ -680,6 +680,7 @@ pub mod test {
         .is_failure());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn check_packed_round_trip_async() {
         quickcheck(round_trip as fn(usize, usize, Vec<Vec<capnp::Word>>) -> TestResult);

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -2157,6 +2157,7 @@ mod tests {
         CheckTestMessage::check_test_message(message_reader.get().unwrap());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn test_raw_code_generator_request_path() {
         use capnp::serialize;

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -89,7 +89,7 @@ mod tests {
     use crate::test_util::{init_test_message, CheckTestMessage};
     use capnp::message::ReaderOptions;
     use capnp::message::{self, TypedBuilder, TypedReader};
-    use capnp::{primitive_list, text};
+    use capnp::{primitive_list, text, Word};
 
     // like the unstable std::assert_matches::assert_matches but doesn't
     // require $left implement Debug
@@ -2123,11 +2123,16 @@ mod tests {
         CheckTestMessage::check_test_message(typed_builder.get_root().unwrap());
         CheckTestMessage::check_test_message(typed_builder.get_root_as_reader().unwrap());
 
-        let mut buffer = vec![];
-        capnp::serialize::write_message(&mut buffer, typed_builder.borrow_inner()).unwrap();
+        let mut buffer = Word::allocate_zeroed_vec(512);
+
+        capnp::serialize::write_message(
+            Word::words_to_bytes_mut(&mut buffer),
+            typed_builder.borrow_inner(),
+        )
+        .unwrap();
 
         let reader = capnp::serialize::read_message_from_flat_slice(
-            &mut buffer.as_slice(),
+            &mut Word::words_to_bytes(&buffer),
             ReaderOptions::new(),
         )
         .unwrap();
@@ -2145,11 +2150,16 @@ mod tests {
         CheckTestMessage::check_test_message(typed_builder.get_root().unwrap());
         CheckTestMessage::check_test_message(typed_builder.get_root_as_reader().unwrap());
 
-        let mut buffer = vec![];
-        capnp::serialize::write_message(&mut buffer, typed_builder.borrow_inner()).unwrap();
+        let mut buffer = Word::allocate_zeroed_vec(512);
+
+        capnp::serialize::write_message(
+            Word::words_to_bytes_mut(&mut buffer),
+            typed_builder.borrow_inner(),
+        )
+        .unwrap();
 
         let reader = capnp::serialize::read_message_from_flat_slice_no_alloc(
-            &mut buffer.as_slice(),
+            &mut Word::words_to_bytes(&buffer),
             ReaderOptions::new(),
         )
         .unwrap();


### PR DESCRIPTION
The only substantive change is [using a raw pointer instead of a reference](https://github.com/capnproto/capnproto-rust/pull/406/commits/a4874defa8b6a3616d0b0cbf0574289ff4387238). This is a change to a public function in capnp::private so I don't think it's a breaking change.