### PR TITLE
Add NoAllocBufferSegments, suitable for no_alloc environments

### DIFF
--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -24,7 +24,7 @@
 //! where each message is preceded by a segment table indicating the size of its segments.
 
 mod no_alloc_slice_segments;
-pub use no_alloc_slice_segments::NoAllocSliceSegments;
+pub use no_alloc_slice_segments::{NoAllocBufferSegments, NoAllocSliceSegments};
 
 #[cfg(feature = "alloc")]
 use crate::io::{Read, Write};


### PR DESCRIPTION
It is similar to BufferSegments, but it avoids any allocations.