### PR TITLE
Replace error strings with enums

### DIFF
--- a/benchmark/benchmark.rs
+++ b/benchmark/benchmark.rs
@@ -470,7 +470,7 @@ fn try_main() -> ::capnp::Result<()> {
         return Err(::capnp::Error::failed(format!(
             "Could not parse a u64 from: {}",
             args[5]
-        )))
+        )));
     };
 
     let mode = Mode::parse(&args[2])?;

--- a/capnp-futures/src/serialize.rs
+++ b/capnp-futures/src/serialize.rs
@@ -52,7 +52,7 @@ where
     R: AsyncRead + Unpin,
 {
     let Some(segment_lengths_builder) = read_segment_table(&mut reader, options).await? else {
-        return Ok(None)
+        return Ok(None);
     };
     Ok(Some(
         read_segments(

--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -355,12 +355,16 @@ fn to_pipeline_ops(
 }
 
 fn from_error(error: &Error, mut builder: exception::Builder) {
-    builder.set_reason(&error.description);
+    builder.set_reason(&error.to_string());
     let typ = match error.kind {
         ::capnp::ErrorKind::Failed => exception::Type::Failed,
         ::capnp::ErrorKind::Overloaded => exception::Type::Overloaded,
         ::capnp::ErrorKind::Disconnected => exception::Type::Disconnected,
         ::capnp::ErrorKind::Unimplemented => exception::Type::Unimplemented,
+        ::capnp::ErrorKind::SettingDynamicCapabilitiesIsUnsupported => {
+            exception::Type::Unimplemented
+        }
+        _ => exception::Type::Failed,
     };
     builder.set_type(typ);
 }
@@ -378,7 +382,7 @@ fn remote_exception_to_error(exception: exception::Reader) -> Error {
         _ => (::capnp::ErrorKind::Failed, "(malformed error)"),
     };
     Error {
-        description: format!("remote exception: {reason}"),
+        extra: format!("remote exception: {reason}"),
         kind,
     }
 }

--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -651,7 +651,7 @@ impl<VatId> ConnectionState<VatId> {
         let Some(state) = weak_state.upgrade() else {
             return Promise::err(Error::disconnected(
                 "message loop cannot continue without a connection".into(),
-            ))
+            ));
         };
 
         let promise = match *state.connection.borrow_mut() {
@@ -898,7 +898,7 @@ impl<VatId> ConnectionState<VatId> {
         let Some(connection_state) = weak_state.upgrade() else {
             return Err(Error::disconnected(
                 "handle_message() cannot continue without a connection".into(),
-            ))
+            ));
         };
 
         let reader = message.get_body()?.get_as::<message::Reader>()?;
@@ -2045,7 +2045,7 @@ impl<VatId> Pipeline<VatId> {
             let resolve_self_promise =
                 connection_state.eagerly_evaluate(fork.clone().then(move |response| {
                     let Some(state) = this.upgrade() else {
-                        return Promise::err(Error::failed("dangling reference to this".into()))
+                        return Promise::err(Error::failed("dangling reference to this".into()));
                     };
                     PipelineState::resolve(&state, response);
                     Promise::ok(())

--- a/capnp-rpc/test/reconnect_test.rs
+++ b/capnp-rpc/test/reconnect_test.rs
@@ -101,8 +101,8 @@ macro_rules! assert_err {
         let e1 = $e1;
         let e2 = $e2;
         assert_eq!(e1.kind, e2.kind);
-        if !e1.description.ends_with(&e2.description) {
-            assert_eq!(e1.description, e2.description);
+        if !e1.extra.ends_with(&e2.extra) {
+            assert_eq!(e1.extra, e2.extra);
         }
     };
 }

--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -335,9 +335,7 @@ fn pipelining_return_null() {
         let cap = request.send().pipeline.get_cap();
         match cap.foo_request().send().promise.await {
             Err(ref e) => {
-                if e.description
-                    .contains("Message contains null capability pointer")
-                {
+                if e.extra.contains("Message contains null capability pointer") {
                     Ok(())
                 } else {
                     Err(Error::failed(format!(

--- a/capnp/Cargo.toml
+++ b/capnp/Cargo.toml
@@ -21,7 +21,8 @@ quickcheck = { version = "1", optional = true }
 quickcheck = "1"
 
 [features]
-default = ["std"]
+alloc = []
+default = ["std", "alloc"]
 
 rpc_try = []
 

--- a/capnp/src/any_pointer.rs
+++ b/capnp/src/any_pointer.rs
@@ -21,10 +21,12 @@
 
 //! Untyped pointer that can be cast to any struct, list, or capability type.
 
-use alloc::boxed::Box;
-use alloc::vec::Vec;
+#[cfg(feature = "alloc")]
+use alloc::{boxed::Box, vec::Vec};
 
+#[cfg(feature = "alloc")]
 use crate::capability::FromClientHook;
+#[cfg(feature = "alloc")]
 use crate::private::capability::{ClientHook, PipelineHook, PipelineOp};
 use crate::private::layout::{PointerBuilder, PointerReader};
 use crate::traits::{FromPointerBuilder, FromPointerReader, SetPointerBuilder};
@@ -44,6 +46,7 @@ impl crate::introspect::Introspect for Owned {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl crate::traits::Pipelined for Owned {
     type Pipeline = Pipeline;
 }
@@ -73,12 +76,14 @@ impl<'a> Reader<'a> {
         FromPointerReader::get_from_pointer(&self.reader, None)
     }
 
+    #[cfg(feature = "alloc")]
     pub fn get_as_capability<T: FromClientHook>(&self) -> Result<T> {
         Ok(FromClientHook::new(self.reader.get_capability()?))
     }
 
     //# Used by RPC system to implement pipelining. Applications
     //# generally shouldn't use this directly.
+    #[cfg(feature = "alloc")]
     pub fn get_pipelined_cap(&self, ops: &[PipelineOp]) -> Result<Box<dyn ClientHook>> {
         let mut pointer = self.reader;
 
@@ -117,6 +122,7 @@ impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
     fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
         self.reader
@@ -165,6 +171,7 @@ impl<'a> Builder<'a> {
     }
 
     // XXX value should be a user client.
+    #[cfg(feature = "alloc")]
     pub fn set_as_capability(&mut self, value: Box<dyn ClientHook>) {
         self.builder.set_capability(value);
     }
@@ -199,6 +206,7 @@ impl<'a> FromPointerBuilder<'a> for Builder<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
     fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
         self.builder
@@ -206,6 +214,7 @@ impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 pub struct Pipeline {
     // XXX this should not be public
     pub hook: Box<dyn PipelineHook>,
@@ -213,6 +222,7 @@ pub struct Pipeline {
     ops: Vec<PipelineOp>,
 }
 
+#[cfg(feature = "alloc")]
 impl Pipeline {
     pub fn new(hook: Box<dyn PipelineHook>) -> Self {
         Self {
@@ -245,24 +255,28 @@ impl Pipeline {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl crate::capability::FromTypelessPipeline for Pipeline {
     fn new(typeless: Pipeline) -> Self {
         typeless
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<Reader<'a>> for crate::dynamic_value::Reader<'a> {
     fn from(a: Reader<'a>) -> crate::dynamic_value::Reader<'a> {
         crate::dynamic_value::Reader::AnyPointer(a)
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<Builder<'a>> for crate::dynamic_value::Builder<'a> {
     fn from(a: Builder<'a>) -> crate::dynamic_value::Builder<'a> {
         crate::dynamic_value::Builder::AnyPointer(a)
     }
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn init_clears_value() {
     let mut message = crate::message::Builder::new_default();

--- a/capnp/src/any_pointer_list.rs
+++ b/capnp/src/any_pointer_list.rs
@@ -189,6 +189,7 @@ impl<'a> core::iter::IntoIterator for Reader<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<Reader<'a>> for crate::dynamic_value::Reader<'a> {
     fn from(t: Reader<'a>) -> crate::dynamic_value::Reader<'a> {
         crate::dynamic_value::Reader::List(crate::dynamic_list::Reader::new(
@@ -198,6 +199,7 @@ impl<'a> From<Reader<'a>> for crate::dynamic_value::Reader<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<Builder<'a>> for crate::dynamic_value::Builder<'a> {
     fn from(t: Builder<'a>) -> crate::dynamic_value::Builder<'a> {
         crate::dynamic_value::Builder::List(crate::dynamic_list::Builder::new(

--- a/capnp/src/capability.rs
+++ b/capnp/src/capability.rs
@@ -22,6 +22,7 @@
 //! Hooks for for the RPC system.
 //!
 //! Roughly corresponds to capability.h in the C++ implementation.
+#![cfg(feature = "alloc")]
 
 use alloc::boxed::Box;
 use core::future::Future;

--- a/capnp/src/capability_list.rs
+++ b/capnp/src/capability_list.rs
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 //! List of capabilities.
+#![cfg(feature = "alloc")]
 
 use alloc::boxed::Box;
 use core::marker::PhantomData;

--- a/capnp/src/data.rs
+++ b/capnp/src/data.rs
@@ -82,12 +82,14 @@ impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<Reader<'a>> for crate::dynamic_value::Reader<'a> {
     fn from(d: Reader<'a>) -> crate::dynamic_value::Reader<'a> {
         crate::dynamic_value::Reader::Data(d)
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<Builder<'a>> for crate::dynamic_value::Builder<'a> {
     fn from(d: Builder<'a>) -> crate::dynamic_value::Builder<'a> {
         crate::dynamic_value::Builder::Data(d)

--- a/capnp/src/data_list.rs
+++ b/capnp/src/data_list.rs
@@ -199,6 +199,7 @@ impl<'a> ::core::iter::IntoIterator for Reader<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<Reader<'a>> for crate::dynamic_value::Reader<'a> {
     fn from(t: Reader<'a>) -> crate::dynamic_value::Reader<'a> {
         crate::dynamic_value::Reader::List(crate::dynamic_list::Reader {
@@ -208,6 +209,7 @@ impl<'a> From<Reader<'a>> for crate::dynamic_value::Reader<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<Builder<'a>> for crate::dynamic_value::Builder<'a> {
     fn from(t: Builder<'a>) -> crate::dynamic_value::Builder<'a> {
         crate::dynamic_value::Builder::List(crate::dynamic_list::Builder {

--- a/capnp/src/dynamic_list.rs
+++ b/capnp/src/dynamic_list.rs
@@ -1,5 +1,6 @@
 //! Dynamically-typed lists.
 
+#![cfg(feature = "alloc")]
 use crate::dynamic_value;
 use crate::introspect::{Type, TypeVariant};
 use crate::private::layout::{self, PrimitiveElement};

--- a/capnp/src/dynamic_struct.rs
+++ b/capnp/src/dynamic_struct.rs
@@ -1,5 +1,6 @@
 //! Dynamically-typed structs.
 
+#![cfg(feature = "alloc")]
 use crate::introspect::TypeVariant;
 use crate::private::layout;
 use crate::schema::{Field, StructSchema};

--- a/capnp/src/dynamic_struct.rs
+++ b/capnp/src/dynamic_struct.rs
@@ -183,7 +183,7 @@ impl<'a> Reader<'a> {
     /// Otherwise, returns None.
     pub fn which(&self) -> Result<Option<Field>> {
         let node::Struct(st) = self.schema.get_proto().which()? else {
-            return Err(Error::from_kind(ErrorKind::NotAStruct))
+            return Err(Error::from_kind(ErrorKind::NotAStruct));
         };
         if st.get_discriminant_count() == 0 {
             Ok(None)
@@ -201,7 +201,7 @@ impl<'a> Reader<'a> {
         let proto = field.get_proto();
         if has_discriminant_value(proto) {
             let node::Struct(st) = self.schema.get_proto().which()? else {
-                return Err(Error::from_kind(ErrorKind::NotAStruct))
+                return Err(Error::from_kind(ErrorKind::NotAStruct));
             };
 
             let discrim = self
@@ -411,7 +411,7 @@ impl<'a> Builder<'a> {
 
     pub fn which(&self) -> Result<Option<Field>> {
         let node::Struct(st) = self.schema.get_proto().which()? else {
-            return Err(Error::from_kind(ErrorKind::NotAStruct))
+            return Err(Error::from_kind(ErrorKind::NotAStruct));
         };
         if st.get_discriminant_count() == 0 {
             Ok(None)
@@ -531,10 +531,10 @@ impl<'a> Builder<'a> {
             }
             field::Group(_group) => {
                 let dynamic_value::Reader::Struct(src) = value else {
-                    return Err(Error::from_kind(ErrorKind::NotAStruct))
+                    return Err(Error::from_kind(ErrorKind::NotAStruct));
                 };
                 let dynamic_value::Builder::Struct(mut dst) = self.reborrow().init(field)? else {
-                    return Err(Error::from_kind(ErrorKind::NotAStruct))
+                    return Err(Error::from_kind(ErrorKind::NotAStruct));
                 };
                 if let Some(union_field) = src.which()? {
                     dst.set(union_field, src.get(union_field)?)?;
@@ -586,7 +586,7 @@ impl<'a> Builder<'a> {
             field::Group(_) => {
                 self.clear(field)?;
                 let TypeVariant::Struct(schema) = ty.which() else {
-                    return Err(Error::from_kind(ErrorKind::NotAStruct))
+                    return Err(Error::from_kind(ErrorKind::NotAStruct));
                 };
                 Ok((Builder::new(self.builder, schema.into())).into())
             }
@@ -684,7 +684,7 @@ impl<'a> Builder<'a> {
             }
             field::Group(_) => {
                 let TypeVariant::Struct(schema) = ty.which() else {
-                    return Err(Error::from_kind(ErrorKind::NotAStruct))
+                    return Err(Error::from_kind(ErrorKind::NotAStruct));
                 };
                 let mut group = Builder::new(self.builder.reborrow(), schema.into());
 
@@ -711,7 +711,7 @@ impl<'a> Builder<'a> {
     fn set_in_union(&mut self, field: Field) -> Result<()> {
         if has_discriminant_value(field.get_proto()) {
             let node::Struct(st) = self.schema.get_proto().which()? else {
-                return Err(Error::from_kind(ErrorKind::NotAStruct))
+                return Err(Error::from_kind(ErrorKind::NotAStruct));
             };
             self.builder.set_data_field::<u16>(
                 st.get_discriminant_offset() as usize,

--- a/capnp/src/dynamic_value.rs
+++ b/capnp/src/dynamic_value.rs
@@ -104,7 +104,9 @@ pub trait DowncastReader<'a> {
 
 impl<'a> DowncastReader<'a> for () {
     fn downcast_reader(value: Reader<'a>) -> () {
-        let Reader::Void = value else { panic!("error downcasting to void") };
+        let Reader::Void = value else {
+            panic!("error downcasting to void")
+        };
     }
 }
 
@@ -223,7 +225,9 @@ pub trait DowncastBuilder<'a> {
 
 impl<'a> DowncastBuilder<'a> for () {
     fn downcast_builder(value: Builder<'a>) -> () {
-        let Builder::Void = value else { panic!("error downcasting to void") };
+        let Builder::Void = value else {
+            panic!("error downcasting to void")
+        };
     }
 }
 

--- a/capnp/src/dynamic_value.rs
+++ b/capnp/src/dynamic_value.rs
@@ -1,5 +1,6 @@
 //! Dynamically typed values.
 
+#![cfg(feature = "alloc")]
 use crate::introspect::{self, TypeVariant};
 use crate::schema_capnp::value;
 use crate::Result;

--- a/capnp/src/dynamic_value.rs
+++ b/capnp/src/dynamic_value.rs
@@ -59,7 +59,7 @@ impl<'a> Reader<'a> {
             }
             (value::Interface(()), TypeVariant::Capability) => Ok(Capability.into()),
             (value::AnyPointer(a), TypeVariant::AnyPointer) => Ok(a.into()),
-            _ => Err(crate::Error::failed("type mismatch".into())),
+            _ => Err(crate::Error::from_kind(crate::ErrorKind::TypeMismatch)),
         }
     }
 

--- a/capnp/src/enum_list.rs
+++ b/capnp/src/enum_list.rs
@@ -214,6 +214,7 @@ impl<'a, T: TryFrom<u16, Error = NotInSchema>> ::core::iter::IntoIterator for Re
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T: TryFrom<u16, Error = NotInSchema> + crate::introspect::Introspect> From<Reader<'a, T>>
     for crate::dynamic_value::Reader<'a>
 {
@@ -225,6 +226,7 @@ impl<'a, T: TryFrom<u16, Error = NotInSchema> + crate::introspect::Introspect> F
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T: TryFrom<u16, Error = NotInSchema> + crate::introspect::Introspect> From<Builder<'a, T>>
     for crate::dynamic_value::Builder<'a>
 {

--- a/capnp/src/introspect.rs
+++ b/capnp/src/introspect.rs
@@ -1,5 +1,6 @@
 //! Traits and types to support run-time type introspection, i.e. reflection.
 
+#[cfg(feature = "alloc")]
 use crate::private::layout::ElementSize;
 
 /// A type that supports reflection. All types that can appear in a Cap'n Proto message
@@ -70,6 +71,7 @@ impl Type {
 
     /// If this type T appears as List(T), then what is the expected
     /// element size of the list?
+    #[cfg(feature = "alloc")]
     pub(crate) fn expected_element_size(&self) -> ElementSize {
         if self.list_count > 0 {
             ElementSize::Pointer

--- a/capnp/src/io.rs
+++ b/capnp/src/io.rs
@@ -105,6 +105,7 @@ mod no_std_impls {
         }
     }
 
+    #[cfg(feature = "alloc")]
     impl Write for alloc::vec::Vec<u8> {
         fn write_all(&mut self, buf: &[u8]) -> Result<()> {
             self.extend_from_slice(buf);

--- a/capnp/src/lib.rs
+++ b/capnp/src/lib.rs
@@ -63,6 +63,7 @@ pub mod text;
 pub mod text_list;
 pub mod traits;
 
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -134,7 +135,7 @@ impl core::ops::AddAssign for MessageSize {
 }
 
 /// An enum value or union discriminant that was not found among those defined in a schema.
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct NotInSchema(pub u16);
 
 impl ::core::fmt::Display for NotInSchema {
@@ -168,15 +169,17 @@ pub struct Error {
     /// should read only this field in making its decision.
     pub kind: ErrorKind,
 
-    /// Human-readable failure description.
-    pub description: String,
+    /// Extra context about error
+    #[cfg(feature = "alloc")]
+    pub extra: String,
 }
 
 /// The general nature of an error. The purpose of this enum is not to describe the error itself,
 /// but rather to describe how the client might want to respond to the error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ErrorKind {
-    /// Something went wrong. This is the usual error kind. It includes decoding errors.
+    /// Something went wrong
     Failed,
 
     /// The call failed because of a temporary lack of resources. This could be space resources
@@ -194,30 +197,247 @@ pub enum ErrorKind {
     /// The requested method is not implemented. The caller may wish to revert to a fallback
     /// approach based on other methods.
     Unimplemented,
+
+    /// Buffer is not large enough
+    BufferNotLargeEnough,
+
+    /// Cannot create a canonical message with a capability
+    CannotCreateACanonicalMessageWithACapability,
+
+    /// Cannot set AnyPointer field to a primitive value
+    CannotSetAnyPointerFieldToAPrimitiveValue,
+
+    /// Don't know how to handle non-STRUCT inline composite.
+    CantHandleNonStructInlineComposite,
+
+    /// Empty buffer
+    EmptyBuffer,
+
+    /// Empty slice
+    EmptySlice,
+
+    /// Enum value or union discriminant {} was not present in schema
+    EnumValueOrUnionDiscriminantNotPresent(NotInSchema),
+
+    /// Called get_writable_{data|text}_pointer() but existing list pointer is not byte-sized.
+    ExistingListPointerIsNotByteSized,
+
+    /// Existing list value is incompatible with expected type.
+    ExistingListValueIsIncompatibleWithExpectedType,
+
+    /// Called get_writable_{data|text|list|struct_list}_pointer() but existing pointer is not a list.
+    ExistingPointerIsNotAList,
+
+    /// Expected a list or blob.
+    ExpectedAListOrBlob,
+
+    /// Expected a pointer list, but got a list of data-only structs
+    ExpectedAPointerListButGotAListOfDataOnlyStructs,
+
+    /// Expected a primitive list, but got a list of pointer-only structs
+    ExpectedAPrimitiveListButGotAListOfPointerOnlyStructs,
+
+    /// failed to fill the whole buffer
+    FailedToFillTheWholeBuffer,
+
+    /// field and default mismatch
+    FieldAndDefaultMismatch,
+
+    /// field not found
+    FieldNotFound,
+
+    /// Found bit list where struct list was expected; upgrading boolean lists to struct lists is no longer supported
+    FoundBitListWhereStructListWasExpected,
+
+    /// Found struct list where bit list was expected.
+    FoundStructListWhereBitListWasExpected,
+
+    /// Cannot represent 4 byte length as `usize`. This may indicate that you are running on 8 or 16 bit platform or message is too large.
+    FourByteLengthTooBigForUSize,
+
+    /// Cannot represent 4 byte segment length as usize. This may indicate that you are running on 8 or 16 bit platform or segment is too large
+    FourByteSegmentLengthTooBigForUSize,
+
+    /// group field but type is not Struct
+    GroupFieldButTypeIsNotStruct,
+
+    /// init() is only valid for struct and AnyPointer fields
+    InitIsOnlyValidForStructAndAnyPointerFields,
+
+    /// initn() is only valid for list, text, or data fields
+    InitnIsOnlyValidForListTextOrDataFields,
+
+    /// InlineComposite list with non-STRUCT elements not supported.
+    InlineCompositeListWithNonStructElementsNotSupported,
+
+    /// InlineComposite list's elements overrun its word count.
+    InlineCompositeListsElementsOverrunItsWordCount,
+
+    /// InlineComposite lists of non-STRUCT type are not supported.
+    InlineCompositeListsOfNonStructTypeAreNotSupported,
+
+    /// Too many or too few segments {segment_count}
+    InvalidNumberOfSegments(usize),
+
+    /// Invalid segment id {id}
+    InvalidSegmentId(u32),
+
+    /// List(AnyPointer) not supported.
+    ListAnyPointerNotSupported,
+
+    /// List(Capability) not supported
+    ListCapabilityNotSupported,
+
+    /// Malformed double-far pointer.
+    MalformedDoubleFarPointer,
+
+    /// Message contains invalid capability pointer.
+    MessageContainsInvalidCapabilityPointer,
+
+    /// Message contains list pointer of non-bytes where data was expected.
+    MessageContainsListPointerOfNonBytesWhereDataWasExpected,
+
+    /// Message contains list pointer of non-bytes where text was expected.
+    MessageContainsListPointerOfNonBytesWhereTextWasExpected,
+
+    /// Message contains list with incompatible element type.
+    MessageContainsListWithIncompatibleElementType,
+
+    /// Message contains non-capability pointer where capability pointer was expected.
+    MessageContainsNonCapabilityPointerWhereCapabilityPointerWasExpected,
+
+    /// Message contains non-struct pointer where struct pointer was expected.
+    MessageContainsNonStructPointerWhereStructPointerWasExpected,
+
+    /// Message contains non-list pointer where data was expected.
+    MessageContainsNonListPointerWhereDataWasExpected,
+
+    /// Message contains non-list pointer where list pointer was expected
+    MessageContainsNonListPointerWhereListPointerWasExpected,
+
+    /// Message contains non-list pointer where text was expected.
+    MessageContainsNonListPointerWhereTextWasExpected,
+
+    /// Message contains null capability pointer.
+    MessageContainsNullCapabilityPointer,
+
+    /// Message contains out-of-bounds pointer,
+    MessageContainsOutOfBoundsPointer,
+
+    /// Message contains text that is not NUL-terminated
+    MessageContainsTextThatIsNotNULTerminated,
+
+    /// Message ends prematurely. Header claimed {header} words, but message only has {body} words,
+    MessageEndsPrematurely(usize, usize),
+
+    /// Message is too deeply nested.
+    MessageIsTooDeeplyNested,
+
+    /// Message is too deeply-nested or contains cycles.
+    MessageIsTooDeeplyNestedOrContainsCycles,
+
+    /// Message was not aligned by 8 bytes boundary. Either ensure that message is properly aligned or compile `capnp` crate with \"unaligned\" feature enabled.
+    MessageNotAlignedBy8BytesBoundary,
+
+    /// Message's size cannot be represented in usize
+    MessageSizeOverflow,
+
+    /// Message is too large
+    MessageTooLarge(usize),
+
+    /// Nesting limit exceeded
+    NestingLimitExceeded,
+
+    /// Not a struct
+    NotAStruct,
+
+    /// Only one of the section pointers is pointing to ourself
+    OnlyOneOfTheSectionPointersIsPointingToOurself,
+
+    /// Packed input did not end cleanly on a segment boundary.
+    PackedInputDidNotEndCleanlyOnASegmentBoundary,
+
+    /// Premature end of file
+    PrematureEndOfFile,
+
+    /// Premature end of packed input.
+    PrematureEndOfPackedInput,
+
+    /// Read limit exceeded
+    ReadLimitExceeded,
+
+    /// setting dynamic capabilities is unsupported
+    SettingDynamicCapabilitiesIsUnsupported,
+
+    /// Struct reader had bitwidth other than 1
+    StructReaderHadBitwidthOtherThan1,
+
+    /// Text blob missing NUL terminator.
+    TextBlobMissingNULTerminator,
+
+    /// Text contains non-utf8 data
+    TextContainsNonUtf8Data(core::str::Utf8Error),
+
+    /// Tried to read from null arena
+    TriedToReadFromNullArena,
+
+    /// type mismatch
+    TypeMismatch,
+
+    /// Detected unaligned segment. You must either ensure all of your segments are 8-byte aligned,
+    /// or you must enable the "unaligned" feature in the capnp crate
+    UnalignedSegment,
+
+    /// Unexpected far pointer
+    UnexepectedFarPointer,
+
+    /// Unknown pointer type.
+    UnknownPointerType,
 }
 
 impl Error {
+    #[cfg(feature = "alloc")]
+    pub fn extra(&mut self, message: String) {
+        self.extra = message;
+    }
+
+    #[cfg(feature = "alloc")]
     pub fn failed(description: String) -> Self {
         Self {
-            description,
+            extra: description,
             kind: ErrorKind::Failed,
         }
     }
+
+    pub fn from_kind(kind: ErrorKind) -> Self {
+        #[cfg(not(feature = "alloc"))]
+        return Self { kind };
+        #[cfg(feature = "alloc")]
+        return Self {
+            kind,
+            extra: String::new(),
+        };
+    }
+
+    #[cfg(feature = "alloc")]
     pub fn overloaded(description: String) -> Self {
         Self {
-            description,
+            extra: description,
             kind: ErrorKind::Overloaded,
         }
     }
+    #[cfg(feature = "alloc")]
     pub fn disconnected(description: String) -> Self {
         Self {
-            description,
+            extra: description,
             kind: ErrorKind::Disconnected,
         }
     }
+
+    #[cfg(feature = "alloc")]
     pub fn unimplemented(description: String) -> Self {
         Self {
-            description,
+            extra: description,
             kind: ErrorKind::Unimplemented,
         }
     }
@@ -236,19 +456,24 @@ impl core::convert::From<::std::io::Error> for Error {
             | io::ErrorKind::NotConnected => ErrorKind::Disconnected,
             _ => ErrorKind::Failed,
         };
-        Self {
-            description: format!("{err}"),
+        #[cfg(feature = "alloc")]
+        return Self {
             kind,
-        }
+            extra: format!("{err}"),
+        };
+        #[cfg(not(feature = "alloc"))]
+        return Self { kind };
     }
 }
 
+#[cfg(feature = "alloc")]
 impl core::convert::From<alloc::string::FromUtf8Error> for Error {
     fn from(err: alloc::string::FromUtf8Error) -> Self {
         Self::failed(format!("{err}"))
     }
 }
 
+#[cfg(feature = "alloc")]
 impl core::convert::From<alloc::str::Utf8Error> for Error {
     fn from(err: alloc::str::Utf8Error) -> Self {
         Self::failed(format!("{err}"))
@@ -257,23 +482,105 @@ impl core::convert::From<alloc::str::Utf8Error> for Error {
 
 impl core::convert::From<NotInSchema> for Error {
     fn from(e: NotInSchema) -> Self {
-        Self::failed(format!(
-            "Enum value or union discriminant {} was not present in schema.",
-            e.0
-        ))
+        Self::from_kind(ErrorKind::EnumValueOrUnionDiscriminantNotPresent(e))
+    }
+}
+
+impl core::fmt::Display for ErrorKind {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error> {
+        match self {
+            Self::Failed => write!(fmt, "Failed"),
+            Self::Overloaded => write!(fmt, "Overloaded"),
+            Self::Disconnected => write!(fmt, "Disconnected"),
+            Self::Unimplemented => write!(fmt, "Unimplemented"),
+            Self::BufferNotLargeEnough => write!(fmt, "buffer is not large enough"),
+            Self::ExistingListPointerIsNotByteSized => write!(fmt, "Called get_writable_{{data|text}}_pointer() but existing list pointer is not byte-sized."),
+            Self::ExistingPointerIsNotAList => write!(fmt, "Called get_writable_{{data|text|list|struct_list}}_pointer() but existing pointer is not a list."),
+            Self::CannotCreateACanonicalMessageWithACapability => write!(fmt, "Cannot create a canonical message with a capability"),
+            Self::FourByteLengthTooBigForUSize => write!(fmt, "Cannot represent 4 byte length as `usize`. This may indicate that you are running on 8 or 16 bit platform or message is too large."),
+            Self::FourByteSegmentLengthTooBigForUSize => write!(fmt, "Cannot represent 4 byte segment length as usize. This may indicate that you are running on 8 or 16 bit platform or segment is too large"),
+            Self::CannotSetAnyPointerFieldToAPrimitiveValue => write!(fmt, "cannot set AnyPointer field to a primitive value"),
+            Self::CantHandleNonStructInlineComposite => write!(fmt, "Don't know how to handle non-STRUCT inline composite."),
+            Self::EmptyBuffer => write!(fmt, "empty buffer"),
+            Self::EmptySlice => write!(fmt, "empty slice"),
+            Self::EnumValueOrUnionDiscriminantNotPresent(val) => write!(fmt, "Enum value or union discriminant {val} was not present in schema"),
+            Self::ExistingListValueIsIncompatibleWithExpectedType => write!(fmt, "Existing list value is incompatible with expected type."),
+            Self::ExpectedAListOrBlob => write!(fmt, "Expected a list or blob."),
+            Self::ExpectedAPointerListButGotAListOfDataOnlyStructs => write!(fmt, "Expected a pointer list, but got a list of data-only structs"),
+            Self::ExpectedAPrimitiveListButGotAListOfPointerOnlyStructs => write!(fmt, "Expected a primitive list, but got a list of pointer-only structs"),
+            Self::FailedToFillTheWholeBuffer => write!(fmt, "failed to fill the whole buffer"),
+            Self::FieldAndDefaultMismatch => write!(fmt, "field and default mismatch"),
+            Self::FieldNotFound => write!(fmt, "field not found"),
+            Self::FoundBitListWhereStructListWasExpected => write!(fmt, "Found bit list where struct list was expected; upgrading boolean lists to struct lists is no longer supported."),
+            Self::FoundStructListWhereBitListWasExpected => write!(fmt, "Found struct list where bit list was expected."),
+            Self::GroupFieldButTypeIsNotStruct => write!(fmt, "group field but type is not Struct"),
+            Self::InitIsOnlyValidForStructAndAnyPointerFields => write!(fmt, "init() is only valid for struct and AnyPointer fields"),
+            Self::InitnIsOnlyValidForListTextOrDataFields => write!(fmt, "initn() is only valid for list, text, or data fields"),
+            Self::InlineCompositeListWithNonStructElementsNotSupported => write!(fmt, "InlineComposite list with non-STRUCT elements not supported."),
+            Self::InlineCompositeListsElementsOverrunItsWordCount => write!(fmt, "InlineComposite list's elements overrun its word count."),
+            Self::InlineCompositeListsOfNonStructTypeAreNotSupported => write!(fmt, "InlineComposite lists of non-STRUCT type are not supported."),
+            Self::InvalidNumberOfSegments(segment_count) => write!(fmt, "Too many or too few segments {segment_count}"),
+            Self::InvalidSegmentId(id) => write!(fmt, "Invalid segment id {id}"),
+            Self::ListAnyPointerNotSupported => write!(fmt, "List(AnyPointer) not supported."),
+            Self::ListCapabilityNotSupported => write!(fmt, "List(Capability) not supported"),
+            Self::MalformedDoubleFarPointer => write!(fmt, "Malformed double-far pointer."),
+            Self::MessageContainsInvalidCapabilityPointer => write!(fmt, "Message contained invalid capability pointer."),
+            Self::MessageContainsListPointerOfNonBytesWhereDataWasExpected => write!(fmt, "Message contains list pointer of non-bytes where data was expected."),
+            Self::MessageContainsListPointerOfNonBytesWhereTextWasExpected => write!(fmt, "Message contains list pointer of non-bytes where text was expected."),
+            Self::MessageContainsListWithIncompatibleElementType => write!(fmt, "Message contains list with incompatible element type."),
+            Self::MessageContainsNonCapabilityPointerWhereCapabilityPointerWasExpected => write!(fmt, "Message contains non-capability pointer where capability pointer was expected."),
+            Self::MessageContainsNonListPointerWhereDataWasExpected => write!(fmt, "Message contains non-list pointer where data was expected."),
+            Self::MessageContainsNonListPointerWhereListPointerWasExpected => write!(fmt, "Message contains non-list pointer where list pointer was expected"),
+            Self::MessageContainsNonListPointerWhereTextWasExpected => write!(fmt, "Message contains non-list pointer where text was expected."),
+            Self::MessageContainsNonStructPointerWhereStructPointerWasExpected => write!(fmt, "Message contains non-struct pointer where struct pointer was expected."),
+            Self::MessageContainsNullCapabilityPointer => write!(fmt, "Message contains null capability pointer."),
+            Self::MessageContainsOutOfBoundsPointer => write!(fmt, "Message contains out-of-bounds pointer"),
+            Self::MessageContainsTextThatIsNotNULTerminated => write!(fmt, "Message contains text that is not NUL-terminated"),
+            Self::MessageEndsPrematurely(header, body) => write!(fmt, "Message ends prematurely. Header claimed {header} words, but message only has {body} words"),
+            Self::MessageIsTooDeeplyNested => write!(fmt, "Message is too deeply nested."),
+            Self::MessageIsTooDeeplyNestedOrContainsCycles => write!(fmt, "Message is too deeply-nested or contains cycles."),
+            Self::MessageSizeOverflow => write!(fmt, "Message's size cannot be represented in usize"),
+            Self::MessageTooLarge(val) => write!(fmt, "Message is too large: {val}"),
+            Self::MessageNotAlignedBy8BytesBoundary => write!(fmt, "Message was not aligned by 8 bytes boundary. Either ensure that message is properly aligned or compile `capnp` crate with \"unaligned\" feature enabled."),
+            Self::NestingLimitExceeded => write!(fmt, "nesting limit exceeded"),
+            Self::NotAStruct => write!(fmt, "not a struct"),
+            Self::OnlyOneOfTheSectionPointersIsPointingToOurself => write!(fmt, "Only one of the section pointers is pointing to ourself"),
+            Self::PackedInputDidNotEndCleanlyOnASegmentBoundary => write!(fmt, "Packed input did not end cleanly on a segment boundary."),
+            Self::PrematureEndOfFile => write!(fmt, "Premature end of file"),
+            Self::PrematureEndOfPackedInput => write!(fmt, "Premature end of packed input."),
+            Self::ReadLimitExceeded => write!(fmt, "Read limit exceeded"),
+            Self::SettingDynamicCapabilitiesIsUnsupported => write!(fmt, "setting dynamic capabilities is unsupported"),
+            Self::StructReaderHadBitwidthOtherThan1 => write!(fmt, "struct reader had bitwidth other than 1"),
+            Self::TextBlobMissingNULTerminator => write!(fmt, "Text blob missing NUL terminator."),
+            Self::TextContainsNonUtf8Data(e) => write!(fmt, "Text contains non-utf8 data: {e}"),
+            Self::TriedToReadFromNullArena => write!(fmt, "Tried to read from null arena"),
+            Self::TypeMismatch => write!(fmt, "type mismatch"),
+            Self::UnalignedSegment => write!(fmt, "Detected unaligned segment. You must either ensure all of your segments are 8-byte aligned, or you must enable the \"unaligned\" feature in the capnp crate"),
+            Self::UnexepectedFarPointer => write!(fmt, "Unexpected far pointer"),
+            Self::UnknownPointerType => write!(fmt, "Unknown pointer type."),
+        }
     }
 }
 
 impl core::fmt::Display for Error {
     fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error> {
-        write!(fmt, "{:?}: {}", self.kind, self.description)
+        #[cfg(feature = "alloc")]
+        let result = if self.extra.is_empty() {
+            write!(fmt, "{}", self.kind)
+        } else {
+            write!(fmt, "{}: {}", self.kind, self.extra)
+        };
+        #[cfg(not(feature = "alloc"))]
+        let result = write!(fmt, "{}", self.kind);
+        result
     }
 }
 
 #[cfg(feature = "std")]
 impl ::std::error::Error for Error {
+    #[cfg(feature = "alloc")]
     fn description(&self) -> &str {
-        &self.description
+        &self.extra
     }
     fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         None

--- a/capnp/src/lib.rs
+++ b/capnp/src/lib.rs
@@ -29,11 +29,13 @@
 #![cfg_attr(feature = "rpc_try", feature(try_trait_v2))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature = "alloc")]
 #[macro_use]
 extern crate alloc;
 
 /// Code generated from
 /// [schema.capnp](https://github.com/capnproto/capnproto/blob/master/c%2B%2B/src/capnp/schema.capnp).
+#[cfg(feature = "alloc")]
 pub mod schema_capnp;
 
 pub mod any_pointer;
@@ -65,6 +67,7 @@ pub mod traits;
 
 #[cfg(feature = "alloc")]
 use alloc::string::String;
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 ///
@@ -81,6 +84,7 @@ pub struct Word {
 ///
 /// Constructs a word with the given bytes.
 ///
+#[allow(clippy::too_many_arguments)]
 pub const fn word(b0: u8, b1: u8, b2: u8, b3: u8, b4: u8, b5: u8, b6: u8, b7: u8) -> Word {
     Word {
         raw_content: [b0, b1, b2, b3, b4, b5, b6, b7],
@@ -89,6 +93,7 @@ pub const fn word(b0: u8, b1: u8, b2: u8, b3: u8, b4: u8, b5: u8, b6: u8, b7: u8
 
 impl Word {
     /// Allocates a vec of `length` words, all set to zero.
+    #[cfg(feature = "alloc")]
     pub fn allocate_zeroed_vec(length: usize) -> Vec<Self> {
         vec![word(0, 0, 0, 0, 0, 0, 0, 0); length]
     }
@@ -589,11 +594,13 @@ impl ::std::error::Error for Error {
 
 /// Helper struct that allows `MessageBuilder::get_segments_for_output()` to avoid heap allocations
 /// in the single-segment case.
+#[cfg(feature = "alloc")]
 pub enum OutputSegments<'a> {
     SingleSegment([&'a [u8]; 1]),
     MultiSegment(Vec<&'a [u8]>),
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> core::ops::Deref for OutputSegments<'a> {
     type Target = [&'a [u8]];
     fn deref(&self) -> &[&'a [u8]] {
@@ -604,6 +611,7 @@ impl<'a> core::ops::Deref for OutputSegments<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'s> message::ReaderSegments for OutputSegments<'s> {
     fn get_segment(&self, id: u32) -> Option<&[u8]> {
         match self {

--- a/capnp/src/list_list.rs
+++ b/capnp/src/list_list.rs
@@ -280,6 +280,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T: crate::traits::Owned> From<Reader<'a, T>> for crate::dynamic_value::Reader<'a> {
     fn from(t: Reader<'a, T>) -> crate::dynamic_value::Reader<'a> {
         crate::dynamic_value::Reader::List(crate::dynamic_list::Reader::new(
@@ -289,6 +290,7 @@ impl<'a, T: crate::traits::Owned> From<Reader<'a, T>> for crate::dynamic_value::
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T: crate::traits::Owned> From<Builder<'a, T>> for crate::dynamic_value::Builder<'a> {
     fn from(t: Builder<'a, T>) -> crate::dynamic_value::Builder<'a> {
         crate::dynamic_value::Builder::List(crate::dynamic_list::Builder::new(

--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -68,15 +68,22 @@
 //! }
 //!
 //! ```
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 use core::convert::From;
 
 use crate::any_pointer;
-use crate::private::arena::{BuilderArena, BuilderArenaImpl, ReaderArena, ReaderArenaImpl};
+#[cfg(feature = "alloc")]
+use crate::private::arena::{BuilderArena, BuilderArenaImpl};
+use crate::private::arena::{ReaderArena, ReaderArenaImpl};
 use crate::private::layout;
 use crate::private::units::BYTES_PER_WORD;
-use crate::traits::{FromPointerBuilder, FromPointerReader, Owned, SetPointerBuilder};
-use crate::{OutputSegments, Result};
+#[cfg(feature = "alloc")]
+use crate::traits::{FromPointerBuilder, SetPointerBuilder};
+use crate::traits::{FromPointerReader, Owned};
+#[cfg(feature = "alloc")]
+use crate::OutputSegments;
+use crate::Result;
 
 /// Options controlling how data is read.
 #[derive(Clone, Copy, Debug)]
@@ -275,6 +282,7 @@ where
     /// Gets the [canonical](https://capnproto.org/encoding.html#canonicalization) form
     /// of this message. Works by copying the message twice. For a canonicalization
     /// method that only requires one copy, see `message::Builder::set_root_canonical()`.
+    #[cfg(feature = "alloc")]
     pub fn canonicalize(&self) -> Result<Vec<crate::Word>> {
         let root = self.get_root_internal()?;
         let size = root.target_size()?.word_count + 1;
@@ -336,6 +344,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<A, T> From<Builder<A>> for TypedReader<Builder<A>, T>
 where
     A: Allocator,
@@ -347,6 +356,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<A, T> From<TypedBuilder<T, A>> for TypedReader<Builder<A>, T>
 where
     A: Allocator,
@@ -394,6 +404,7 @@ pub unsafe trait Allocator {
 }
 
 /// A container used to build a message.
+#[cfg(feature = "alloc")]
 pub struct Builder<A>
 where
     A: Allocator,
@@ -401,8 +412,10 @@ where
     arena: BuilderArenaImpl<A>,
 }
 
+#[cfg(feature = "alloc")]
 unsafe impl<A> Send for Builder<A> where A: Send + Allocator {}
 
+#[cfg(feature = "alloc")]
 fn _assert_kinds() {
     fn _assert_send<T: Send>() {}
     fn _assert_reader<S: ReaderSegments + Send>() {
@@ -413,6 +426,7 @@ fn _assert_kinds() {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<A> Builder<A>
 where
     A: Allocator,
@@ -519,6 +533,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<A> ReaderSegments for Builder<A>
 where
     A: Allocator,
@@ -538,6 +553,7 @@ where
 /// - `T` - type of the capnp message which this builder is specialized on. Please see
 ///   [module documentation](self) for more info about builder type specialization.
 /// - `A` - type of allocator
+#[cfg(feature = "alloc")]
 pub struct TypedBuilder<T, A = HeapAllocator>
 where
     T: Owned,
@@ -547,6 +563,7 @@ where
     message: Builder<A>,
 }
 
+#[cfg(feature = "alloc")]
 impl<T> TypedBuilder<T, HeapAllocator>
 where
     T: Owned,
@@ -556,6 +573,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, A> TypedBuilder<T, A>
 where
     T: Owned,
@@ -605,6 +623,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, A> From<Builder<A>> for TypedBuilder<T, A>
 where
     T: Owned,
@@ -617,6 +636,7 @@ where
 
 /// Standard segment allocator. Allocates each segment via `alloc::alloc::alloc_zeroed()`.
 #[derive(Debug)]
+#[cfg(feature = "alloc")]
 pub struct HeapAllocator {
     // Minimum number of words in the next allocation.
     next_size: u32,
@@ -641,6 +661,7 @@ pub enum AllocationStrategy {
 pub const SUGGESTED_FIRST_SEGMENT_WORDS: u32 = 1024;
 pub const SUGGESTED_ALLOCATION_STRATEGY: AllocationStrategy = AllocationStrategy::GrowHeuristically;
 
+#[cfg(feature = "alloc")]
 impl Default for HeapAllocator {
     fn default() -> Self {
         Self {
@@ -651,6 +672,7 @@ impl Default for HeapAllocator {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl HeapAllocator {
     pub fn new() -> Self {
         Self::default()
@@ -677,6 +699,7 @@ impl HeapAllocator {
     }
 }
 
+#[cfg(feature = "alloc")]
 unsafe impl Allocator for HeapAllocator {
     fn allocate_segment(&mut self, minimum_size: u32) -> (*mut u8, u32) {
         let size = core::cmp::max(minimum_size, self.next_size);
@@ -711,6 +734,7 @@ unsafe impl Allocator for HeapAllocator {
     }
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn test_allocate_max() {
     let allocation_size = 1 << 24;
@@ -735,6 +759,7 @@ fn test_allocate_max() {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Builder<HeapAllocator> {
     /// Constructs a new `message::Builder<HeapAllocator>` whose first segment has length
     /// `SUGGESTED_FIRST_SEGMENT_WORDS`.
@@ -753,12 +778,14 @@ impl Builder<HeapAllocator> {
 /// You can reuse a `ScratchSpaceHeapAllocator` by calling `message::Builder::into_allocator()`,
 /// or by initally passing it to `message::Builder::new()` as a `&mut ScratchSpaceHeapAllocator`.
 /// Such reuse can save significant amounts of zeroing.
+#[cfg(feature = "alloc")]
 pub struct ScratchSpaceHeapAllocator<'a> {
     scratch_space: &'a mut [u8],
     scratch_space_allocated: bool,
     allocator: HeapAllocator,
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> ScratchSpaceHeapAllocator<'a> {
     /// Writes zeroes into the entire buffer and constructs a new allocator from it.
     ///
@@ -805,6 +832,7 @@ impl<'a> ScratchSpaceHeapAllocator<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 unsafe impl<'a> Allocator for ScratchSpaceHeapAllocator<'a> {
     fn allocate_segment(&mut self, minimum_size: u32) -> (*mut u8, u32) {
         if (minimum_size as usize) < (self.scratch_space.len() / BYTES_PER_WORD)
@@ -835,6 +863,7 @@ unsafe impl<'a> Allocator for ScratchSpaceHeapAllocator<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 unsafe impl<'a, A> Allocator for &'a mut A
 where
     A: Allocator,

--- a/capnp/src/primitive_list.rs
+++ b/capnp/src/primitive_list.rs
@@ -256,6 +256,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T: PrimitiveElement + crate::introspect::Introspect> From<Reader<'a, T>>
     for crate::dynamic_value::Reader<'a>
 {
@@ -267,6 +268,7 @@ impl<'a, T: PrimitiveElement + crate::introspect::Introspect> From<Reader<'a, T>
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T: PrimitiveElement + crate::introspect::Introspect> From<Builder<'a, T>>
     for crate::dynamic_value::Builder<'a>
 {

--- a/capnp/src/private/arena.rs
+++ b/capnp/src/private/arena.rs
@@ -18,15 +18,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+#[cfg(feature = "alloc")]
 use core::slice;
 use core::u64;
 
 use crate::message;
-use crate::message::{Allocator, ReaderSegments};
+#[cfg(feature = "alloc")]
+use crate::message::Allocator;
+use crate::message::ReaderSegments;
 use crate::private::read_limiter::ReadLimiter;
 use crate::private::units::*;
-use crate::{Error, ErrorKind, OutputSegments, Result};
+#[cfg(feature = "alloc")]
+use crate::OutputSegments;
+use crate::{Error, ErrorKind, Result};
 
 pub type SegmentId = u32;
 
@@ -157,6 +163,7 @@ pub trait BuilderArena: ReaderArena {
 }
 
 /// A wrapper around a memory segment used in building a message.
+#[cfg(feature = "alloc")]
 struct BuilderSegment {
     /// Pointer to the start of the segment.
     ptr: *mut u8,
@@ -169,6 +176,7 @@ struct BuilderSegment {
     allocated: u32,
 }
 
+#[cfg(feature = "alloc")]
 pub struct BuilderArenaImplInner<A>
 where
     A: Allocator,
@@ -179,6 +187,7 @@ where
     segments: Vec<BuilderSegment>,
 }
 
+#[cfg(feature = "alloc")]
 pub struct BuilderArenaImpl<A>
 where
     A: Allocator,
@@ -186,6 +195,7 @@ where
     inner: BuilderArenaImplInner<A>,
 }
 
+#[cfg(feature = "alloc")]
 impl<A> BuilderArenaImpl<A>
 where
     A: Allocator,
@@ -248,6 +258,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<A> ReaderArena for BuilderArenaImpl<A>
 where
     A: Allocator,
@@ -279,6 +290,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<A> BuilderArenaImplInner<A>
 where
     A: Allocator,
@@ -343,6 +355,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<A> BuilderArena for BuilderArenaImpl<A>
 where
     A: Allocator,
@@ -364,6 +377,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<A> Drop for BuilderArenaImplInner<A>
 where
     A: Allocator,

--- a/capnp/src/private/capability.rs
+++ b/capnp/src/private/capability.rs
@@ -19,6 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#![cfg(feature = "alloc")]
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 

--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -1,5 +1,6 @@
 //! Convenience wrappers of the datatypes defined in schema.capnp.
 
+#![cfg(feature = "alloc")]
 use crate::dynamic_value;
 use crate::introspect::{self, RawBrandedStructSchema, RawEnumSchema};
 use crate::private::layout;

--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -70,10 +70,12 @@ impl StructSchema {
         if let Some(field) = self.find_field_by_name(name)? {
             Ok(field)
         } else {
-            Err(crate::Error::failed(format!(
-                "field \"{}\" not found",
-                name
-            )))
+            // error needs to be mutable only when the alloc feature is enabled
+            #[allow(unused_mut)]
+            let mut error = crate::Error::from_kind(crate::ErrorKind::FieldNotFound);
+            #[cfg(feature = "alloc")]
+            error.extra(name.to_string());
+            Err(error)
         }
     }
 

--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -27,14 +27,13 @@ mod no_alloc_slice_segments;
 pub use no_alloc_slice_segments::NoAllocSliceSegments;
 
 use crate::io::{Read, Write};
-use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::convert::TryInto;
 use core::ops::Deref;
 
 use crate::message;
 use crate::private::units::BYTES_PER_WORD;
-use crate::{Error, Result};
+use crate::{Error, ErrorKind, Result};
 
 pub const SEGMENTS_COUNT_LIMIT: usize = 512;
 
@@ -76,17 +75,16 @@ pub fn read_message_from_flat_slice<'a>(
     let mut bytes = *slice;
     let orig_bytes_len = bytes.len();
     let Some(segment_lengths_builder) = read_segment_table(&mut bytes, options)? else {
-        return Err(Error::failed("empty slice".to_string()))
+        return Err(Error::from_kind(ErrorKind::EmptySlice))
     };
     let segment_table_bytes_len = orig_bytes_len - bytes.len();
     assert_eq!(segment_table_bytes_len % BYTES_PER_WORD, 0);
     let num_words = segment_lengths_builder.total_words();
     let body_bytes = &all_bytes[segment_table_bytes_len..];
     if num_words > (body_bytes.len() / BYTES_PER_WORD) {
-        Err(Error::failed(format!(
-            "Message ends prematurely. Header claimed {} words, but message only has {} words.",
+        Err(Error::from_kind(ErrorKind::MessageEndsPrematurely(
             num_words,
-            body_bytes.len() / BYTES_PER_WORD
+            body_bytes.len() / BYTES_PER_WORD,
         )))
     } else {
         *slice = &body_bytes[(num_words * BYTES_PER_WORD)..];
@@ -101,7 +99,7 @@ pub fn read_message_from_flat_slice<'a>(
 /// The slice is allowed to extend beyond the end of the message. On success, updates `slice` to point
 /// to the remaining bytes beyond the end of the message.
 ///
-/// Unlike read_message_from_flat_slice_no_alloc it does not do heap allocation (except for error message)
+/// Unlike read_message_from_flat_slice_no_alloc it does not do heap allocation
 ///
 /// ALIGNMENT: If the "unaligned" feature is enabled, then there are no alignment requirements on `slice`.
 /// Otherwise, `slice` must be 8-byte aligned (attempts to read the message will trigger errors).
@@ -138,7 +136,7 @@ impl<T: Deref<Target = [u8]>> BufferSegments<T> {
         let mut segment_bytes = &*buffer;
 
         let Some(segment_table) = read_segment_table(&mut segment_bytes, options)? else {
-            return Err(Error::failed("empty buffer".to_string()))
+            return Err(Error::from_kind(ErrorKind::EmptyBuffer))
         };
         let segment_table_bytes_len = buffer.len() - segment_bytes.len();
 
@@ -279,7 +277,7 @@ where
     R: Read,
 {
     let Some(owned_segments_builder) = read_segment_table(&mut read, options)? else {
-        return Err(Error::failed("Premature end of file".to_string()))
+        return Err(Error::from_kind(ErrorKind::PrematureEndOfFile))
     };
     read_segments(
         &mut read,
@@ -333,9 +331,13 @@ where
     let segment_count = u32::from_le_bytes(buf[0..4].try_into().unwrap()).wrapping_add(1) as usize;
 
     if segment_count >= SEGMENTS_COUNT_LIMIT {
-        return Err(Error::failed(format!("Too many segments: {segment_count}")));
+        return Err(Error::from_kind(ErrorKind::InvalidNumberOfSegments(
+            segment_count,
+        )));
     } else if segment_count == 0 {
-        return Err(Error::failed(format!("Too few segments: {segment_count}")));
+        return Err(Error::from_kind(ErrorKind::InvalidNumberOfSegments(
+            segment_count,
+        )));
     }
 
     let mut segment_lengths_builder = SegmentLengthsBuilder::with_capacity(segment_count);
@@ -366,10 +368,8 @@ where
     // size to make the receiver allocate excessive space and possibly crash.
     if let Some(limit) = options.traversal_limit_in_words {
         if segment_lengths_builder.total_words() > limit {
-            return Err(Error::failed(format!(
-                "Message has {} words, which is too large. To increase the limit on the \
-                         receiving end, see capnp::message::ReaderOptions.",
-                segment_lengths_builder.total_words()
+            return Err(Error::from_kind(ErrorKind::MessageTooLarge(
+                segment_lengths_builder.total_words(),
             )));
         }
     }

--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -85,7 +85,7 @@ pub fn read_message_from_flat_slice<'a>(
     let mut bytes = *slice;
     let orig_bytes_len = bytes.len();
     let Some(segment_lengths_builder) = read_segment_table(&mut bytes, options)? else {
-        return Err(Error::from_kind(ErrorKind::EmptySlice))
+        return Err(Error::from_kind(ErrorKind::EmptySlice));
     };
     let segment_table_bytes_len = orig_bytes_len - bytes.len();
     assert_eq!(segment_table_bytes_len % BYTES_PER_WORD, 0);
@@ -148,7 +148,7 @@ impl<T: Deref<Target = [u8]>> BufferSegments<T> {
         let mut segment_bytes = &*buffer;
 
         let Some(segment_table) = read_segment_table(&mut segment_bytes, options)? else {
-            return Err(Error::from_kind(ErrorKind::EmptyBuffer))
+            return Err(Error::from_kind(ErrorKind::EmptyBuffer));
         };
         let segment_table_bytes_len = buffer.len() - segment_bytes.len();
 
@@ -297,7 +297,7 @@ where
     R: Read,
 {
     let Some(owned_segments_builder) = read_segment_table(&mut read, options)? else {
-        return Err(Error::from_kind(ErrorKind::PrematureEndOfFile))
+        return Err(Error::from_kind(ErrorKind::PrematureEndOfFile));
     };
     read_segments(
         &mut read,
@@ -317,7 +317,9 @@ pub fn try_read_message<R>(
 where
     R: Read,
 {
-    let Some(owned_segments_builder) = read_segment_table(&mut read, options)? else { return Ok(None) };
+    let Some(owned_segments_builder) = read_segment_table(&mut read, options)? else {
+        return Ok(None);
+    };
     Ok(Some(read_segments(
         &mut read,
         owned_segments_builder.into_owned_segments(),

--- a/capnp/src/serialize/no_alloc_slice_segments.rs
+++ b/capnp/src/serialize/no_alloc_slice_segments.rs
@@ -289,19 +289,26 @@ fn calculate_data_offset(segments_count: usize) -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "alloc")]
     use quickcheck::{quickcheck, TestResult};
 
+    use crate::serialize::no_alloc_slice_segments::calculate_data_offset;
+    #[cfg(feature = "alloc")]
     use crate::{
         message::{ReaderOptions, ReaderSegments},
-        serialize::{self, no_alloc_slice_segments::calculate_data_offset},
-        word, OutputSegments, Word,
+        serialize, word, Word,
     };
 
+    #[cfg(feature = "alloc")]
+    use crate::OutputSegments;
+
+    #[cfg(feature = "alloc")]
+    use super::NoAllocSliceSegments;
     use super::{
         read_u32_le, u32_to_segment_length_bytes, u32_to_segments_count, verify_alignment,
-        NoAllocSliceSegments,
     };
 
+    #[cfg(feature = "alloc")]
     use alloc::vec::Vec;
 
     #[repr(align(8))]
@@ -382,6 +389,7 @@ mod tests {
         assert_eq!(calculate_data_offset(101), Some(408));
     }
 
+    #[cfg(feature = "alloc")]
     quickcheck! {
         #[cfg_attr(miri, ignore)] // miri takes a long time with quickcheck
         fn test_no_alloc_buffer_segments_single_segment_optimization(
@@ -437,6 +445,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_no_alloc_buffer_segments_message_postfix() {
         let output_segments = OutputSegments::SingleSegment([&[1, 2, 3, 4, 5, 6, 7, 8]]);
@@ -452,6 +461,7 @@ mod tests {
         assert_eq!(*remaining, &[11, 12, 13, 14, 15, 16, 0, 0]);
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_no_alloc_buffer_segments_message_invalid() {
         let mut buf = vec![];
@@ -475,6 +485,7 @@ mod tests {
         buf.clear();
     }
 
+    #[cfg(feature = "alloc")]
     quickcheck! {
         #[cfg_attr(miri, ignore)] // miri takes a long time with quickcheck
         fn test_no_alloc_buffer_segments_message_truncated(segments_vec: Vec<Vec<Word>>) -> TestResult {

--- a/capnp/src/serialize_packed.rs
+++ b/capnp/src/serialize_packed.rs
@@ -25,7 +25,9 @@
 use crate::io::{BufRead, Read, Write};
 use core::{mem, ptr, slice};
 
+#[cfg(feature = "alloc")]
 use crate::message;
+#[cfg(feature = "alloc")]
 use crate::serialize;
 use crate::{Error, ErrorKind, Result};
 
@@ -229,6 +231,7 @@ where
 }
 
 /// Reads a packed message from a stream using the provided options.
+#[cfg(feature = "alloc")]
 pub fn read_message<R>(
     read: R,
     options: message::ReaderOptions,
@@ -241,6 +244,7 @@ where
 }
 
 /// Like read_message(), but returns None instead of an error if there are zero bytes left in `read`.
+#[cfg(feature = "alloc")]
 pub fn try_read_message<R>(
     read: R,
     options: message::ReaderOptions,
@@ -404,6 +408,7 @@ where
 ///
 /// The only source of errors from this function are `write.write_all()` calls. If you pass in
 /// a writer that never returns an error, then this function will never return an error.
+#[cfg(feature = "alloc")]
 pub fn write_message<W, A>(write: W, message: &crate::message::Builder<A>) -> Result<()>
 where
     W: Write,
@@ -413,6 +418,7 @@ where
     serialize::write_message(packed_write, message)
 }
 
+#[cfg(feature = "alloc")]
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;

--- a/capnp/src/stringify.rs
+++ b/capnp/src/stringify.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "alloc")]
 use crate::dynamic_value;
 use core::fmt::{self, Formatter};
 

--- a/capnp/src/struct_list.rs
+++ b/capnp/src/struct_list.rs
@@ -284,6 +284,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T: crate::traits::OwnedStruct> From<Reader<'a, T>> for crate::dynamic_value::Reader<'a> {
     fn from(t: Reader<'a, T>) -> crate::dynamic_value::Reader<'a> {
         crate::dynamic_value::Reader::List(crate::dynamic_list::Reader::new(
@@ -293,6 +294,7 @@ impl<'a, T: crate::traits::OwnedStruct> From<Reader<'a, T>> for crate::dynamic_v
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T: crate::traits::OwnedStruct> From<Builder<'a, T>> for crate::dynamic_value::Builder<'a> {
     fn from(t: Builder<'a, T>) -> crate::dynamic_value::Builder<'a> {
         crate::dynamic_value::Builder::List(crate::dynamic_list::Builder::new(

--- a/capnp/src/text.rs
+++ b/capnp/src/text.rs
@@ -23,7 +23,7 @@
 
 use core::{convert, ops, str};
 
-use crate::{Error, Result};
+use crate::{Error, ErrorKind, Result};
 
 #[derive(Copy, Clone)]
 pub struct Owned(());
@@ -44,7 +44,7 @@ pub type Reader<'a> = &'a str;
 pub fn new_reader(v: &[u8]) -> Result<Reader<'_>> {
     match str::from_utf8(v) {
         Ok(v) => Ok(v),
-        Err(e) => Err(Error::failed(format!("Text contains non-utf8 data: {e:?}"))),
+        Err(e) => Err(Error::from_kind(ErrorKind::TextContainsNonUtf8Data(e))),
     }
 }
 
@@ -66,7 +66,7 @@ impl<'a> Builder<'a> {
     pub fn new(bytes: &mut [u8], pos: u32) -> Result<Builder<'_>> {
         if pos != 0 {
             if let Err(e) = str::from_utf8(bytes) {
-                return Err(Error::failed(format!("Text contains non-utf8 data: {e:?}")));
+                return Err(Error::from_kind(ErrorKind::TextContainsNonUtf8Data(e)));
             }
         }
         Ok(Builder {

--- a/capnp/src/text.rs
+++ b/capnp/src/text.rs
@@ -151,12 +151,14 @@ impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<Reader<'a>> for crate::dynamic_value::Reader<'a> {
     fn from(t: Reader<'a>) -> crate::dynamic_value::Reader<'a> {
         crate::dynamic_value::Reader::Text(t)
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<Builder<'a>> for crate::dynamic_value::Builder<'a> {
     fn from(t: Builder<'a>) -> crate::dynamic_value::Builder<'a> {
         crate::dynamic_value::Builder::Text(t)

--- a/capnp/src/text_list.rs
+++ b/capnp/src/text_list.rs
@@ -197,6 +197,7 @@ impl<'a> ::core::iter::IntoIterator for Reader<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<Reader<'a>> for crate::dynamic_value::Reader<'a> {
     fn from(t: Reader<'a>) -> crate::dynamic_value::Reader<'a> {
         crate::dynamic_value::Reader::List(crate::dynamic_list::Reader {
@@ -206,6 +207,7 @@ impl<'a> From<Reader<'a>> for crate::dynamic_value::Reader<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<Builder<'a>> for crate::dynamic_value::Builder<'a> {
     fn from(t: Builder<'a>) -> crate::dynamic_value::Builder<'a> {
         crate::dynamic_value::Builder::List(crate::dynamic_list::Builder {

--- a/capnp/src/traits.rs
+++ b/capnp/src/traits.rs
@@ -19,8 +19,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#[cfg(feature = "alloc")]
+use crate::private::layout::CapTable;
 use crate::private::layout::{
-    CapTable, ListReader, PointerBuilder, PointerReader, StructBuilder, StructReader, StructSize,
+    ListReader, PointerBuilder, PointerReader, StructBuilder, StructReader, StructSize,
 };
 use crate::Result;
 
@@ -87,10 +89,12 @@ pub trait SetPointerBuilder {
     ) -> Result<()>;
 }
 
+#[cfg(feature = "alloc")]
 pub trait Imbue<'a> {
     fn imbue(&mut self, caps: &'a CapTable);
 }
 
+#[cfg(feature = "alloc")]
 pub trait ImbueMut<'a> {
     fn imbue_mut(&mut self, caps: &'a mut CapTable);
 }

--- a/capnp/tests/canonicalize.rs
+++ b/capnp/tests/canonicalize.rs
@@ -21,6 +21,7 @@
 
 use capnp::message;
 
+#[cfg(feature = "alloc")]
 #[test]
 fn canonicalize_succeeds_on_null_message() {
     let segment: &[capnp::Word] = &[capnp::word(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)];
@@ -34,6 +35,7 @@ fn canonicalize_succeeds_on_null_message() {
     assert_eq!(&canonical_bytes[..], segment);
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn dont_truncate_struct_too_far() {
     let segment: &[capnp::Word] = &[
@@ -63,6 +65,7 @@ fn dont_truncate_struct_too_far() {
     assert_eq!(&canonicalized[..], canonical_segment);
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn dont_truncate_struct_list_too_far() {
     let segment: &[capnp::Word] = &[
@@ -175,6 +178,7 @@ fn is_canonical_requires_dense_packing() {
     assert!(!message.is_canonical().unwrap());
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn simple_multisegment_message() {
     let segment0: &[capnp::Word] = &[
@@ -206,6 +210,7 @@ fn simple_multisegment_message() {
     assert_eq!(&canonicalized[..], canonical_segment);
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn multisegment_only_first_segment_used() {
     // A segment with a canonicalized struct.
@@ -265,6 +270,7 @@ fn is_canonical_rejects_unused_trailing_words() {
     assert!(!message.is_canonical().unwrap());
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn empty_inline_composite_list_of_0_sized_structs() {
     let segment: &[capnp::Word] = &[
@@ -285,6 +291,7 @@ fn empty_inline_composite_list_of_0_sized_structs() {
     assert_eq!(segment, &canonical_words[..]);
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn inline_composite_list_with_void_list() {
     let segment: &[capnp::Word] = &[
@@ -330,6 +337,7 @@ fn is_canonical_rejects_inline_composite_list_with_inaccurate_word_length() {
     assert!(!message.is_canonical().unwrap());
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn truncate_data_section_inline_composite() {
     let segment: &[capnp::Word] = &[
@@ -354,6 +362,7 @@ fn truncate_data_section_inline_composite() {
     assert!(canonical_message.is_canonical().unwrap());
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn truncate_pointer_section_inline_composite() {
     let segment: &[capnp::Word] = &[
@@ -387,6 +396,7 @@ fn truncate_pointer_section_inline_composite() {
     assert_eq!(expected_canonical_words, &canonical_words[..]);
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn list_padding_must_be_zero() {
     let segment: &[capnp::Word] = &[
@@ -416,6 +426,7 @@ fn list_padding_must_be_zero() {
     assert_eq!(expected_canonical_words, &canonical_words[..]);
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn bit_list_padding_must_be_zero() {
     let segment: &[capnp::Word] = &[

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -302,7 +302,9 @@ impl<'a> GeneratorContext<'a> {
         node_id: u64,
     ) -> ::capnp::Result<()> {
         // unused nodes in imported files might be omitted from the node map
-        let Some(&node_reader) = self.node_map.get(&node_id) else { return Ok(()) };
+        let Some(&node_reader) = self.node_map.get(&node_id) else {
+            return Ok(());
+        };
 
         for annotation in node_reader.get_annotations()? {
             if annotation.get_id() == NAME_ANNOTATION_ID {
@@ -1328,7 +1330,9 @@ fn used_params_of_brand(
     let brand_scopes = brand_scopes; // freeze
     let mut current_node_id = node_id;
     loop {
-        let Some(current_node) = ctx.node_map.get(&current_node_id) else { break };
+        let Some(current_node) = ctx.node_map.get(&current_node_id) else {
+            break;
+        };
         let params = current_node.get_parameters()?;
         match brand_scopes.get(&current_node_id) {
             None => (),

--- a/capnpc/src/lib.rs
+++ b/capnpc/src/lib.rs
@@ -90,7 +90,7 @@ pub(crate) fn convert_io_err(err: std::io::Error) -> capnp::Error {
         _ => capnp::ErrorKind::Failed,
     };
     capnp::Error {
-        description: format!("{err}"),
+        extra: format!("{err}"),
         kind,
     }
 }
@@ -399,6 +399,6 @@ impl CompilerCommand {
 #[cfg_attr(miri, ignore)]
 fn compiler_command_new_no_out_dir() {
     std::env::remove_var("OUT_DIR");
-    let error = CompilerCommand::new().run().unwrap_err().description;
+    let error = CompilerCommand::new().run().unwrap_err().extra;
     assert!(error.starts_with("Could not access `OUT_DIR` environment variable"));
 }

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -1590,7 +1590,7 @@ mod tests {
         match message.get_root::<crate::test_capnp::test_all_types::Reader<'_>>() {
             Ok(_) => panic!("expected out-of-bounds error"),
             Err(e) => {
-                assert_eq!(e.description, "message contained out-of-bounds pointer")
+                assert_eq!(&e.to_string(), "Message contains out-of-bounds pointer")
             }
         }
     }
@@ -1623,7 +1623,7 @@ mod tests {
         match message.get_root::<crate::test_capnp::test_all_types::Reader<'_>>() {
             Ok(_) => panic!("expected out-of-bounds error"),
             Err(e) => {
-                assert_eq!(e.description, "message contained out-of-bounds pointer")
+                assert_eq!(e.to_string(), "Message contains out-of-bounds pointer")
             }
         }
     }
@@ -1688,7 +1688,7 @@ mod tests {
         match root.total_size() {
             Err(e) => assert_eq!(
                 "InlineComposite list's elements overrun its word count.",
-                e.description
+                &e.to_string()
             ),
             _ => panic!("did not get expected error"),
         }
@@ -1706,7 +1706,7 @@ mod tests {
         match builder_root.get_any_pointer_field().set_as(root) {
             Err(e) => assert_eq!(
                 "InlineComposite list's elements overrun its word count.",
-                e.description
+                &e.to_string()
             ),
             _ => panic!("did not get expected error"),
         }
@@ -1829,7 +1829,7 @@ mod tests {
             *ReaderOptions::new().traversal_limit_in_words(Some(2)),
         );
         match reader.get_root::<test_all_types::Reader<'_>>() {
-            Err(e) => assert_eq!(e.description, "read limit exceeded"),
+            Err(e) => assert_eq!(&e.to_string(), "Read limit exceeded"),
             Ok(_) => panic!("expected error"),
         }
     }

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -114,7 +114,11 @@ mod tests {
             schema::StructSchema,
         };
 
-        let TypeVariant::Struct(schema) = field_subset_indexes_correctly::Owned::introspect().which() else { unreachable!() };
+        let TypeVariant::Struct(schema) =
+            field_subset_indexes_correctly::Owned::introspect().which()
+        else {
+            unreachable!()
+        };
         let schema = StructSchema::new(schema);
 
         let subset = schema.get_non_union_fields().unwrap();


### PR DESCRIPTION
This is useful in `no alloc` scenarios and in cases where String is not
available (such as the Linux kernel).