### PR TITLE
add AsRef to ease upgrading to 0.18

### DIFF
--- a/capnp/src/text.rs
+++ b/capnp/src/text.rs
@@ -21,6 +21,7 @@
 
 //! UTF-8 encoded text.
 
+use core::convert::AsRef;
 use core::str;
 
 use crate::Result;
@@ -66,6 +67,16 @@ impl<'a> core::fmt::Debug for Reader<'a> {
     }
 }
 
+impl<'a, T> From<&'a T> for Reader<'a>
+where
+    T: AsRef<str>,
+{
+    #[inline]
+    fn from(value: &'a T) -> Self {
+        Self(value.as_ref().as_bytes())
+    }
+}
+
 impl<'a> From<&'a str> for Reader<'a> {
     #[inline]
     fn from(value: &'a str) -> Self {
@@ -77,12 +88,6 @@ impl<'a> From<&'a [u8]> for Reader<'a> {
     #[inline]
     fn from(value: &'a [u8]) -> Self {
         Self(value)
-    }
-}
-
-impl<'a, const N: usize> From<&'a [u8; N]> for Reader<'a> {
-    fn from(value: &'a [u8; N]) -> Self {
-        Self(&value[..])
     }
 }
 


### PR DESCRIPTION
Hi! 

I help maintain an open source repo that uses capnp and I'm trying to upgrade it to the latest version v0.18.1. I saw that you added LazyUtf8 support and now everything needs to be a `Reader<T>`: https://dwrensha.github.io/capnproto-rust/2023/09/04/0.18-release.html

I think it is more easy to upgrade & also fits more with the rust ecosystem to add a `From <AsRef<str>>` implementation to the text reader.

Note: This is my first ever commit to this repo and it's possible I missed something or there might be more places where adding this From might make sense.  I also understand that the lack of this `From` implementation may have been a conscious choice to make debugging compilation errors easier, or there may be other things I have overlooked.