### PR TITLE
Implement this_client()

### DIFF
--- a/capnp-rpc/test/test.capnp
+++ b/capnp-rpc/test/test.capnp
@@ -79,6 +79,7 @@ interface Bootstrap {
   testCallOrder @4 () -> (cap: TestCallOrder);
   testMoreStuff @5 () -> (cap: TestMoreStuff);
   testCapabilityServerSet @6 () -> (cap: TestCapabilityServerSet);
+  testRecursiveClientFactorial @7 () -> (cap: TestRecursiveClientFactorial);
 }
 
 interface TestInterface {
@@ -182,4 +183,8 @@ interface TestCapabilityServerSet {
 
   createHandle @0 () -> (handle :Handle);
   checkHandle @1 (handle: Handle) -> (isOurs :Bool);
+}
+
+interface TestRecursiveClientFactorial {
+  fact @0 (n: Int32) -> (res :Int32);
 }

--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -1014,3 +1014,22 @@ fn capability_server_set_rpc() {
         Ok(())
     })
 }
+#[test]
+fn recursive_client() {
+    rpc_top_level(|_spawner, client| async move {
+        let response1 = client
+            .test_recursive_client_factorial_request()
+            .send()
+            .promise
+            .await?;
+        let client1 = response1.get()?.get_cap()?;
+
+        let mut req = client1.fact_request();
+        req.get().set_n(4);
+
+        let res = req.send().promise.await?;
+        assert_eq!(res.get()?.get_res(), 24);
+
+        Ok(())
+    })
+}

--- a/capnp/src/private/capability.rs
+++ b/capnp/src/private/capability.rs
@@ -22,10 +22,15 @@
 #![cfg(feature = "alloc")]
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use core::cell::RefCell;
 
 use crate::any_pointer;
 use crate::capability::{Params, Promise, RemotePromise, Request, Results};
 use crate::MessageSize;
+
+thread_local! {
+    pub static CURRENT_THIS: RefCell<Option<*const dyn Fn() -> Box<dyn ClientHook>>> = Default::default();
+}
 
 pub trait ResponseHook {
     fn get(&self) -> crate::Result<any_pointer::Reader<'_>>;

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -2745,6 +2745,10 @@ fn generate_node(
                     params.params, server_base, params.where_clause
                 )),
                 indent(server_interior),
+                indent(line(format!("fn this_client<'a>(&'a mut self) -> Client<{}> {{", params.params))), // are these generics ALWAYS the same as the Client generics? It seems like so.
+                indent(indent(Line(format!("::capnp::private::capability::CURRENT_THIS.with_borrow(|curr_this| <Client<{}> as ::capnp::capability::FromClientHook>::new(", params.params)))), // Should replace ::capnp with {capnp} maybe?
+                indent(indent(Line(fmt!(ctx, "unsafe {{&*curr_this.unwrap() as &dyn Fn() -> Box<dyn ({capnp}::private::capability::ClientHook)>}}()))")))),
+                indent(line("}")),
                 line("}"),
             ]));
 


### PR DESCRIPTION
fixes #87.

One question though: this currently works well for a struct implementing a single interface. 
If a single struct implements multiple interfaces, there will be multiple `this_client` implementations, one for each interface.
I'm not sure how this is going to handle multiple interfaces...

For example:
```rust
struct Calculator{}
impl calculator_add::Server for Calculator {
  fn add(&mut self, params, results) {...} 
}
impl calculator_sub::Server for Calculator {
  fn sub(&mut self, params, results) {
    let client = calculator_sub::Server::this_client(self); // Works perfectly.
    let client = calculator_add::Server::this_client(self); // OUCH, we are trying to get a `calculator_add::Client` from a `calculator_sub::Client`.
  } 
}
```

If the two interfaces share the same `ClientHook` anyway, this is fine. Do they? Else, it's going to be a problem.