### PR TITLE
enable some serialize and serialize_packed functions in no-alloc mode

### DIFF
--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -321,7 +321,7 @@ where
     R: Read,
 {
     if buffer.len() < 8 {
-        return Err(Error::from_kind(ErrorKind::BufferNotLargeEnough))
+        return Err(Error::from_kind(ErrorKind::BufferNotLargeEnough));
     }
 
     // read the first Word, which contains segment_count and the 1st segment length
@@ -350,7 +350,7 @@ where
         let start = num_segment_counts_read * 8;
         let end = start + 8;
         if buffer.len() < end {
-            return Err(Error::from_kind(ErrorKind::BufferNotLargeEnough))
+            return Err(Error::from_kind(ErrorKind::BufferNotLargeEnough));
         }
 
         read.read(&mut buffer[start..end])?;
@@ -374,7 +374,7 @@ where
     let start = num_segment_counts_read * 8;
     let end = start + total_body_words as usize;
     if buffer.len() < end {
-        return Err(Error::from_kind(ErrorKind::BufferNotLargeEnough))
+        return Err(Error::from_kind(ErrorKind::BufferNotLargeEnough));
     }
     read.read_exact(&mut buffer[start..end])?;
 

--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -322,10 +322,8 @@ pub fn try_read_message_no_alloc<R>(
 where
     R: Read,
 {
-    if !cfg!(feature = "unaligned") {
-        if buffer.as_ptr() as usize % BYTES_PER_WORD != 0 {
-            return Err(Error::from_kind(ErrorKind::UnalignedSegment));
-        }
+    if !cfg!(feature = "unaligned") && buffer.as_ptr() as usize % BYTES_PER_WORD != 0 {
+        return Err(Error::from_kind(ErrorKind::UnalignedSegment));
     }
 
     if buffer.len() < 8 {

--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -386,7 +386,7 @@ where
 
     let info = no_alloc_buffer_segments::ReadSegmentTableResult {
         segments_count: segment_count,
-        segment_table_length_bytes: num_segment_counts_read * 8,
+        segment_table_length_bytes: (num_segment_counts_read + 1) * 4,
         total_segments_length_bytes: total_body_words as usize * 8,
     };
 

--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -316,8 +316,8 @@ where
 /// Otherwise, `buffer` must be 8-byte aligned (attempts to read the message will trigger errors).
 pub fn try_read_message_no_alloc<R>(
     mut read: R,
-    options: message::ReaderOptions,
     buffer: &mut [u8],
+    options: message::ReaderOptions,
 ) -> Result<Option<message::Reader<NoAllocBufferSegments<&[u8]>>>>
 where
     R: Read,
@@ -401,13 +401,13 @@ where
 /// Otherwise, `buffer` must be 8-byte aligned (attempts to read the message will trigger errors).
 pub fn read_message_no_alloc<R>(
     read: R,
-    options: message::ReaderOptions,
     buffer: &mut [u8],
+    options: message::ReaderOptions,
 ) -> Result<message::Reader<NoAllocBufferSegments<&[u8]>>>
 where
     R: Read,
 {
-    match try_read_message_no_alloc(read, options, buffer)? {
+    match try_read_message_no_alloc(read, buffer, options)? {
         Some(m) => Ok(m),
         None => Err(Error::from_kind(ErrorKind::PrematureEndOfFile)),
     }

--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -310,6 +310,8 @@ where
 }
 
 /// Like `try_read_message()`, but does not allocate any memory.
+/// Stores the message in `buffer`. Returns a `BufferNotLargeEnough`
+/// error if the buffer is not large enough.
 pub fn try_read_message_no_alloc<R>(
     mut read: R,
     options: message::ReaderOptions,
@@ -387,6 +389,8 @@ where
 }
 
 /// Like `read_message()`, but does not allocate.
+/// Stores the message in `buffer`. Returns a `BufferNotLargeEnough`
+/// error if the buffer is not large enough.
 pub fn read_message_no_alloc<R>(
     read: R,
     options: message::ReaderOptions,

--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -353,7 +353,7 @@ where
     let mut total_body_words = u32::from_le_bytes(buffer[4..8].try_into().unwrap());
     let mut num_segment_counts_read = 1;
     while num_segment_counts_read < segment_count {
-        let start = num_segment_counts_read * 8;
+        let start = (num_segment_counts_read + 1) * 4;
         let end = start + 8;
         if buffer.len() < end {
             return Err(Error::from_kind(ErrorKind::BufferNotLargeEnough));

--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -377,8 +377,8 @@ where
         }
     }
 
-    let start = num_segment_counts_read * 8;
-    let end = start + total_body_words as usize;
+    let start = (num_segment_counts_read + 1) * 4;
+    let end = start + (total_body_words as usize * 8);
     if buffer.len() < end {
         return Err(Error::from_kind(ErrorKind::BufferNotLargeEnough));
     }

--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -320,6 +320,12 @@ pub fn try_read_message_no_alloc<R>(
 where
     R: Read,
 {
+    if !cfg!(feature = "unaligned") {
+        if buffer.as_ptr() as usize % BYTES_PER_WORD != 0 {
+            return Err(Error::from_kind(ErrorKind::UnalignedSegment));
+        }
+    }
+
     if buffer.len() < 8 {
         return Err(Error::from_kind(ErrorKind::BufferNotLargeEnough));
     }

--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -312,6 +312,8 @@ where
 /// Like `try_read_message()`, but does not allocate any memory.
 /// Stores the message in `buffer`. Returns a `BufferNotLargeEnough`
 /// error if the buffer is not large enough.
+/// ALIGNMENT: If the "unaligned" feature is enabled, then there are no alignment requirements on `buffer`.
+/// Otherwise, `buffer` must be 8-byte aligned (attempts to read the message will trigger errors).
 pub fn try_read_message_no_alloc<R>(
     mut read: R,
     options: message::ReaderOptions,
@@ -397,6 +399,8 @@ where
 /// Like `read_message()`, but does not allocate.
 /// Stores the message in `buffer`. Returns a `BufferNotLargeEnough`
 /// error if the buffer is not large enough.
+/// ALIGNMENT: If the "unaligned" feature is enabled, then there are no alignment requirements on `buffer`.
+/// Otherwise, `buffer` must be 8-byte aligned (attempts to read the message will trigger errors).
 pub fn read_message_no_alloc<R>(
     read: R,
     options: message::ReaderOptions,

--- a/capnp/src/serialize/no_alloc_buffer_segments.rs
+++ b/capnp/src/serialize/no_alloc_buffer_segments.rs
@@ -10,10 +10,10 @@ use super::SEGMENTS_COUNT_LIMIT;
 
 const U32_LEN_IN_BYTES: usize = core::mem::size_of::<u32>();
 
-struct ReadSegmentTableResult {
-    segments_count: usize,
-    segment_table_length_bytes: usize,
-    total_segments_length_bytes: usize,
+pub(crate) struct ReadSegmentTableResult {
+    pub segments_count: usize,
+    pub segment_table_length_bytes: usize,
+    pub total_segments_length_bytes: usize,
 }
 
 fn read_segment_table(slice: &[u8], options: ReaderOptions) -> Result<ReadSegmentTableResult> {
@@ -108,7 +108,7 @@ pub struct NoAllocBufferSegments<T> {
 }
 
 impl<T> NoAllocBufferSegments<T> {
-    fn from_segment_table(buffer: T, info: ReadSegmentTableResult) -> Self {
+    pub(crate) fn from_segment_table(buffer: T, info: ReadSegmentTableResult) -> Self {
         if info.segments_count == 1 {
             let message_length = info.segment_table_length_bytes + info.total_segments_length_bytes;
             Self {

--- a/capnp/src/serialize_packed.rs
+++ b/capnp/src/serialize_packed.rs
@@ -255,6 +255,8 @@ where
 }
 
 /// Like read_message(), but does not allocate.
+/// Stores the message in `buffer`. Returns a `BufferNotLargeEnough`
+/// error if the buffer is not large enough.
 pub fn read_message_no_alloc<R>(
     read: R,
     options: message::ReaderOptions,
@@ -268,6 +270,8 @@ where
 }
 
 /// Like try_read_message(), but does not allocate.
+/// Stores the message in `buffer`. Returns a `BufferNotLargeEnough`
+/// error if the buffer is not large enough.
 pub fn try_read_message_no_alloc<R>(
     read: R,
     options: message::ReaderOptions,

--- a/capnp/src/serialize_packed.rs
+++ b/capnp/src/serialize_packed.rs
@@ -25,9 +25,7 @@
 use crate::io::{BufRead, Read, Write};
 use core::{mem, ptr, slice};
 
-#[cfg(feature = "alloc")]
 use crate::message;
-#[cfg(feature = "alloc")]
 use crate::serialize;
 use crate::{Error, ErrorKind, Result};
 
@@ -256,6 +254,32 @@ where
     serialize::try_read_message(packed_read, options)
 }
 
+/// Like read_message(), but does not allocate.
+pub fn read_message_no_alloc<R>(
+    read: R,
+    options: message::ReaderOptions,
+    buffer: &mut [u8],
+) -> Result<crate::message::Reader<serialize::NoAllocBufferSegments<&[u8]>>>
+where
+    R: BufRead,
+{
+    let packed_read = PackedRead { inner: read };
+    serialize::read_message_no_alloc(packed_read, options, buffer)
+}
+
+/// Like try_read_message(), but does not allocate.
+pub fn try_read_message_no_alloc<R>(
+    read: R,
+    options: message::ReaderOptions,
+    buffer: &mut [u8],
+) -> Result<Option<crate::message::Reader<serialize::NoAllocBufferSegments<&[u8]>>>>
+where
+    R: BufRead,
+{
+    let packed_read = PackedRead { inner: read };
+    serialize::try_read_message_no_alloc(packed_read, options, buffer)
+}
+
 struct PackedWrite<W>
 where
     W: Write,
@@ -408,7 +432,6 @@ where
 ///
 /// The only source of errors from this function are `write.write_all()` calls. If you pass in
 /// a writer that never returns an error, then this function will never return an error.
-#[cfg(feature = "alloc")]
 pub fn write_message<W, A>(write: W, message: &crate::message::Builder<A>) -> Result<()>
 where
     W: Write,

--- a/capnp/src/serialize_packed.rs
+++ b/capnp/src/serialize_packed.rs
@@ -257,6 +257,8 @@ where
 /// Like read_message(), but does not allocate.
 /// Stores the message in `buffer`. Returns a `BufferNotLargeEnough`
 /// error if the buffer is not large enough.
+/// ALIGNMENT: If the "unaligned" feature is enabled, then there are no alignment requirements on `buffer`.
+/// Otherwise, `buffer` must be 8-byte aligned (attempts to read the message will trigger errors).
 pub fn read_message_no_alloc<R>(
     read: R,
     options: message::ReaderOptions,
@@ -272,6 +274,8 @@ where
 /// Like try_read_message(), but does not allocate.
 /// Stores the message in `buffer`. Returns a `BufferNotLargeEnough`
 /// error if the buffer is not large enough.
+/// ALIGNMENT: If the "unaligned" feature is enabled, then there are no alignment requirements on `buffer`.
+/// Otherwise, `buffer` must be 8-byte aligned (attempts to read the message will trigger errors).
 pub fn try_read_message_no_alloc<R>(
     read: R,
     options: message::ReaderOptions,

--- a/capnp/src/serialize_packed.rs
+++ b/capnp/src/serialize_packed.rs
@@ -261,14 +261,14 @@ where
 /// Otherwise, `buffer` must be 8-byte aligned (attempts to read the message will trigger errors).
 pub fn read_message_no_alloc<R>(
     read: R,
-    options: message::ReaderOptions,
     buffer: &mut [u8],
+    options: message::ReaderOptions,
 ) -> Result<crate::message::Reader<serialize::NoAllocBufferSegments<&[u8]>>>
 where
     R: BufRead,
 {
     let packed_read = PackedRead { inner: read };
-    serialize::read_message_no_alloc(packed_read, options, buffer)
+    serialize::read_message_no_alloc(packed_read, buffer, options)
 }
 
 /// Like try_read_message(), but does not allocate.
@@ -278,14 +278,14 @@ where
 /// Otherwise, `buffer` must be 8-byte aligned (attempts to read the message will trigger errors).
 pub fn try_read_message_no_alloc<R>(
     read: R,
-    options: message::ReaderOptions,
     buffer: &mut [u8],
+    options: message::ReaderOptions,
 ) -> Result<Option<crate::message::Reader<serialize::NoAllocBufferSegments<&[u8]>>>>
 where
     R: BufRead,
 {
     let packed_read = PackedRead { inner: read };
-    serialize::try_read_message_no_alloc(packed_read, options, buffer)
+    serialize::try_read_message_no_alloc(packed_read, buffer, options)
 }
 
 struct PackedWrite<W>

--- a/capnp/tests/serialize_read_message_no_alloc.rs
+++ b/capnp/tests/serialize_read_message_no_alloc.rs
@@ -9,11 +9,11 @@ pub fn serialize_read_message_no_alloc() {
         let mut msg = message::Builder::new(allocator);
         msg.set_root("hello world!").unwrap();
 
-        let mut out_buffer = Word::allocate_zeroed_vec(512);
+        let mut out_buffer = [capnp::word(0, 0, 0, 0, 0, 0, 0, 0); 256];
 
         serialize::write_message(Word::words_to_bytes_mut(&mut out_buffer), &msg).unwrap();
 
-        let mut read_buffer = Word::allocate_zeroed_vec(512);
+        let mut read_buffer = [capnp::word(0, 0, 0, 0, 0, 0, 0, 0); 256];
 
         let reader = serialize::read_message_no_alloc(
             &mut Word::words_to_bytes(&out_buffer),

--- a/capnp/tests/serialize_read_message_no_alloc.rs
+++ b/capnp/tests/serialize_read_message_no_alloc.rs
@@ -1,0 +1,28 @@
+use capnp::{message, serialize, Word};
+
+#[test]
+pub fn serialize_read_message_no_alloc() {
+    let mut buffer = [capnp::word(0, 0, 0, 0, 0, 0, 0, 0); 200];
+    {
+        let allocator =
+            message::SingleSegmentAllocator::new(capnp::Word::words_to_bytes_mut(&mut buffer[..]));
+        let mut msg = message::Builder::new(allocator);
+        msg.set_root("hello world!").unwrap();
+
+        let mut out_buffer = Word::allocate_zeroed_vec(512);
+
+        serialize::write_message(Word::words_to_bytes_mut(&mut out_buffer), &msg).unwrap();
+
+        let mut read_buffer = Word::allocate_zeroed_vec(512);
+
+        let reader = serialize::read_message_no_alloc(
+            &mut Word::words_to_bytes(&out_buffer),
+            message::ReaderOptions::new(),
+            Word::words_to_bytes_mut(&mut read_buffer),
+        )
+        .unwrap();
+
+        let s: capnp::text::Reader = reader.get_root().unwrap();
+        assert_eq!("hello world!", s);
+    }
+}

--- a/capnp/tests/serialize_read_message_no_alloc.rs
+++ b/capnp/tests/serialize_read_message_no_alloc.rs
@@ -17,8 +17,8 @@ pub fn serialize_read_message_no_alloc() {
 
         let reader = serialize::read_message_no_alloc(
             &mut Word::words_to_bytes(&out_buffer),
-            message::ReaderOptions::new(),
             Word::words_to_bytes_mut(&mut read_buffer),
+            message::ReaderOptions::new(),
         )
         .unwrap();
 

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -2209,8 +2209,8 @@ mod tests {
         let mut read_buffer = Word::allocate_zeroed_vec(512);
         let reader = capnp::serialize::read_message_no_alloc(
             &mut Word::words_to_bytes(&buffer),
-            ReaderOptions::new(),
             Word::words_to_bytes_mut(&mut read_buffer),
+            ReaderOptions::new(),
         )
         .unwrap();
         let message_reader = TypedReader::<_, test_all_types::Owned>::new(reader);
@@ -2242,8 +2242,8 @@ mod tests {
         let mut read_buffer = Word::allocate_zeroed_vec(512);
         let reader = capnp::serialize::read_message_no_alloc(
             &mut Word::words_to_bytes(&buffer),
-            ReaderOptions::new(),
             Word::words_to_bytes_mut(&mut read_buffer),
+            ReaderOptions::new(),
         )
         .unwrap();
         let message_reader = TypedReader::<_, test_all_types::Owned>::new(reader);

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -2188,6 +2188,35 @@ mod tests {
         CheckTestMessage::check_test_message(message_reader.get().unwrap());
     }
 
+    #[test]
+    fn test_read_message_no_alloc() {
+        use crate::test_capnp::test_all_types;
+
+        let mut typed_builder = TypedBuilder::<test_all_types::Owned>::new_default();
+        init_test_message(typed_builder.init_root());
+
+        CheckTestMessage::check_test_message(typed_builder.get_root().unwrap());
+        CheckTestMessage::check_test_message(typed_builder.get_root_as_reader().unwrap());
+
+        let mut buffer = Word::allocate_zeroed_vec(512);
+
+        capnp::serialize::write_message(
+            Word::words_to_bytes_mut(&mut buffer),
+            typed_builder.borrow_inner(),
+        )
+        .unwrap();
+
+        let mut read_buffer = Word::allocate_zeroed_vec(512);
+        let reader = capnp::serialize::read_message_no_alloc(
+            &mut Word::words_to_bytes(&buffer),
+            ReaderOptions::new(),
+            Word::words_to_bytes_mut(&mut read_buffer),
+        )
+        .unwrap();
+        let message_reader = TypedReader::<_, test_all_types::Owned>::new(reader);
+        CheckTestMessage::check_test_message(message_reader.get().unwrap());
+    }
+
     #[cfg_attr(miri, ignore)]
     #[test]
     fn test_raw_code_generator_request_path() {


### PR DESCRIPTION
* Adds `serialize::read_message_no_alloc()` and `serialize::try_read_message_no_alloc()`.
* Adds `serialize_packed::read_message_no_alloc()` and `serialize_packed::try_read_message_no_alloc()`.
* Enables `serialize::write_message()` and `serialize_packed::write_message()` in no-alloc mode.