### PR TITLE
Support List(T) passthrough

### DIFF
--- a/capnpc/src/codegen_types.rs
+++ b/capnpc/src/codegen_types.rs
@@ -241,7 +241,17 @@ impl<'a> RustTypeInfo for type_::Reader<'a> {
                         ))
                     }
                     type_::AnyPointer(_) => {
-                        Err(Error::failed("List(AnyPointer) is unsupported".to_string()))
+                        // This is actually an AnyList, which means we just return an anypointer and
+                        // let the user cast it appropriately.
+                        match module {
+                            Leaf::Reader(lifetime) => {
+                                Ok(fmt!(ctx, "{capnp}::any_pointer::Reader<{lifetime}>"))
+                            }
+                            Leaf::Builder(lifetime) => {
+                                Ok(fmt!(ctx, "{capnp}::any_pointer::Builder<{lifetime}>"))
+                            }
+                            _ => Ok(fmt!(ctx, "{capnp}::any_pointer::{module}")),
+                        }
                     }
                     _ => {
                         let inner = element_type.type_string(ctx, Leaf::Owned)?;


### PR DESCRIPTION
This is an implementation of https://github.com/capnproto/capnproto/pull/1807 for allowing `List(T)` in schemas. Essentially, it is treated as an AnyList parameter on the wire, but the type information is preserved in the schema, which allows the C++ version to implement a proxy List(T) over the AnyList that enforces the correct type usage.

I could not find an equivalent to capnp-c++'s `AnyList` class, it appears that AnyLists are simply converted to `any_pointer`s and it is left to the user to cast them appropriately. So, this change simply replaces rejecting a `List(AnyPointer)` by replacing it with an `any_pointer`, the same way `AnyList` is handled. This change doesn't break any existing tests, but also does not add any tests either, because any test for this feature would have to be gated behind whatever version of capnp ends up incorporating List(T) support.

It may be possible to restrict the acceptance of `List(AnyPointer)` to only cases where the `any_pointer` is an actual parameter (which is what was done in the C++ version) but I wasn't sure how to do that.