### PR TITLE
Use binary search for find capnp struct field by name

### DIFF
--- a/capnp-rpc/src/rpc_capnp.rs
+++ b/capnp-rpc/src/rpc_capnp.rs
@@ -1059,22 +1059,7 @@ pub mod message {
         pub static NONUNION_MEMBERS: &[u16] = &[];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] =
             &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-            ("abort", 1),
-            ("accept", 11),
-            ("bootstrap", 8),
-            ("call", 2),
-            ("disembargo", 13),
-            ("finish", 4),
-            ("join", 12),
-            ("obsoleteDelete", 9),
-            ("obsoleteSave", 7),
-            ("provide", 10),
-            ("release", 6),
-            ("resolve", 5),
-            ("return", 3),
-            ("unimplemented", 0),
-        ];
+        pub static MEMBERS_BY_NAME: &[u16] = &[1, 11, 8, 2, 13, 4, 12, 9, 7, 10, 6, 5, 3, 0];
         pub const TYPE_ID: u64 = 0x91b7_9f1f_808d_b032;
     }
     pub enum Which<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> {
@@ -1440,8 +1425,7 @@ pub mod bootstrap {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] =
-            &[("deprecatedObjectId", 1), ("questionId", 0)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[1, 0];
         pub const TYPE_ID: u64 = 0xe94c_cf80_3117_6ec4;
     }
 }
@@ -1944,15 +1928,7 @@ pub mod call {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3, 4, 5, 6];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-            ("allowThirdPartyTailCall", 6),
-            ("interfaceId", 2),
-            ("methodId", 3),
-            ("params", 4),
-            ("questionId", 0),
-            ("sendResultsTo", 5),
-            ("target", 1),
-        ];
+        pub static MEMBERS_BY_NAME: &[u16] = &[6, 2, 3, 4, 0, 5, 1];
         pub const TYPE_ID: u64 = 0x836a_53ce_789d_4cd4;
     }
 
@@ -2312,8 +2288,7 @@ pub mod call {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1, 2];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] =
-                &[("caller", 0), ("thirdParty", 2), ("yourself", 1)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[0, 2, 1];
             pub const TYPE_ID: u64 = 0xdae8_b0f6_1aab_5f99;
         }
         pub enum Which<A0> {
@@ -2882,16 +2857,7 @@ pub mod return_ {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[2, 3, 4, 5, 6, 7];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-            ("acceptFromThirdParty", 7),
-            ("answerId", 0),
-            ("canceled", 4),
-            ("exception", 3),
-            ("releaseParamCaps", 1),
-            ("results", 2),
-            ("resultsSentElsewhere", 5),
-            ("takeFromOtherQuestion", 6),
-        ];
+        pub static MEMBERS_BY_NAME: &[u16] = &[7, 0, 4, 3, 1, 2, 5, 6];
         pub const TYPE_ID: u64 = 0x9e19_b28d_3db3_573a;
     }
     pub enum Which<A0, A1, A2> {
@@ -3213,7 +3179,7 @@ pub mod finish {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("questionId", 0), ("releaseResultCaps", 1)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[0, 1];
         pub const TYPE_ID: u64 = 0xd37d_2eb2_c2f8_0e63;
     }
 }
@@ -3620,8 +3586,7 @@ pub mod resolve {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[1, 2];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] =
-            &[("cap", 1), ("exception", 2), ("promiseId", 0)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[1, 2, 0];
         pub const TYPE_ID: u64 = 0xbbc2_9655_fa89_086e;
     }
     pub enum Which<A0, A1> {
@@ -3935,7 +3900,7 @@ pub mod release {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("id", 0), ("referenceCount", 1)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[0, 1];
         pub const TYPE_ID: u64 = 0xad1a_6c0d_7dd0_7497;
     }
 }
@@ -4263,7 +4228,7 @@ pub mod disembargo {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("context", 1), ("target", 0)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[1, 0];
         pub const TYPE_ID: u64 = 0xf964_368b_0fbd_3711;
     }
 
@@ -4632,12 +4597,7 @@ pub mod disembargo {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1, 2, 3];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-                ("accept", 2),
-                ("provide", 3),
-                ("receiverLoopback", 1),
-                ("senderLoopback", 0),
-            ];
+            pub static MEMBERS_BY_NAME: &[u16] = &[2, 3, 1, 0];
             pub const TYPE_ID: u64 = 0xd562_b4df_655b_dd4d;
         }
         pub enum Which {
@@ -5019,8 +4979,7 @@ pub mod provide {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] =
-            &[("questionId", 0), ("recipient", 2), ("target", 1)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[0, 2, 1];
         pub const TYPE_ID: u64 = 0x9c6a_046b_fbc1_ac5a;
     }
 }
@@ -5365,8 +5324,7 @@ pub mod accept {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] =
-            &[("embargo", 2), ("provision", 1), ("questionId", 0)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[2, 1, 0];
         pub const TYPE_ID: u64 = 0xd4c9_b562_9055_4016;
     }
 }
@@ -5737,8 +5695,7 @@ pub mod join {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] =
-            &[("keyPart", 2), ("questionId", 0), ("target", 1)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[2, 0, 1];
         pub const TYPE_ID: u64 = 0xfbe1_9804_90e0_01af;
     }
 }
@@ -6081,7 +6038,7 @@ pub mod message_target {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("importedCap", 0), ("promisedAnswer", 1)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[0, 1];
         pub const TYPE_ID: u64 = 0x95bc_1454_5813_fbc1;
     }
     pub enum Which<A0> {
@@ -6448,7 +6405,7 @@ pub mod payload {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("capTable", 1), ("content", 0)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[1, 0];
         pub const TYPE_ID: u64 = 0x9a0e_6122_3d96_743b;
     }
 }
@@ -6965,15 +6922,7 @@ pub mod cap_descriptor {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[6];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1, 2, 3, 4, 5];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-            ("attachedFd", 6),
-            ("none", 0),
-            ("receiverAnswer", 4),
-            ("receiverHosted", 3),
-            ("senderHosted", 1),
-            ("senderPromise", 2),
-            ("thirdPartyHosted", 5),
-        ];
+        pub static MEMBERS_BY_NAME: &[u16] = &[6, 0, 4, 3, 1, 2, 5];
         pub const TYPE_ID: u64 = 0x8523_ddc4_0b86_b8b0;
     }
     pub enum Which<A0, A1> {
@@ -7340,7 +7289,7 @@ pub mod promised_answer {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("questionId", 0), ("transform", 1)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[0, 1];
         pub const TYPE_ID: u64 = 0xd800_b1d6_cd6f_1ca0;
     }
 
@@ -7658,7 +7607,7 @@ pub mod promised_answer {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("getPointerField", 1), ("noop", 0)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[1, 0];
             pub const TYPE_ID: u64 = 0xf316_9444_1556_9081;
         }
         pub enum Which {
@@ -7982,7 +7931,7 @@ pub mod third_party_cap_descriptor {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("id", 0), ("vineId", 1)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[0, 1];
         pub const TYPE_ID: u64 = 0xd370_07fd_e1f0_027d;
     }
 }
@@ -8416,13 +8365,7 @@ pub mod exception {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3, 4];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-            ("obsoleteDurability", 2),
-            ("obsoleteIsCallersFault", 1),
-            ("reason", 0),
-            ("trace", 4),
-            ("type", 3),
-        ];
+        pub static MEMBERS_BY_NAME: &[u16] = &[2, 1, 0, 4, 3];
         pub const TYPE_ID: u64 = 0xd625_b706_3acf_691a;
     }
 

--- a/capnp-rpc/src/rpc_capnp.rs
+++ b/capnp-rpc/src/rpc_capnp.rs
@@ -1054,10 +1054,27 @@ pub mod message {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] =
             &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+            ("abort", 1),
+            ("accept", 11),
+            ("bootstrap", 8),
+            ("call", 2),
+            ("disembargo", 13),
+            ("finish", 4),
+            ("join", 12),
+            ("obsoleteDelete", 9),
+            ("obsoleteSave", 7),
+            ("provide", 10),
+            ("release", 6),
+            ("resolve", 5),
+            ("return", 3),
+            ("unimplemented", 0),
+        ];
         pub const TYPE_ID: u64 = 0x91b7_9f1f_808d_b032;
     }
     pub enum Which<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> {
@@ -1419,9 +1436,12 @@ pub mod bootstrap {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] =
+            &[("deprecatedObjectId", 1), ("questionId", 0)];
         pub const TYPE_ID: u64 = 0xe94c_cf80_3117_6ec4;
     }
 }
@@ -1920,9 +1940,19 @@ pub mod call {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3, 4, 5, 6];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+            ("allowThirdPartyTailCall", 6),
+            ("interfaceId", 2),
+            ("methodId", 3),
+            ("params", 4),
+            ("questionId", 0),
+            ("sendResultsTo", 5),
+            ("target", 1),
+        ];
         pub const TYPE_ID: u64 = 0x836a_53ce_789d_4cd4;
     }
 
@@ -2278,9 +2308,12 @@ pub mod call {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1, 2];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] =
+                &[("caller", 0), ("thirdParty", 2), ("yourself", 1)];
             pub const TYPE_ID: u64 = 0xdae8_b0f6_1aab_5f99;
         }
         pub enum Which<A0> {
@@ -2845,9 +2878,20 @@ pub mod return_ {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[2, 3, 4, 5, 6, 7];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+            ("acceptFromThirdParty", 7),
+            ("answerId", 0),
+            ("canceled", 4),
+            ("exception", 3),
+            ("releaseParamCaps", 1),
+            ("results", 2),
+            ("resultsSentElsewhere", 5),
+            ("takeFromOtherQuestion", 6),
+        ];
         pub const TYPE_ID: u64 = 0x9e19_b28d_3db3_573a;
     }
     pub enum Which<A0, A1, A2> {
@@ -3165,9 +3209,11 @@ pub mod finish {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("questionId", 0), ("releaseResultCaps", 1)];
         pub const TYPE_ID: u64 = 0xd37d_2eb2_c2f8_0e63;
     }
 }
@@ -3570,9 +3616,12 @@ pub mod resolve {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[1, 2];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] =
+            &[("cap", 1), ("exception", 2), ("promiseId", 0)];
         pub const TYPE_ID: u64 = 0xbbc2_9655_fa89_086e;
     }
     pub enum Which<A0, A1> {
@@ -3882,9 +3931,11 @@ pub mod release {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("id", 0), ("referenceCount", 1)];
         pub const TYPE_ID: u64 = 0xad1a_6c0d_7dd0_7497;
     }
 }
@@ -4208,9 +4259,11 @@ pub mod disembargo {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("context", 1), ("target", 0)];
         pub const TYPE_ID: u64 = 0xf964_368b_0fbd_3711;
     }
 
@@ -4575,9 +4628,16 @@ pub mod disembargo {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1, 2, 3];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+                ("accept", 2),
+                ("provide", 3),
+                ("receiverLoopback", 1),
+                ("senderLoopback", 0),
+            ];
             pub const TYPE_ID: u64 = 0xd562_b4df_655b_dd4d;
         }
         pub enum Which {
@@ -4955,9 +5015,12 @@ pub mod provide {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] =
+            &[("questionId", 0), ("recipient", 2), ("target", 1)];
         pub const TYPE_ID: u64 = 0x9c6a_046b_fbc1_ac5a;
     }
 }
@@ -5298,9 +5361,12 @@ pub mod accept {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] =
+            &[("embargo", 2), ("provision", 1), ("questionId", 0)];
         pub const TYPE_ID: u64 = 0xd4c9_b562_9055_4016;
     }
 }
@@ -5667,9 +5733,12 @@ pub mod join {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] =
+            &[("keyPart", 2), ("questionId", 0), ("target", 1)];
         pub const TYPE_ID: u64 = 0xfbe1_9804_90e0_01af;
     }
 }
@@ -6008,9 +6077,11 @@ pub mod message_target {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("importedCap", 0), ("promisedAnswer", 1)];
         pub const TYPE_ID: u64 = 0x95bc_1454_5813_fbc1;
     }
     pub enum Which<A0> {
@@ -6373,9 +6444,11 @@ pub mod payload {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("capTable", 1), ("content", 0)];
         pub const TYPE_ID: u64 = 0x9a0e_6122_3d96_743b;
     }
 }
@@ -6888,9 +6961,19 @@ pub mod cap_descriptor {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[6];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1, 2, 3, 4, 5];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+            ("attachedFd", 6),
+            ("none", 0),
+            ("receiverAnswer", 4),
+            ("receiverHosted", 3),
+            ("senderHosted", 1),
+            ("senderPromise", 2),
+            ("thirdPartyHosted", 5),
+        ];
         pub const TYPE_ID: u64 = 0x8523_ddc4_0b86_b8b0;
     }
     pub enum Which<A0, A1> {
@@ -7253,9 +7336,11 @@ pub mod promised_answer {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("questionId", 0), ("transform", 1)];
         pub const TYPE_ID: u64 = 0xd800_b1d6_cd6f_1ca0;
     }
 
@@ -7569,9 +7654,11 @@ pub mod promised_answer {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("getPointerField", 1), ("noop", 0)];
             pub const TYPE_ID: u64 = 0xf316_9444_1556_9081;
         }
         pub enum Which {
@@ -7891,9 +7978,11 @@ pub mod third_party_cap_descriptor {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("id", 0), ("vineId", 1)];
         pub const TYPE_ID: u64 = 0xd370_07fd_e1f0_027d;
     }
 }
@@ -8323,9 +8412,17 @@ pub mod exception {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3, 4];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+            ("obsoleteDurability", 2),
+            ("obsoleteIsCallersFault", 1),
+            ("reason", 0),
+            ("trace", 4),
+            ("type", 3),
+        ];
         pub const TYPE_ID: u64 = 0xd625_b706_3acf_691a;
     }
 

--- a/capnp-rpc/src/rpc_twoparty_capnp.rs
+++ b/capnp-rpc/src/rpc_twoparty_capnp.rs
@@ -361,7 +361,7 @@ pub mod vat_id {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("side", 0)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[0];
         pub const TYPE_ID: u64 = 0xd20b_909f_ee73_3a8e;
     }
 }
@@ -635,7 +635,7 @@ pub mod provision_id {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("joinId", 0)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[0];
         pub const TYPE_ID: u64 = 0xb88d_09a9_c5f3_9817;
     }
 }
@@ -878,7 +878,7 @@ pub mod recipient_id {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[];
+        pub static MEMBERS_BY_NAME: &[u16] = &[];
         pub const TYPE_ID: u64 = 0x89f3_89b6_fd40_82c1;
     }
 }
@@ -1122,7 +1122,7 @@ pub mod third_party_cap_id {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[];
+        pub static MEMBERS_BY_NAME: &[u16] = &[];
         pub const TYPE_ID: u64 = 0xb47f_4979_672c_b59d;
     }
 }
@@ -1453,8 +1453,7 @@ pub mod join_key_part {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] =
-            &[("joinId", 0), ("partCount", 1), ("partNum", 2)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[0, 1, 2];
         pub const TYPE_ID: u64 = 0x95b2_9059_097f_ca83;
     }
 }
@@ -1799,7 +1798,7 @@ pub mod join_result {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("cap", 2), ("joinId", 0), ("succeeded", 1)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[2, 0, 1];
         pub const TYPE_ID: u64 = 0x9d26_3a36_30b7_ebee;
     }
 }

--- a/capnp-rpc/src/rpc_twoparty_capnp.rs
+++ b/capnp-rpc/src/rpc_twoparty_capnp.rs
@@ -357,9 +357,11 @@ pub mod vat_id {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("side", 0)];
         pub const TYPE_ID: u64 = 0xd20b_909f_ee73_3a8e;
     }
 }
@@ -629,9 +631,11 @@ pub mod provision_id {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("joinId", 0)];
         pub const TYPE_ID: u64 = 0xb88d_09a9_c5f3_9817;
     }
 }
@@ -870,9 +874,11 @@ pub mod recipient_id {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[];
         pub const TYPE_ID: u64 = 0x89f3_89b6_fd40_82c1;
     }
 }
@@ -1112,9 +1118,11 @@ pub mod third_party_cap_id {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[];
         pub const TYPE_ID: u64 = 0xb47f_4979_672c_b59d;
     }
 }
@@ -1441,9 +1449,12 @@ pub mod join_key_part {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] =
+            &[("joinId", 0), ("partCount", 1), ("partNum", 2)];
         pub const TYPE_ID: u64 = 0x95b2_9059_097f_ca83;
     }
 }
@@ -1784,9 +1795,11 @@ pub mod join_result {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("cap", 2), ("joinId", 0), ("succeeded", 1)];
         pub const TYPE_ID: u64 = 0x9d26_3a36_30b7_ebee;
     }
 }

--- a/capnp/src/introspect.rs
+++ b/capnp/src/introspect.rs
@@ -203,7 +203,7 @@ primitive_introspect!(f64, Float64);
 
 /// Type information that gets included in the generated code for every
 /// user-defined Cap'n Proto struct.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct RawStructSchema {
     /// The Node (as defined in schema.capnp), as a single segment message.
     pub encoded_node: &'static [crate::Word],
@@ -214,8 +214,8 @@ pub struct RawStructSchema {
     /// Map from discriminant value to field index.
     pub members_by_discriminant: &'static [u16],
 
-    // Map field name to field index.
-    pub members_by_name: std::collections::HashMap<&'static str, u16>,
+    // Sorted array of field names with matching field index.
+    pub members_by_name: &'static [(&'static str, u16)],
 }
 
 /// A RawStructSchema with branding information, i.e. resolution of type parameters.

--- a/capnp/src/introspect.rs
+++ b/capnp/src/introspect.rs
@@ -215,7 +215,7 @@ pub struct RawStructSchema {
     pub members_by_discriminant: &'static [u16],
 
     // Sorted array of field names with matching field index.
-    pub members_by_name: &'static [(&'static str, u16)],
+    pub members_by_name: &'static [u16],
 }
 
 /// A RawStructSchema with branding information, i.e. resolution of type parameters.

--- a/capnp/src/introspect.rs
+++ b/capnp/src/introspect.rs
@@ -203,7 +203,7 @@ primitive_introspect!(f64, Float64);
 
 /// Type information that gets included in the generated code for every
 /// user-defined Cap'n Proto struct.
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct RawStructSchema {
     /// The Node (as defined in schema.capnp), as a single segment message.
     pub encoded_node: &'static [crate::Word],
@@ -213,8 +213,9 @@ pub struct RawStructSchema {
 
     /// Map from discriminant value to field index.
     pub members_by_discriminant: &'static [u16],
-    //
-    // TODO: members_by_name, allowing fast field lookup by name.
+
+    // Map field name to field index.
+    pub members_by_name: std::collections::HashMap<&'static str, u16>,
 }
 
 /// A RawStructSchema with branding information, i.e. resolution of type parameters.

--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -55,12 +55,24 @@ impl StructSchema {
         }
     }
 
-    /// Looks up a field by name. Returns `None` if no matching field is found.
+    /// Looks up a field by name using binary search. Returns `None` if no matching field is found.
     pub fn find_field_by_name(&self, name: &str) -> Result<Option<Field>> {
-        for field in self.get_fields()? {
-            if field.get_proto().get_name()? == name {
-                return Ok(Some(field));
+        self.raw.generic.members_by_name;
+        let mut lower: usize = 0;
+        let mut upper: usize = self.raw.generic.members_by_name.len();
+        let mut mid: usize = (lower + upper) / 2;
+        let (mut candidate_name, mut candidate_index) = self.raw.generic.members_by_name[mid];
+
+        while lower < upper {
+            if name == candidate_name {
+                return Ok(Some(self.get_fields()?.get(candidate_index)))
+            } else if candidate_name < name {
+                lower = mid + 1;
+            } else {
+                upper = mid;
             }
+            mid = (lower + upper) / 2;
+            (candidate_name, candidate_index) = self.raw.generic.members_by_name[mid];
         }
         Ok(None)
     }

--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -57,19 +57,16 @@ impl StructSchema {
 
     /// Looks up a field by name using binary search. Returns `None` if no matching field is found.
     pub fn find_field_by_name(&self, name: &str) -> Result<Option<Field>> {
-        self.raw.generic.members_by_name;
         let mut lower: usize = 0;
         let mut upper: usize = self.raw.generic.members_by_name.len();
         let mut mid: usize = (lower + upper) / 2;
         let (mut candidate_name, mut candidate_index) = self.raw.generic.members_by_name[mid];
 
         while lower < upper {
-            if name == candidate_name {
-                return Ok(Some(self.get_fields()?.get(candidate_index)));
-            } else if candidate_name < name {
-                lower = mid + 1;
-            } else {
-                upper = mid;
+            match name.cmp(candidate_name) {
+                std::cmp::Ordering::Equal => return Ok(Some(self.get_fields()?.get(candidate_index))),
+                std::cmp::Ordering::Greater => lower = mid + 1,
+                std::cmp::Ordering::Less => upper = mid,
             }
             mid = (lower + upper) / 2;
             (candidate_name, candidate_index) = self.raw.generic.members_by_name[mid];

--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -65,7 +65,7 @@ impl StructSchema {
 
         while lower < upper {
             if name == candidate_name {
-                return Ok(Some(self.get_fields()?.get(candidate_index)))
+                return Ok(Some(self.get_fields()?.get(candidate_index)));
             } else if candidate_name < name {
                 lower = mid + 1;
             } else {

--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -57,19 +57,24 @@ impl StructSchema {
 
     /// Looks up a field by name using binary search. Returns `None` if no matching field is found.
     pub fn find_field_by_name(&self, name: &str) -> Result<Option<Field>> {
+        let fields = self.get_fields()?;
         let mut lower: usize = 0;
         let mut upper: usize = self.raw.generic.members_by_name.len();
         let mut mid: usize = (lower + upper) / 2;
-        let (mut candidate_name, mut candidate_index) = self.raw.generic.members_by_name[mid];
+        let mut candidate_index = self.raw.generic.members_by_name[mid];
+        let mut candidate_name = fields.get(candidate_index).get_proto().get_name()?;
 
         while lower < upper {
-            match name.cmp(candidate_name) {
-                std::cmp::Ordering::Equal => return Ok(Some(self.get_fields()?.get(candidate_index))),
-                std::cmp::Ordering::Greater => lower = mid + 1,
-                std::cmp::Ordering::Less => upper = mid,
+            if name == candidate_name {
+                return Ok(Some(fields.get(candidate_index)));
+            } else if candidate_name < name {
+                lower = mid + 1;
+            } else {
+                upper = mid;
             }
             mid = (lower + upper) / 2;
-            (candidate_name, candidate_index) = self.raw.generic.members_by_name[mid];
+            candidate_index = self.raw.generic.members_by_name[mid];
+            candidate_name = fields.get(candidate_index).get_proto().get_name()?;
         }
         Ok(None)
     }

--- a/capnp/src/schema_capnp.rs
+++ b/capnp/src/schema_capnp.rs
@@ -762,22 +762,7 @@ pub mod node {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3, 4, 5, 12, 13];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[6, 7, 8, 9, 10, 11];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-            ("annotation", 11),
-            ("annotations", 5),
-            ("const", 10),
-            ("displayName", 1),
-            ("displayNamePrefixLength", 2),
-            ("enum", 8),
-            ("file", 6),
-            ("id", 0),
-            ("interface", 9),
-            ("isGeneric", 13),
-            ("nestedNodes", 4),
-            ("parameters", 12),
-            ("scopeId", 3),
-            ("struct", 7),
-        ];
+        pub static MEMBERS_BY_NAME: &[u16] = &[11, 5, 10, 1, 2, 8, 6, 0, 9, 13, 4, 12, 3, 7];
         pub const TYPE_ID: u64 = 0xe682_ab4c_f923_a417;
     }
     pub enum Which<A0, A1, A2, A3, A4> {
@@ -1090,7 +1075,7 @@ pub mod node {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("name", 0)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[0];
             pub const TYPE_ID: u64 = 0xb952_1bcc_f10f_a3b1;
         }
     }
@@ -1410,7 +1395,7 @@ pub mod node {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("id", 1), ("name", 0)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[1, 0];
             pub const TYPE_ID: u64 = 0xdebf_55bb_fa0f_c242;
         }
     }
@@ -1819,8 +1804,7 @@ pub mod node {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] =
-                &[("docComment", 1), ("id", 0), ("members", 2)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[1, 0, 2];
             pub const TYPE_ID: u64 = 0xf38e_1de3_0413_57ae;
         }
 
@@ -2122,7 +2106,7 @@ pub mod node {
                     };
                 pub static NONUNION_MEMBERS: &[u16] = &[0];
                 pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-                pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("docComment", 0)];
+                pub static MEMBERS_BY_NAME: &[u16] = &[0];
                 pub const TYPE_ID: u64 = 0xc2ba_9038_898e_1fa2;
             }
         }
@@ -2619,15 +2603,7 @@ pub mod node {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3, 4, 5, 6];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-                ("dataWordCount", 0),
-                ("discriminantCount", 4),
-                ("discriminantOffset", 5),
-                ("fields", 6),
-                ("isGroup", 3),
-                ("pointerCount", 1),
-                ("preferredListEncoding", 2),
-            ];
+            pub static MEMBERS_BY_NAME: &[u16] = &[0, 4, 5, 6, 3, 1, 2];
             pub const TYPE_ID: u64 = 0x9ea0_b19b_37fb_4435;
         }
     }
@@ -2942,7 +2918,7 @@ pub mod node {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("enumerants", 0)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[0];
             pub const TYPE_ID: u64 = 0xb54a_b336_4333_f598;
         }
     }
@@ -3328,7 +3304,7 @@ pub mod node {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("methods", 0), ("superclasses", 1)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[0, 1];
             pub const TYPE_ID: u64 = 0xe827_53cf_f0c2_218f;
         }
     }
@@ -3691,7 +3667,7 @@ pub mod node {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("type", 0), ("value", 1)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[0, 1];
             pub const TYPE_ID: u64 = 0xb18a_a5ac_7a0d_9420;
         }
     }
@@ -4347,21 +4323,7 @@ pub mod node {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-                ("targetsAnnotation", 12),
-                ("targetsConst", 2),
-                ("targetsEnum", 3),
-                ("targetsEnumerant", 4),
-                ("targetsField", 6),
-                ("targetsFile", 1),
-                ("targetsGroup", 8),
-                ("targetsInterface", 9),
-                ("targetsMethod", 10),
-                ("targetsParam", 11),
-                ("targetsStruct", 5),
-                ("targetsUnion", 7),
-                ("type", 0),
-            ];
+            pub static MEMBERS_BY_NAME: &[u16] = &[12, 2, 3, 4, 6, 1, 8, 9, 10, 11, 5, 7, 0];
             pub const TYPE_ID: u64 = 0xec16_19d4_400a_0290;
         }
     }
@@ -4858,15 +4820,7 @@ pub mod field {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3, 6];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[4, 5];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-            ("annotations", 2),
-            ("codeOrder", 1),
-            ("discriminantValue", 3),
-            ("group", 5),
-            ("name", 0),
-            ("ordinal", 6),
-            ("slot", 4),
-        ];
+        pub static MEMBERS_BY_NAME: &[u16] = &[2, 1, 3, 5, 0, 6, 4];
         pub const TYPE_ID: u64 = 0x9aad_50a4_1f4a_f45f;
     }
     pub enum Which<A0, A1> {
@@ -5304,12 +5258,7 @@ pub mod field {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-                ("defaultValue", 2),
-                ("hadExplicitDefault", 3),
-                ("offset", 0),
-                ("type", 1),
-            ];
+            pub static MEMBERS_BY_NAME: &[u16] = &[2, 3, 0, 1];
             pub const TYPE_ID: u64 = 0xc423_0547_6bb4_746f;
         }
     }
@@ -5582,7 +5531,7 @@ pub mod field {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("typeId", 0)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[0];
             pub const TYPE_ID: u64 = 0xcafc_cddb_68db_1d11;
         }
     }
@@ -5890,7 +5839,7 @@ pub mod field {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("explicit", 1), ("implicit", 0)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[1, 0];
             pub const TYPE_ID: u64 = 0xbb90_d5c2_8787_0be6;
         }
         pub enum Which {
@@ -6281,8 +6230,7 @@ pub mod enumerant {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] =
-            &[("annotations", 2), ("codeOrder", 1), ("name", 0)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[2, 1, 0];
         pub const TYPE_ID: u64 = 0x978a_7ceb_dc54_9a4d;
     }
 }
@@ -6612,7 +6560,7 @@ pub mod superclass {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("brand", 1), ("id", 0)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[1, 0];
         pub const TYPE_ID: u64 = 0xa996_2a9e_d0a4_d7f8;
     }
 }
@@ -7240,16 +7188,7 @@ pub mod method {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3, 4, 5, 6, 7];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-            ("annotations", 4),
-            ("codeOrder", 1),
-            ("implicitParameters", 7),
-            ("name", 0),
-            ("paramBrand", 5),
-            ("paramStructType", 2),
-            ("resultBrand", 6),
-            ("resultStructType", 3),
-        ];
+        pub static MEMBERS_BY_NAME: &[u16] = &[4, 1, 7, 0, 5, 2, 6, 3];
         pub const TYPE_ID: u64 = 0x9500_cce2_3b33_4d80;
     }
 }
@@ -7912,26 +7851,8 @@ pub mod type_ {
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
         ];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-            ("anyPointer", 18),
-            ("bool", 1),
-            ("data", 13),
-            ("enum", 15),
-            ("float32", 10),
-            ("float64", 11),
-            ("int16", 3),
-            ("int32", 4),
-            ("int64", 5),
-            ("int8", 2),
-            ("interface", 17),
-            ("list", 14),
-            ("struct", 16),
-            ("text", 12),
-            ("uint16", 7),
-            ("uint32", 8),
-            ("uint64", 9),
-            ("uint8", 6),
-            ("void", 0),
+        pub static MEMBERS_BY_NAME: &[u16] = &[
+            18, 1, 13, 15, 10, 11, 3, 4, 5, 2, 17, 14, 16, 12, 7, 8, 9, 6, 0,
         ];
         pub const TYPE_ID: u64 = 0xd073_78ed_e1f9_cc60;
     }
@@ -8273,7 +8194,7 @@ pub mod type_ {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("elementType", 0)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[0];
             pub const TYPE_ID: u64 = 0x87e7_3925_0a60_ea97;
         }
     }
@@ -8605,7 +8526,7 @@ pub mod type_ {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("brand", 1), ("typeId", 0)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[1, 0];
             pub const TYPE_ID: u64 = 0x9e0e_7871_1a7f_87a9;
         }
     }
@@ -8938,7 +8859,7 @@ pub mod type_ {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("brand", 1), ("typeId", 0)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[1, 0];
             pub const TYPE_ID: u64 = 0xac3a_6f60_ef4c_c6d3;
         }
     }
@@ -9271,7 +9192,7 @@ pub mod type_ {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("brand", 1), ("typeId", 0)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[1, 0];
             pub const TYPE_ID: u64 = 0xed8b_ca69_f7fb_0cbf;
         }
     }
@@ -9593,11 +9514,7 @@ pub mod type_ {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1, 2];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-                ("implicitMethodParameter", 2),
-                ("parameter", 1),
-                ("unconstrained", 0),
-            ];
+            pub static MEMBERS_BY_NAME: &[u16] = &[2, 1, 0];
             pub const TYPE_ID: u64 = 0xc257_3fe8_a23e_49f1;
         }
         pub enum Which<A0, A1, A2> {
@@ -9970,12 +9887,7 @@ pub mod type_ {
                     };
                 pub static NONUNION_MEMBERS: &[u16] = &[];
                 pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1, 2, 3];
-                pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-                    ("anyKind", 0),
-                    ("capability", 3),
-                    ("list", 2),
-                    ("struct", 1),
-                ];
+                pub static MEMBERS_BY_NAME: &[u16] = &[0, 3, 2, 1];
                 pub const TYPE_ID: u64 = 0x8e3b_5f79_fe59_3656;
             }
             pub enum Which {
@@ -10295,8 +10207,7 @@ pub mod type_ {
                     };
                 pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
                 pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-                pub static MEMBERS_BY_NAME: &[(&str, u16)] =
-                    &[("parameterIndex", 1), ("scopeId", 0)];
+                pub static MEMBERS_BY_NAME: &[u16] = &[1, 0];
                 pub const TYPE_ID: u64 = 0x9dd1_f724_f461_4a85;
             }
         }
@@ -10582,7 +10493,7 @@ pub mod type_ {
                     };
                 pub static NONUNION_MEMBERS: &[u16] = &[0];
                 pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-                pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("parameterIndex", 0)];
+                pub static MEMBERS_BY_NAME: &[u16] = &[0];
                 pub const TYPE_ID: u64 = 0xbaef_c912_0c56_e274;
             }
         }
@@ -10898,7 +10809,7 @@ pub mod brand {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("scopes", 0)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[0];
         pub const TYPE_ID: u64 = 0x9034_55f0_6065_422b;
     }
 
@@ -11277,8 +11188,7 @@ pub mod brand {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[1, 2];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] =
-                &[("bind", 1), ("inherit", 2), ("scopeId", 0)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[1, 2, 0];
             pub const TYPE_ID: u64 = 0xabd7_3485_a963_6bc9;
         }
         pub enum Which<A0> {
@@ -11636,7 +11546,7 @@ pub mod brand {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("type", 1), ("unbound", 0)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[1, 0];
             pub const TYPE_ID: u64 = 0xc863_cd16_969e_e7fc;
         }
         pub enum Which<A0> {
@@ -12459,26 +12369,8 @@ pub mod value {
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
         ];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-            ("anyPointer", 18),
-            ("bool", 1),
-            ("data", 13),
-            ("enum", 15),
-            ("float32", 10),
-            ("float64", 11),
-            ("int16", 3),
-            ("int32", 4),
-            ("int64", 5),
-            ("int8", 2),
-            ("interface", 17),
-            ("list", 14),
-            ("struct", 16),
-            ("text", 12),
-            ("uint16", 7),
-            ("uint32", 8),
-            ("uint64", 9),
-            ("uint8", 6),
-            ("void", 0),
+        pub static MEMBERS_BY_NAME: &[u16] = &[
+            18, 1, 13, 15, 10, 11, 3, 4, 5, 2, 17, 14, 16, 12, 7, 8, 9, 6, 0,
         ];
         pub const TYPE_ID: u64 = 0xce23_dcd2_d7b0_0c9b;
     }
@@ -12903,7 +12795,7 @@ pub mod annotation {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("brand", 2), ("id", 0), ("value", 1)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[2, 0, 1];
         pub const TYPE_ID: u64 = 0xf1c8_950d_ab25_7542;
     }
 }
@@ -13354,7 +13246,7 @@ pub mod capnp_version {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("major", 0), ("micro", 2), ("minor", 1)];
+        pub static MEMBERS_BY_NAME: &[u16] = &[0, 2, 1];
         pub const TYPE_ID: u64 = 0xd85d_305b_7d83_9963;
     }
 }
@@ -13881,12 +13773,7 @@ pub mod code_generator_request {
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
-            ("capnpVersion", 2),
-            ("nodes", 0),
-            ("requestedFiles", 1),
-            ("sourceInfo", 3),
-        ];
+        pub static MEMBERS_BY_NAME: &[u16] = &[2, 0, 1, 3];
         pub const TYPE_ID: u64 = 0xbfc5_46f6_210a_d7ce;
     }
 
@@ -14296,8 +14183,7 @@ pub mod code_generator_request {
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-            pub static MEMBERS_BY_NAME: &[(&str, u16)] =
-                &[("filename", 1), ("id", 0), ("imports", 2)];
+            pub static MEMBERS_BY_NAME: &[u16] = &[1, 0, 2];
             pub const TYPE_ID: u64 = 0xcfea_0eb0_2e81_0062;
         }
 
@@ -14628,7 +14514,7 @@ pub mod code_generator_request {
                     };
                 pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
                 pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
-                pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("id", 0), ("name", 1)];
+                pub static MEMBERS_BY_NAME: &[u16] = &[0, 1];
                 pub const TYPE_ID: u64 = 0xae50_4193_1223_57e5;
             }
         }

--- a/capnp/src/schema_capnp.rs
+++ b/capnp/src/schema_capnp.rs
@@ -758,9 +758,26 @@ pub mod node {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3, 4, 5, 12, 13];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[6, 7, 8, 9, 10, 11];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+            ("annotation", 11),
+            ("annotations", 5),
+            ("const", 10),
+            ("displayName", 1),
+            ("displayNamePrefixLength", 2),
+            ("enum", 8),
+            ("file", 6),
+            ("id", 0),
+            ("interface", 9),
+            ("isGeneric", 13),
+            ("nestedNodes", 4),
+            ("parameters", 12),
+            ("scopeId", 3),
+            ("struct", 7),
+        ];
         pub const TYPE_ID: u64 = 0xe682_ab4c_f923_a417;
     }
     pub enum Which<A0, A1, A2, A3, A4> {
@@ -1069,9 +1086,11 @@ pub mod node {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("name", 0)];
             pub const TYPE_ID: u64 = 0xb952_1bcc_f10f_a3b1;
         }
     }
@@ -1387,9 +1406,11 @@ pub mod node {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("id", 1), ("name", 0)];
             pub const TYPE_ID: u64 = 0xdebf_55bb_fa0f_c242;
         }
     }
@@ -1794,9 +1815,12 @@ pub mod node {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] =
+                &[("docComment", 1), ("id", 0), ("members", 2)];
             pub const TYPE_ID: u64 = 0xf38e_1de3_0413_57ae;
         }
 
@@ -2094,9 +2118,11 @@ pub mod node {
                         encoded_node: &ENCODED_NODE,
                         nonunion_members: NONUNION_MEMBERS,
                         members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                        members_by_name: MEMBERS_BY_NAME,
                     };
                 pub static NONUNION_MEMBERS: &[u16] = &[0];
                 pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+                pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("docComment", 0)];
                 pub const TYPE_ID: u64 = 0xc2ba_9038_898e_1fa2;
             }
         }
@@ -2589,9 +2615,19 @@ pub mod node {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3, 4, 5, 6];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+                ("dataWordCount", 0),
+                ("discriminantCount", 4),
+                ("discriminantOffset", 5),
+                ("fields", 6),
+                ("isGroup", 3),
+                ("pointerCount", 1),
+                ("preferredListEncoding", 2),
+            ];
             pub const TYPE_ID: u64 = 0x9ea0_b19b_37fb_4435;
         }
     }
@@ -2902,9 +2938,11 @@ pub mod node {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("enumerants", 0)];
             pub const TYPE_ID: u64 = 0xb54a_b336_4333_f598;
         }
     }
@@ -3286,9 +3324,11 @@ pub mod node {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("methods", 0), ("superclasses", 1)];
             pub const TYPE_ID: u64 = 0xe827_53cf_f0c2_218f;
         }
     }
@@ -3647,9 +3687,11 @@ pub mod node {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("type", 0), ("value", 1)];
             pub const TYPE_ID: u64 = 0xb18a_a5ac_7a0d_9420;
         }
     }
@@ -4301,9 +4343,25 @@ pub mod node {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+                ("targetsAnnotation", 12),
+                ("targetsConst", 2),
+                ("targetsEnum", 3),
+                ("targetsEnumerant", 4),
+                ("targetsField", 6),
+                ("targetsFile", 1),
+                ("targetsGroup", 8),
+                ("targetsInterface", 9),
+                ("targetsMethod", 10),
+                ("targetsParam", 11),
+                ("targetsStruct", 5),
+                ("targetsUnion", 7),
+                ("type", 0),
+            ];
             pub const TYPE_ID: u64 = 0xec16_19d4_400a_0290;
         }
     }
@@ -4796,9 +4854,19 @@ pub mod field {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3, 6];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[4, 5];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+            ("annotations", 2),
+            ("codeOrder", 1),
+            ("discriminantValue", 3),
+            ("group", 5),
+            ("name", 0),
+            ("ordinal", 6),
+            ("slot", 4),
+        ];
         pub const TYPE_ID: u64 = 0x9aad_50a4_1f4a_f45f;
     }
     pub enum Which<A0, A1> {
@@ -5232,9 +5300,16 @@ pub mod field {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+                ("defaultValue", 2),
+                ("hadExplicitDefault", 3),
+                ("offset", 0),
+                ("type", 1),
+            ];
             pub const TYPE_ID: u64 = 0xc423_0547_6bb4_746f;
         }
     }
@@ -5503,9 +5578,11 @@ pub mod field {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("typeId", 0)];
             pub const TYPE_ID: u64 = 0xcafc_cddb_68db_1d11;
         }
     }
@@ -5809,9 +5886,11 @@ pub mod field {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("explicit", 1), ("implicit", 0)];
             pub const TYPE_ID: u64 = 0xbb90_d5c2_8787_0be6;
         }
         pub enum Which {
@@ -6198,9 +6277,12 @@ pub mod enumerant {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] =
+            &[("annotations", 2), ("codeOrder", 1), ("name", 0)];
         pub const TYPE_ID: u64 = 0x978a_7ceb_dc54_9a4d;
     }
 }
@@ -6526,9 +6608,11 @@ pub mod superclass {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("brand", 1), ("id", 0)];
         pub const TYPE_ID: u64 = 0xa996_2a9e_d0a4_d7f8;
     }
 }
@@ -7152,9 +7236,20 @@ pub mod method {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3, 4, 5, 6, 7];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+            ("annotations", 4),
+            ("codeOrder", 1),
+            ("implicitParameters", 7),
+            ("name", 0),
+            ("paramBrand", 5),
+            ("paramStructType", 2),
+            ("resultBrand", 6),
+            ("resultStructType", 3),
+        ];
         pub const TYPE_ID: u64 = 0x9500_cce2_3b33_4d80;
     }
 }
@@ -7811,10 +7906,32 @@ pub mod type_ {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+        ];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+            ("anyPointer", 18),
+            ("bool", 1),
+            ("data", 13),
+            ("enum", 15),
+            ("float32", 10),
+            ("float64", 11),
+            ("int16", 3),
+            ("int32", 4),
+            ("int64", 5),
+            ("int8", 2),
+            ("interface", 17),
+            ("list", 14),
+            ("struct", 16),
+            ("text", 12),
+            ("uint16", 7),
+            ("uint32", 8),
+            ("uint64", 9),
+            ("uint8", 6),
+            ("void", 0),
         ];
         pub const TYPE_ID: u64 = 0xd073_78ed_e1f9_cc60;
     }
@@ -8152,9 +8269,11 @@ pub mod type_ {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("elementType", 0)];
             pub const TYPE_ID: u64 = 0x87e7_3925_0a60_ea97;
         }
     }
@@ -8482,9 +8601,11 @@ pub mod type_ {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("brand", 1), ("typeId", 0)];
             pub const TYPE_ID: u64 = 0x9e0e_7871_1a7f_87a9;
         }
     }
@@ -8813,9 +8934,11 @@ pub mod type_ {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("brand", 1), ("typeId", 0)];
             pub const TYPE_ID: u64 = 0xac3a_6f60_ef4c_c6d3;
         }
     }
@@ -9144,9 +9267,11 @@ pub mod type_ {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("brand", 1), ("typeId", 0)];
             pub const TYPE_ID: u64 = 0xed8b_ca69_f7fb_0cbf;
         }
     }
@@ -9464,9 +9589,15 @@ pub mod type_ {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1, 2];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+                ("implicitMethodParameter", 2),
+                ("parameter", 1),
+                ("unconstrained", 0),
+            ];
             pub const TYPE_ID: u64 = 0xc257_3fe8_a23e_49f1;
         }
         pub enum Which<A0, A1, A2> {
@@ -9835,9 +9966,16 @@ pub mod type_ {
                         encoded_node: &ENCODED_NODE,
                         nonunion_members: NONUNION_MEMBERS,
                         members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                        members_by_name: MEMBERS_BY_NAME,
                     };
                 pub static NONUNION_MEMBERS: &[u16] = &[];
                 pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1, 2, 3];
+                pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+                    ("anyKind", 0),
+                    ("capability", 3),
+                    ("list", 2),
+                    ("struct", 1),
+                ];
                 pub const TYPE_ID: u64 = 0x8e3b_5f79_fe59_3656;
             }
             pub enum Which {
@@ -10153,9 +10291,12 @@ pub mod type_ {
                         encoded_node: &ENCODED_NODE,
                         nonunion_members: NONUNION_MEMBERS,
                         members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                        members_by_name: MEMBERS_BY_NAME,
                     };
                 pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
                 pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+                pub static MEMBERS_BY_NAME: &[(&str, u16)] =
+                    &[("parameterIndex", 1), ("scopeId", 0)];
                 pub const TYPE_ID: u64 = 0x9dd1_f724_f461_4a85;
             }
         }
@@ -10437,9 +10578,11 @@ pub mod type_ {
                         encoded_node: &ENCODED_NODE,
                         nonunion_members: NONUNION_MEMBERS,
                         members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                        members_by_name: MEMBERS_BY_NAME,
                     };
                 pub static NONUNION_MEMBERS: &[u16] = &[0];
                 pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+                pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("parameterIndex", 0)];
                 pub const TYPE_ID: u64 = 0xbaef_c912_0c56_e274;
             }
         }
@@ -10751,9 +10894,11 @@ pub mod brand {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("scopes", 0)];
         pub const TYPE_ID: u64 = 0x9034_55f0_6065_422b;
     }
 
@@ -11128,9 +11273,12 @@ pub mod brand {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[1, 2];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] =
+                &[("bind", 1), ("inherit", 2), ("scopeId", 0)];
             pub const TYPE_ID: u64 = 0xabd7_3485_a963_6bc9;
         }
         pub enum Which<A0> {
@@ -11484,9 +11632,11 @@ pub mod brand {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[0, 1];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("type", 1), ("unbound", 0)];
             pub const TYPE_ID: u64 = 0xc863_cd16_969e_e7fc;
         }
         pub enum Which<A0> {
@@ -12303,10 +12453,32 @@ pub mod value {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+        ];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+            ("anyPointer", 18),
+            ("bool", 1),
+            ("data", 13),
+            ("enum", 15),
+            ("float32", 10),
+            ("float64", 11),
+            ("int16", 3),
+            ("int32", 4),
+            ("int64", 5),
+            ("int8", 2),
+            ("interface", 17),
+            ("list", 14),
+            ("struct", 16),
+            ("text", 12),
+            ("uint16", 7),
+            ("uint32", 8),
+            ("uint64", 9),
+            ("uint8", 6),
+            ("void", 0),
         ];
         pub const TYPE_ID: u64 = 0xce23_dcd2_d7b0_0c9b;
     }
@@ -12727,9 +12899,11 @@ pub mod annotation {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("brand", 2), ("id", 0), ("value", 1)];
         pub const TYPE_ID: u64 = 0xf1c8_950d_ab25_7542;
     }
 }
@@ -13176,9 +13350,11 @@ pub mod capnp_version {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("major", 0), ("micro", 2), ("minor", 1)];
         pub const TYPE_ID: u64 = 0xd85d_305b_7d83_9963;
     }
 }
@@ -13701,9 +13877,16 @@ pub mod code_generator_request {
                 encoded_node: &ENCODED_NODE,
                 nonunion_members: NONUNION_MEMBERS,
                 members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                members_by_name: MEMBERS_BY_NAME,
             };
         pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3];
         pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[
+            ("capnpVersion", 2),
+            ("nodes", 0),
+            ("requestedFiles", 1),
+            ("sourceInfo", 3),
+        ];
         pub const TYPE_ID: u64 = 0xbfc5_46f6_210a_d7ce;
     }
 
@@ -14109,9 +14292,12 @@ pub mod code_generator_request {
                     encoded_node: &ENCODED_NODE,
                     nonunion_members: NONUNION_MEMBERS,
                     members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    members_by_name: MEMBERS_BY_NAME,
                 };
             pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
             pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub static MEMBERS_BY_NAME: &[(&str, u16)] =
+                &[("filename", 1), ("id", 0), ("imports", 2)];
             pub const TYPE_ID: u64 = 0xcfea_0eb0_2e81_0062;
         }
 
@@ -14438,9 +14624,11 @@ pub mod code_generator_request {
                         encoded_node: &ENCODED_NODE,
                         nonunion_members: NONUNION_MEMBERS,
                         members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                        members_by_name: MEMBERS_BY_NAME,
                     };
                 pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
                 pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+                pub static MEMBERS_BY_NAME: &[(&str, u16)] = &[("id", 0), ("name", 1)];
                 pub const TYPE_ID: u64 = 0xae50_4193_1223_57e5;
             }
         }

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1854,9 +1854,9 @@ fn generate_members_by_name(
     members_by_name.sort_by_key(|k| k.0);
 
     let mut members_by_name_string: String =
-        "pub static MEMBERS_BY_NAME : &[(&str, u16)] = &[".into();
-    for (i, (name, index)) in members_by_name.iter().enumerate() {
-        members_by_name_string += &format!("(\"{}\", {})", *name, *index);
+        "pub static MEMBERS_BY_NAME : &[u16] = &[".into();
+    for (i, (_, index)) in members_by_name.iter().enumerate() {
+        members_by_name_string += &format!("{}", *index);
         if i + 1 < members_by_name.len() {
             members_by_name_string += ",";
         }

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1847,9 +1847,8 @@ fn generate_members_by_name(
 
     let mut members_by_name = Vec::new();
     for (index, field) in st.get_fields()?.iter().enumerate() {
-        match get_field_name(field) {
-            Ok(name) => members_by_name.push((name, index)),
-            _ => (),
+        if let Ok(name) = get_field_name(field) {
+            members_by_name.push((name, index));
         }
     }
     members_by_name.sort_by_key(|k| k.0);


### PR DESCRIPTION
Following discussion in https://github.com/capnproto/capnproto-rust/issues/455 I added `members_by_name` to `RawStructSchema` which contains a sorted list of tuples with the name of the field and the index of the field. This is used for binary search when finding the field in a capnp schema using the name of the field copying the [C++ binary search algorithm](https://github.com/capnproto/capnproto/blob/537fe97d6ab1962e92e15b8a16f60439a63b90f5/c%2B%2B/src/capnp/schema.c%2B%2B#L458-L481).

I need to test the performance improvement of this change.