### PR TITLE
Support for embedded-io

### DIFF
--- a/capnp/Cargo.toml
+++ b/capnp/Cargo.toml
@@ -36,8 +36,6 @@ unaligned = []
 # with the Rust standard library.
 std = ["embedded-io?/std"]
 
-
-embedded-io = []
 # If enabled, ReadLimiter will use `AtomicUsize` instead of `Cell<usize>`, allowing
 # message readers to be `Sync`. Note that AtomicUsize is not supported by all
 # rustc targets.

--- a/capnp/Cargo.toml
+++ b/capnp/Cargo.toml
@@ -17,13 +17,13 @@ keywords = ["encoding", "protocol", "serialization"]
 [dependencies]
 quickcheck = { version = "1", optional = true }
 
-embedded-io = { version = "0.5.0", default-features = false }
+embedded-io = { version = "0.5.0", default-features = false, optional = true }
 
 [dev-dependencies]
 quickcheck = "1"
 
 [features]
-alloc = ["embedded-io/alloc"]
+alloc = ["embedded-io?/alloc"]
 default = ["std", "alloc"]
 
 rpc_try = []
@@ -34,8 +34,10 @@ unaligned = []
 
 # If disabled, turns on no_std, which tells rustc to not link
 # with the Rust standard library.
-std = ["embedded-io/std"]
+std = ["embedded-io?/std"]
 
+
+embedded-io = []
 # If enabled, ReadLimiter will use `AtomicUsize` instead of `Cell<usize>`, allowing
 # message readers to be `Sync`. Note that AtomicUsize is not supported by all
 # rustc targets.

--- a/capnp/Cargo.toml
+++ b/capnp/Cargo.toml
@@ -17,11 +17,13 @@ keywords = ["encoding", "protocol", "serialization"]
 [dependencies]
 quickcheck = { version = "1", optional = true }
 
+embedded-io = { version = "0.5.0", default-features = false }
+
 [dev-dependencies]
 quickcheck = "1"
 
 [features]
-alloc = []
+alloc = ["embedded-io/alloc"]
 default = ["std", "alloc"]
 
 rpc_try = []
@@ -32,7 +34,7 @@ unaligned = []
 
 # If disabled, turns on no_std, which tells rustc to not link
 # with the Rust standard library.
-std = []
+std = ["embedded-io/std"]
 
 # If enabled, ReadLimiter will use `AtomicUsize` instead of `Cell<usize>`, allowing
 # message readers to be `Sync`. Note that AtomicUsize is not supported by all

--- a/capnp/src/capability.rs
+++ b/capnp/src/capability.rs
@@ -107,22 +107,22 @@ impl<T, E> Future for Promise<T, E> {
 
 #[cfg(feature = "alloc")]
 #[cfg(feature = "rpc_try")]
-impl<T> std::ops::Try for Promise<T, crate::Error> {
+impl<T> core::ops::Try for Promise<T, crate::Error> {
     type Output = Self;
-    type Residual = Result<std::convert::Infallible, crate::Error>;
+    type Residual = Result<core::convert::Infallible, crate::Error>;
 
     fn from_output(output: Self::Output) -> Self {
         output
     }
 
-    fn branch(self) -> std::ops::ControlFlow<Self::Residual, Self::Output> {
+    fn branch(self) -> core::ops::ControlFlow<Self::Residual, Self::Output> {
         unimplemented!();
     }
 }
 
 #[cfg(feature = "alloc")]
 #[cfg(feature = "rpc_try")]
-impl<T> std::ops::FromResidual for Promise<T, crate::Error> {
+impl<T> core::ops::FromResidual for Promise<T, crate::Error> {
     fn from_residual(residual: <Self as Try>::Residual) -> Self {
         match residual {
             Ok(_) => unimplemented!(),

--- a/capnp/src/io.rs
+++ b/capnp/src/io.rs
@@ -162,7 +162,7 @@ mod no_std_impls {
     }
 }
 
-#[cfg(feature = "embedded-io")]
+#[cfg(all(feature = "embedded-io", not(feature = "std")))]
 mod no_std_impls {
     use crate::io::{BufRead, Read, Write};
     use crate::Result;

--- a/capnp/src/io.rs
+++ b/capnp/src/io.rs
@@ -85,7 +85,6 @@ mod std_impls {
     }
 }
 
-
 #[cfg(not(any(feature = "std", feature = "embedded-io")))]
 mod no_std_impls {
     use crate::io::{BufRead, Read, Write};
@@ -113,8 +112,8 @@ mod no_std_impls {
     }
 
     impl<W: ?Sized> Write for &mut W
-        where
-            W: Write,
+    where
+        W: Write,
     {
         fn write_all(&mut self, buf: &[u8]) -> Result<()> {
             (**self).write_all(buf)
@@ -133,8 +132,8 @@ mod no_std_impls {
     }
 
     impl<R: ?Sized> Read for &mut R
-        where
-            R: Read,
+    where
+        R: Read,
     {
         fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
             (**self).read(buf)
@@ -151,8 +150,8 @@ mod no_std_impls {
     }
 
     impl<R: ?Sized> BufRead for &mut R
-        where
-            R: BufRead,
+    where
+        R: BufRead,
     {
         fn fill_buf(&mut self) -> Result<&[u8]> {
             (**self).fill_buf()
@@ -165,31 +164,25 @@ mod no_std_impls {
 
 #[cfg(feature = "embedded-io")]
 mod no_std_impls {
-    use embedded_io::Error;
     use crate::io::{BufRead, Read, Write};
-    use crate::{Result};
+    use crate::Result;
+    use embedded_io::Error;
 
     impl<W: embedded_io::Write> Write for W {
         fn write_all(&mut self, buf: &[u8]) -> Result<()> {
-            embedded_io::Write::write_all(self, buf)
-                .map_err(|e| {
-                    match e {
-                        embedded_io::WriteAllError::WriteZero => {
-                            crate::Error::from_kind(crate::ErrorKind::Failed)
-                        }
-                        embedded_io::WriteAllError::Other(e) => crate::Error::from_kind(e.kind().into()),
-                    }
-                })?;
+            embedded_io::Write::write_all(self, buf).map_err(|e| match e {
+                embedded_io::WriteAllError::WriteZero => {
+                    crate::Error::from_kind(crate::ErrorKind::Failed)
+                }
+                embedded_io::WriteAllError::Other(e) => crate::Error::from_kind(e.kind().into()),
+            })?;
             Ok(())
         }
     }
 
     impl<R: embedded_io::Read> Read for R {
         fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-            embedded_io::Read::read(self, buf)
-                .map_err(|e| {
-                    crate::Error::from_kind(e.kind().into())
-                })
+            embedded_io::Read::read(self, buf).map_err(|e| crate::Error::from_kind(e.kind().into()))
         }
     }
 

--- a/capnp/src/lib.rs
+++ b/capnp/src/lib.rs
@@ -470,6 +470,31 @@ impl core::convert::From<::std::io::Error> for Error {
     }
 }
 
+impl From<embedded_io::ErrorKind> for ErrorKind {
+    fn from(value: embedded_io::ErrorKind) -> Self {
+        match value {
+            embedded_io::ErrorKind::Other => { Self::Failed }
+            embedded_io::ErrorKind::NotFound => { Self::Failed }
+            embedded_io::ErrorKind::PermissionDenied => { Self::Failed }
+            embedded_io::ErrorKind::ConnectionRefused => { Self::Failed }
+            embedded_io::ErrorKind::ConnectionReset => { Self::Failed }
+            embedded_io::ErrorKind::ConnectionAborted => { Self::Failed }
+            embedded_io::ErrorKind::NotConnected => { Self::Failed }
+            embedded_io::ErrorKind::AddrInUse => { Self::Failed }
+            embedded_io::ErrorKind::AddrNotAvailable => { Self::Failed }
+            embedded_io::ErrorKind::BrokenPipe => { Self::Failed }
+            embedded_io::ErrorKind::AlreadyExists => { Self::Failed }
+            embedded_io::ErrorKind::InvalidInput => { Self::Failed }
+            embedded_io::ErrorKind::InvalidData => { Self::Failed }
+            embedded_io::ErrorKind::TimedOut => { Self::Failed }
+            embedded_io::ErrorKind::Interrupted => { Self::Failed }
+            embedded_io::ErrorKind::Unsupported => { Self::Failed }
+            embedded_io::ErrorKind::OutOfMemory => { Self::Failed }
+            _ => { Self::Failed }
+        }
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl core::convert::From<alloc::string::FromUtf8Error> for Error {
     fn from(err: alloc::string::FromUtf8Error) -> Self {

--- a/capnp/src/lib.rs
+++ b/capnp/src/lib.rs
@@ -474,24 +474,24 @@ impl core::convert::From<::std::io::Error> for Error {
 impl From<embedded_io::ErrorKind> for ErrorKind {
     fn from(value: embedded_io::ErrorKind) -> Self {
         match value {
-            embedded_io::ErrorKind::Other => { Self::Failed }
-            embedded_io::ErrorKind::NotFound => { Self::Failed }
-            embedded_io::ErrorKind::PermissionDenied => { Self::Failed }
-            embedded_io::ErrorKind::ConnectionRefused => { Self::Failed }
-            embedded_io::ErrorKind::ConnectionReset => { Self::Failed }
-            embedded_io::ErrorKind::ConnectionAborted => { Self::Failed }
-            embedded_io::ErrorKind::NotConnected => { Self::Failed }
-            embedded_io::ErrorKind::AddrInUse => { Self::Failed }
-            embedded_io::ErrorKind::AddrNotAvailable => { Self::Failed }
-            embedded_io::ErrorKind::BrokenPipe => { Self::Failed }
-            embedded_io::ErrorKind::AlreadyExists => { Self::Failed }
-            embedded_io::ErrorKind::InvalidInput => { Self::Failed }
-            embedded_io::ErrorKind::InvalidData => { Self::Failed }
-            embedded_io::ErrorKind::TimedOut => { Self::Failed }
-            embedded_io::ErrorKind::Interrupted => { Self::Failed }
-            embedded_io::ErrorKind::Unsupported => { Self::Failed }
-            embedded_io::ErrorKind::OutOfMemory => { Self::Failed }
-            _ => { Self::Failed }
+            embedded_io::ErrorKind::Other => Self::Failed,
+            embedded_io::ErrorKind::NotFound => Self::Failed,
+            embedded_io::ErrorKind::PermissionDenied => Self::Failed,
+            embedded_io::ErrorKind::ConnectionRefused => Self::Failed,
+            embedded_io::ErrorKind::ConnectionReset => Self::Failed,
+            embedded_io::ErrorKind::ConnectionAborted => Self::Failed,
+            embedded_io::ErrorKind::NotConnected => Self::Failed,
+            embedded_io::ErrorKind::AddrInUse => Self::Failed,
+            embedded_io::ErrorKind::AddrNotAvailable => Self::Failed,
+            embedded_io::ErrorKind::BrokenPipe => Self::Failed,
+            embedded_io::ErrorKind::AlreadyExists => Self::Failed,
+            embedded_io::ErrorKind::InvalidInput => Self::Failed,
+            embedded_io::ErrorKind::InvalidData => Self::Failed,
+            embedded_io::ErrorKind::TimedOut => Self::Failed,
+            embedded_io::ErrorKind::Interrupted => Self::Failed,
+            embedded_io::ErrorKind::Unsupported => Self::Failed,
+            embedded_io::ErrorKind::OutOfMemory => Self::Failed,
+            _ => Self::Failed,
         }
     }
 }

--- a/capnp/src/lib.rs
+++ b/capnp/src/lib.rs
@@ -470,6 +470,7 @@ impl core::convert::From<::std::io::Error> for Error {
     }
 }
 
+#[cfg(feature = "embedded-io")]
 impl From<embedded_io::ErrorKind> for ErrorKind {
     fn from(value: embedded_io::ErrorKind) -> Self {
         match value {

--- a/capnp/src/private/layout_test.rs
+++ b/capnp/src/private/layout_test.rs
@@ -26,9 +26,9 @@ use crate::private::layout::PointerReader;
 fn test_at_alignments(words: &[crate::Word], verify: &dyn Fn(PointerReader)) {
     verify(unsafe { PointerReader::get_root_unchecked(words.as_ptr() as *const u8) });
 
-    #[cfg(feature = "unaligned")]
+    #[cfg(all(feature = "unaligned", feature = "alloc"))]
     {
-        let mut unaligned_data = Vec::with_capacity((words.len() + 1) * 8);
+        let mut unaligned_data = crate::Vec::with_capacity((words.len() + 1) * 8);
         for offset in 0..8 {
             unaligned_data.clear();
             unaligned_data.resize(offset, 0);


### PR DESCRIPTION
Added support for embedded-io.

Implemented Write, Read, and BufRead for objects with implementations in embedded-io.
This makes capnp easier to use on embedded devices.
