### PR TITLE
Catch EOF properly in `serialize_packed` AsyncRead

### DIFF
--- a/capnp-futures/src/serialize_packed.rs
+++ b/capnp-futures/src/serialize_packed.rs
@@ -100,6 +100,9 @@ where
                     match Pin::new(&mut *inner).poll_read(cx, &mut buf[*buf_pos..2])? {
                         Poll::Pending => return Poll::Pending,
                         Poll::Ready(n) => {
+                            if n == 0 {
+                                return Poll::Ready(Ok(0));
+                            }
                             *buf_pos += n;
                             if *buf_pos >= 2 {
                                 let tag = buf[0];
@@ -179,6 +182,9 @@ where
                         match Pin::new(&mut *inner).poll_read(cx, &mut outbuf[0..upper_bound])? {
                             Poll::Pending => return Poll::Pending,
                             Poll::Ready(n) => {
+                                if n == 0 {
+                                    return Poll::Ready(Ok(0));
+                                }
                                 if n >= *num_run_bytes_remaining {
                                     *stage = PackedReadStage::Start;
                                 }


### PR DESCRIPTION
Problem: `capnp_futures::serialize_packed::try_read_message()` blocks forever on an input stream which is completed and reports EOF to us. The library uses 100% cpu while is doing that.

Solution: As soon as the library reads 0 bytes from the stream, interpret it as EOF and return `Poll::Ready(Ok(0))` as expected by AsyncRead trait.

Issue: https://github.com/capnproto/capnproto-rust/issues/445