### PR TITLE
add generic parameter to SetPointerBuilder

### DIFF
--- a/benchmark/carsales.rs
+++ b/benchmark/carsales.rs
@@ -82,8 +82,8 @@ const MAKES: [&str; 5] = ["Toyota", "GM", "Ford", "Honda", "Tesla"];
 const MODELS: [&str; 6] = ["Camry", "Prius", "Volt", "Accord", "Leaf", "Model S"];
 
 pub fn random_car(rng: &mut FastRand, mut car: car::Builder) {
-    car.set_make(MAKES[rng.next_less_than(MAKES.len() as u32) as usize].into());
-    car.set_model(MODELS[rng.next_less_than(MODELS.len() as u32) as usize].into());
+    car.set_make(MAKES[rng.next_less_than(MAKES.len() as u32) as usize]);
+    car.set_model(MODELS[rng.next_less_than(MODELS.len() as u32) as usize]);
 
     car.set_color(
         (rng.next_less_than(Color::Silver as u32 + 1) as u16)

--- a/benchmark/catrank.rs
+++ b/benchmark/catrank.rs
@@ -84,7 +84,7 @@ impl crate::TestCase for CatRank {
                 snippet.push_str(WORDS[rng.next_less_than(WORDS.len() as u32) as usize]);
             }
 
-            result.set_snippet(snippet[..].into());
+            result.set_snippet(&snippet[..]);
         }
 
         good_count

--- a/capnp-futures/test/test.rs
+++ b/capnp-futures/test/test.rs
@@ -35,32 +35,32 @@ mod tests {
         {
             let mut alice = people.reborrow().get(0);
             alice.set_id(123);
-            alice.set_name("Alice".into());
-            alice.set_email("alice@example.com".into());
+            alice.set_name("Alice");
+            alice.set_email("alice@example.com");
             {
                 let mut alice_phones = alice.reborrow().init_phones(1);
-                alice_phones.reborrow().get(0).set_number("555-1212".into());
+                alice_phones.reborrow().get(0).set_number("555-1212");
                 alice_phones
                     .reborrow()
                     .get(0)
                     .set_type(person::phone_number::Type::Mobile);
             }
-            alice.get_employment().set_school("MIT".into());
+            alice.get_employment().set_school("MIT");
         }
 
         {
             let mut bob = people.get(1);
             bob.set_id(456);
-            bob.set_name("Bob".into());
-            bob.set_email("bob@example.com".into());
+            bob.set_name("Bob");
+            bob.set_email("bob@example.com");
             {
                 let mut bob_phones = bob.reborrow().init_phones(2);
-                bob_phones.reborrow().get(0).set_number("555-4567".into());
+                bob_phones.reborrow().get(0).set_number("555-4567");
                 bob_phones
                     .reborrow()
                     .get(0)
                     .set_type(person::phone_number::Type::Home);
-                bob_phones.reborrow().get(1).set_number("555-7654".into());
+                bob_phones.reborrow().get(1).set_number("555-7654");
                 bob_phones
                     .reborrow()
                     .get(1)

--- a/capnp-rpc/examples/hello-world/client.rs
+++ b/capnp-rpc/examples/hello-world/client.rs
@@ -58,7 +58,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             tokio::task::spawn_local(rpc_system);
 
             let mut request = hello_world.say_hello_request();
-            request.get().init_request().set_name(msg[..].into());
+            request.get().init_request().set_name(&msg[..]);
 
             let reply = request.send().promise.await?;
 

--- a/capnp-rpc/examples/hello-world/server.rs
+++ b/capnp-rpc/examples/hello-world/server.rs
@@ -39,7 +39,7 @@ impl hello_world::Server for HelloWorldImpl {
         let name = pry!(pry!(request.get_name()).to_str());
         let message = format!("Hello, {name}!");
 
-        results.get().init_reply().set_message(message[..].into());
+        results.get().init_reply().set_message(&message[..]);
 
         Promise::ok(())
     }

--- a/capnp-rpc/examples/pubsub/server.rs
+++ b/capnp-rpc/examples/pubsub/server.rs
@@ -167,8 +167,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             subscriber.requests_in_flight += 1;
                             let mut request = subscriber.client.push_message_request();
                             request.get().set_message(
-                                format!("system time is: {:?}", ::std::time::SystemTime::now())[..]
-                                    .into(),
+                                &format!("system time is: {:?}", ::std::time::SystemTime::now())[..],
                             )?;
                             let subscribers2 = subscribers1.clone();
                             tokio::task::spawn_local(request.send().promise.map(

--- a/capnp-rpc/src/lib.rs
+++ b/capnp-rpc/src/lib.rs
@@ -450,10 +450,10 @@ where
         root.get_as()
     }
 
-    pub fn set_root<From>(&mut self, value: From) -> ::capnp::Result<()>
-    where
-        From: ::capnp::traits::SetPointerBuilder,
-    {
+    pub fn set_root<From: ::capnp::traits::SetPointerBuilder<impl ::capnp::traits::Owned>>(
+        &mut self,
+        value: From,
+    ) -> ::capnp::Result<()> {
         use capnp::traits::ImbueMut;
         let mut root: ::capnp::any_pointer::Builder = self.builder.get_root()?;
         root.imbue_mut(&mut self.cap_table);

--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -355,7 +355,7 @@ fn to_pipeline_ops(
 }
 
 fn from_error(error: &Error, mut builder: exception::Builder) {
-    builder.set_reason(error.to_string()[..].into());
+    builder.set_reason(&error.to_string());
     let typ = match error.kind {
         ::capnp::ErrorKind::Failed => exception::Type::Failed,
         ::capnp::ErrorKind::Overloaded => exception::Type::Overloaded,

--- a/capnp-rpc/src/rpc_capnp.rs
+++ b/capnp-rpc/src/rpc_capnp.rs
@@ -350,7 +350,7 @@ pub mod message {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -1285,7 +1285,7 @@ pub mod bootstrap {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -1633,7 +1633,7 @@ pub mod call {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -2122,7 +2122,7 @@ pub mod call {
             }
         }
 
-        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -2522,7 +2522,7 @@ pub mod return_ {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -3049,7 +3049,7 @@ pub mod finish {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -3383,7 +3383,7 @@ pub mod resolve {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -3772,7 +3772,7 @@ pub mod release {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -4081,7 +4081,7 @@ pub mod disembargo {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -4418,7 +4418,7 @@ pub mod disembargo {
             }
         }
 
-        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -4795,7 +4795,7 @@ pub mod provide {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -5161,7 +5161,7 @@ pub mod accept {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -5513,7 +5513,7 @@ pub mod join {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -5883,7 +5883,7 @@ pub mod message_target {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -6235,7 +6235,7 @@ pub mod payload {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -6289,7 +6289,7 @@ pub mod payload {
         #[inline]
         pub fn set_cap_table(
             &mut self,
-            value: ::capnp::struct_list::Reader<'a, crate::rpc_capnp::cap_descriptor::Owned>,
+            value: ::capnp::struct_list::Reader<'_, crate::rpc_capnp::cap_descriptor::Owned>,
         ) -> ::capnp::Result<()> {
             ::capnp::traits::SetPointerBuilder::set_pointer_builder(
                 self.builder.reborrow().get_pointer_field(1),
@@ -6619,7 +6619,7 @@ pub mod cap_descriptor {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -7123,7 +7123,7 @@ pub mod promised_answer {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -7171,7 +7171,7 @@ pub mod promised_answer {
         #[inline]
         pub fn set_transform(
             &mut self,
-            value: ::capnp::struct_list::Reader<'a, crate::rpc_capnp::promised_answer::op::Owned>,
+            value: ::capnp::struct_list::Reader<'_, crate::rpc_capnp::promised_answer::op::Owned>,
         ) -> ::capnp::Result<()> {
             ::capnp::traits::SetPointerBuilder::set_pointer_builder(
                 self.builder.reborrow().get_pointer_field(0),
@@ -7475,7 +7475,7 @@ pub mod promised_answer {
             }
         }
 
-        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -7792,7 +7792,7 @@ pub mod third_party_cap_descriptor {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -8134,7 +8134,7 @@ pub mod exception {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -8168,8 +8168,15 @@ pub mod exception {
             )
         }
         #[inline]
-        pub fn set_reason(&mut self, value: ::capnp::text::Reader<'_>) {
-            self.builder.reborrow().get_pointer_field(0).set_text(value);
+        pub fn set_reason<_T: ::capnp::traits::SetPointerBuilder<::capnp::text::Owned>>(
+            &mut self,
+            value: _T,
+        ) {
+            let _ = ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.reborrow().get_pointer_field(0),
+                value,
+                false,
+            );
         }
         #[inline]
         pub fn init_reason(self, size: u32) -> ::capnp::text::Builder<'a> {
@@ -8214,8 +8221,15 @@ pub mod exception {
             )
         }
         #[inline]
-        pub fn set_trace(&mut self, value: ::capnp::text::Reader<'_>) {
-            self.builder.reborrow().get_pointer_field(1).set_text(value);
+        pub fn set_trace<_T: ::capnp::traits::SetPointerBuilder<::capnp::text::Owned>>(
+            &mut self,
+            value: _T,
+        ) {
+            let _ = ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.reborrow().get_pointer_field(1),
+                value,
+                false,
+            );
         }
         #[inline]
         pub fn init_trace(self, size: u32) -> ::capnp::text::Builder<'a> {

--- a/capnp-rpc/src/rpc_twoparty_capnp.rs
+++ b/capnp-rpc/src/rpc_twoparty_capnp.rs
@@ -252,7 +252,7 @@ pub mod vat_id {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -531,7 +531,7 @@ pub mod provision_id {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -801,7 +801,7 @@ pub mod recipient_id {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -1044,7 +1044,7 @@ pub mod third_party_cap_id {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -1300,7 +1300,7 @@ pub mod join_key_part {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -1635,7 +1635,7 @@ pub mod join_result {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
             value: Self,

--- a/capnp-rpc/test/impls.rs
+++ b/capnp-rpc/test/impls.rs
@@ -148,7 +148,7 @@ impl test_interface::Server for TestInterface {
         }
         {
             let mut results = results.get();
-            results.set_x("foo".into());
+            results.set_x("foo");
         }
         Promise::ok(())
     }
@@ -190,7 +190,7 @@ impl test_interface::Server for TestExtends {
         }
         {
             let mut results = results.get();
-            results.set_x("bar".into());
+            results.set_x("bar");
         }
         Promise::ok(())
     }
@@ -259,7 +259,7 @@ impl test_pipeline::Server for TestPipeline {
                 return Err(Error::failed("expected x to equal 'foo'".to_string()));
             }
 
-            results.get().set_s("bar".into());
+            results.get().set_s("bar");
 
             // TODO implement better casting
             results
@@ -352,7 +352,7 @@ impl test_more_stuff::Server for TestMoreStuff {
             if response?.get()?.get_x()? != "foo" {
                 return Err(Error::failed("expected x to equal 'foo'".to_string()));
             }
-            results.get().set_s("bar".into());
+            results.get().set_s("bar");
             Ok(())
         }))
     }
@@ -372,7 +372,7 @@ impl test_more_stuff::Server for TestMoreStuff {
                 if response?.get()?.get_x()? != "foo" {
                     return Err(Error::failed("expected x to equal 'foo'".to_string()));
                 }
-                results.get().set_s("bar".into());
+                results.get().set_s("bar");
                 Ok(())
             })
         }))
@@ -438,7 +438,7 @@ impl test_more_stuff::Server for TestMoreStuff {
                     if response?.get()?.get_x()? != "foo" {
                         Err(Error::failed("expected X to equal 'foo'".to_string()))
                     } else {
-                        results.get().set_s("bar".into());
+                        results.get().set_s("bar");
                         Ok(())
                     }
                 }))

--- a/capnp-rpc/test/reconnect_test.rs
+++ b/capnp-rpc/test/reconnect_test.rs
@@ -76,7 +76,7 @@ impl test_interface::Server for TestInterfaceImpl {
         );
         {
             let mut results = results.get();
-            results.set_x(s[..].into());
+            results.set_x(&s[..]);
         }
         if let Some(fut) = self.inner.borrow().block.as_ref() {
             Promise::from_future(fut.clone())

--- a/capnp-rpc/test/test_util.rs
+++ b/capnp-rpc/test/test_util.rs
@@ -34,7 +34,7 @@ pub fn init_test_message(mut builder: test_all_types::Builder) {
     builder.set_u_int64_field(12345678901234567890);
     builder.set_float32_field(1234.5);
     builder.set_float64_field(-123e45);
-    builder.set_text_field("foo".into());
+    builder.set_text_field("foo");
     builder.set_data_field(b"bar");
     {
         let mut sub_builder = builder.reborrow().init_struct_field();
@@ -50,14 +50,14 @@ pub fn init_test_message(mut builder: test_all_types::Builder) {
         sub_builder.set_u_int64_field(345678901234567890);
         sub_builder.set_float32_field(-1.25e-10);
         sub_builder.set_float64_field(345f64);
-        sub_builder.set_text_field("baz".into());
+        sub_builder.set_text_field("baz");
         sub_builder.set_data_field(b"qux");
         {
             let mut sub_sub_builder = sub_builder.reborrow().init_struct_field();
-            sub_sub_builder.set_text_field("nested".into());
+            sub_sub_builder.set_text_field("nested");
             sub_sub_builder
                 .init_struct_field()
-                .set_text_field("really nested".into());
+                .set_text_field("really nested");
         }
         sub_builder.set_enum_field(TestEnum::Baz);
 
@@ -105,15 +105,15 @@ pub fn init_test_message(mut builder: test_all_types::Builder) {
             struct_list
                 .reborrow()
                 .get(0)
-                .set_text_field("x structlist 1".into());
+                .set_text_field("x structlist 1");
             struct_list
                 .reborrow()
                 .get(1)
-                .set_text_field("x structlist 2".into());
+                .set_text_field("x structlist 2");
             struct_list
                 .reborrow()
                 .get(2)
-                .set_text_field("x structlist 3".into());
+                .set_text_field("x structlist 3");
         }
 
         let mut enum_list = sub_builder.reborrow().init_enum_list(3);

--- a/capnp/src/any_pointer.rs
+++ b/capnp/src/any_pointer.rs
@@ -165,9 +165,9 @@ impl<'a> Builder<'a> {
         FromPointerBuilder::init_pointer(self.builder, size)
     }
 
-    pub fn set_as<From: SetPointerBuilder<impl crate::traits::Owned>>(
+    pub fn set_as<T: crate::traits::Owned>(
         &mut self,
-        value: From,
+        value: impl SetPointerBuilder<T>,
     ) -> Result<()> {
         SetPointerBuilder::set_pointer_builder(self.builder.reborrow(), value, false)
     }

--- a/capnp/src/any_pointer.rs
+++ b/capnp/src/any_pointer.rs
@@ -111,7 +111,7 @@ impl<'a> FromPointerReader<'a> for Reader<'a> {
     }
 }
 
-impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
     fn set_pointer_builder<'b>(
         mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: Reader<'a>,
@@ -165,7 +165,10 @@ impl<'a> Builder<'a> {
         FromPointerBuilder::init_pointer(self.builder, size)
     }
 
-    pub fn set_as<From: SetPointerBuilder>(&mut self, value: From) -> Result<()> {
+    pub fn set_as<From: SetPointerBuilder<impl crate::traits::Owned>>(
+        &mut self,
+        value: From,
+    ) -> Result<()> {
         SetPointerBuilder::set_pointer_builder(self.builder.reborrow(), value, false)
     }
 

--- a/capnp/src/any_pointer_list.rs
+++ b/capnp/src/any_pointer_list.rs
@@ -169,7 +169,7 @@ impl<'a> FromPointerBuilder<'a> for Builder<'a> {
     }
 }
 
-impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
     fn set_pointer_builder<'b>(
         mut pointer: PointerBuilder<'b>,
         value: Reader<'a>,

--- a/capnp/src/capability_list.rs
+++ b/capnp/src/capability_list.rs
@@ -253,7 +253,7 @@ where
     }
 }
 
-impl<'a, T> crate::traits::SetPointerBuilder for Reader<'a, T>
+impl<'a, T> crate::traits::SetPointerBuilder<Owned<T>> for Reader<'a, T>
 where
     T: FromClientHook,
 {

--- a/capnp/src/data.rs
+++ b/capnp/src/data.rs
@@ -71,7 +71,7 @@ impl<'a> crate::traits::FromPointerBuilder<'a> for Builder<'a> {
     }
 }
 
-impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
     fn set_pointer_builder<'b>(
         mut pointer: PointerBuilder<'b>,
         value: Reader<'a>,

--- a/capnp/src/data_list.rs
+++ b/capnp/src/data_list.rs
@@ -185,7 +185,7 @@ impl<'a> Builder<'a> {
     }
 }
 
-impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
     fn set_pointer_builder<'b>(
         mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: Reader<'a>,

--- a/capnp/src/dynamic_list.rs
+++ b/capnp/src/dynamic_list.rs
@@ -397,7 +397,7 @@ impl<'a> Builder<'a> {
     }
 }
 
-impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+impl<'a> crate::traits::SetPointerBuilder<crate::any_pointer::Owned> for Reader<'a> {
     fn set_pointer_builder<'b>(
         mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: Reader<'a>,

--- a/capnp/src/dynamic_struct.rs
+++ b/capnp/src/dynamic_struct.rs
@@ -773,7 +773,7 @@ impl<'a> Builder<'a> {
     }
 }
 
-impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+impl<'a> crate::traits::SetPointerBuilder<crate::any_pointer::Owned> for Reader<'a> {
     fn set_pointer_builder<'b>(
         mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: Reader<'a>,

--- a/capnp/src/dynamic_struct.rs
+++ b/capnp/src/dynamic_struct.rs
@@ -526,7 +526,9 @@ impl<'a> Builder<'a> {
                         );
                         match value {
                             dynamic_value::Reader::Text(t) => target.set_as(t),
-                            dynamic_value::Reader::Data(t) => target.set_as(t),
+                            dynamic_value::Reader::Data(t) => {
+                                target.set_as::<crate::data::Owned>(t)
+                            }
                             dynamic_value::Reader::Struct(s) => target.set_as(s),
                             dynamic_value::Reader::List(l) => target.set_as(l),
                             dynamic_value::Reader::Capability(_) => Err(Error::from_kind(

--- a/capnp/src/enum_list.rs
+++ b/capnp/src/enum_list.rs
@@ -195,7 +195,7 @@ impl<'a, T: Into<u16> + TryFrom<u16, Error = NotInSchema>> Builder<'a, T> {
     }
 }
 
-impl<'a, T> crate::traits::SetPointerBuilder for Reader<'a, T> {
+impl<'a, T> crate::traits::SetPointerBuilder<Owned<T>> for Reader<'a, T> {
     fn set_pointer_builder<'b>(
         mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: Reader<'a, T>,

--- a/capnp/src/list_list.rs
+++ b/capnp/src/list_list.rs
@@ -252,7 +252,7 @@ where
     }
 }
 
-impl<'a, T> crate::traits::SetPointerBuilder for Reader<'a, T>
+impl<'a, T> crate::traits::SetPointerBuilder<Owned<T>> for Reader<'a, T>
 where
     T: crate::traits::Owned,
 {

--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -477,7 +477,7 @@ where
     }
 
     /// Sets the root to a deep copy of the given value.
-    pub fn set_root<From: SetPointerBuilder<impl Owned>>(&mut self, value: From) -> Result<()> {
+    pub fn set_root<T: Owned>(&mut self, value: impl SetPointerBuilder<T>) -> Result<()> {
         let mut root = self.get_root_internal();
         root.set_as(value)
     }
@@ -485,10 +485,7 @@ where
     /// Sets the root to a canonicalized version of `value`. If this was the first action taken
     /// on this `Builder`, then a subsequent call to `get_segments_for_output()` should return
     /// a single segment, containing the full canonicalized message.
-    pub fn set_root_canonical<From: SetPointerBuilder<impl Owned>>(
-        &mut self,
-        value: From,
-    ) -> Result<()> {
+    pub fn set_root_canonical<T: Owned>(&mut self, value: impl SetPointerBuilder<T>) -> Result<()> {
         if self.arena.is_empty() {
             self.arena
                 .allocate_segment(1)

--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -477,7 +477,7 @@ where
     }
 
     /// Sets the root to a deep copy of the given value.
-    pub fn set_root<From: SetPointerBuilder>(&mut self, value: From) -> Result<()> {
+    pub fn set_root<From: SetPointerBuilder<impl Owned>>(&mut self, value: From) -> Result<()> {
         let mut root = self.get_root_internal();
         root.set_as(value)
     }
@@ -485,7 +485,10 @@ where
     /// Sets the root to a canonicalized version of `value`. If this was the first action taken
     /// on this `Builder`, then a subsequent call to `get_segments_for_output()` should return
     /// a single segment, containing the full canonicalized message.
-    pub fn set_root_canonical<From: SetPointerBuilder>(&mut self, value: From) -> Result<()> {
+    pub fn set_root_canonical<From: SetPointerBuilder<impl Owned>>(
+        &mut self,
+        value: From,
+    ) -> Result<()> {
         if self.arena.is_empty() {
             self.arena
                 .allocate_segment(1)

--- a/capnp/src/primitive_list.rs
+++ b/capnp/src/primitive_list.rs
@@ -236,7 +236,7 @@ impl<'a, T: PrimitiveElement> Builder<'a, T> {
     }
 }
 
-impl<'a, T> crate::traits::SetPointerBuilder for Reader<'a, T>
+impl<'a, T> crate::traits::SetPointerBuilder<Owned<T>> for Reader<'a, T>
 where
     T: PrimitiveElement,
 {

--- a/capnp/src/primitive_list.rs
+++ b/capnp/src/primitive_list.rs
@@ -240,12 +240,46 @@ impl<'a, T> crate::traits::SetPointerBuilder<Owned<T>> for Reader<'a, T>
 where
     T: PrimitiveElement,
 {
+    #[inline]
     fn set_pointer_builder<'b>(
         mut pointer: PointerBuilder<'b>,
         value: Reader<'a, T>,
         canonicalize: bool,
     ) -> Result<()> {
         pointer.set_list(&value.reader, canonicalize)
+    }
+}
+
+impl<'a, T> crate::traits::SetPointerBuilder<Owned<T>> for &'a [T]
+where
+    T: PrimitiveElement + Copy,
+{
+    #[inline]
+    fn set_pointer_builder<'b>(
+        pointer: PointerBuilder<'b>,
+        value: &'a [T],
+        _canonicalize: bool,
+    ) -> Result<()> {
+        let builder =
+            pointer.init_list(<T as PrimitiveElement>::element_size(), value.len() as u32);
+        for (idx, v) in value.iter().enumerate() {
+            PrimitiveElement::set(&builder, idx as u32, *v)
+        }
+        Ok(())
+    }
+}
+
+impl<'a, T, const N: usize> crate::traits::SetPointerBuilder<Owned<T>> for &'a [T; N]
+where
+    T: PrimitiveElement + Copy,
+{
+    #[inline]
+    fn set_pointer_builder<'b>(
+        pointer: PointerBuilder<'b>,
+        value: &'a [T; N],
+        canonicalize: bool,
+    ) -> Result<()> {
+        crate::traits::SetPointerBuilder::set_pointer_builder(pointer, &value[..], canonicalize)
     }
 }
 

--- a/capnp/src/schema_capnp.rs
+++ b/capnp/src/schema_capnp.rs
@@ -245,7 +245,7 @@ pub mod node {
         }
     }
 
-    impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: crate::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -287,8 +287,15 @@ pub mod node {
             )
         }
         #[inline]
-        pub fn set_display_name(&mut self, value: crate::text::Reader<'_>) {
-            self.builder.reborrow().get_pointer_field(0).set_text(value);
+        pub fn set_display_name<_T: crate::traits::SetPointerBuilder<crate::text::Owned>>(
+            &mut self,
+            value: _T,
+        ) {
+            let _ = crate::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.reborrow().get_pointer_field(0),
+                value,
+                false,
+            );
         }
         #[inline]
         pub fn init_display_name(self, size: u32) -> crate::text::Builder<'a> {
@@ -960,7 +967,7 @@ pub mod node {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -994,8 +1001,15 @@ pub mod node {
                 )
             }
             #[inline]
-            pub fn set_name(&mut self, value: crate::text::Reader<'_>) {
-                self.builder.reborrow().get_pointer_field(0).set_text(value);
+            pub fn set_name<_T: crate::traits::SetPointerBuilder<crate::text::Owned>>(
+                &mut self,
+                value: _T,
+            ) {
+                let _ = crate::traits::SetPointerBuilder::set_pointer_builder(
+                    self.builder.reborrow().get_pointer_field(0),
+                    value,
+                    false,
+                );
             }
             #[inline]
             pub fn init_name(self, size: u32) -> crate::text::Builder<'a> {
@@ -1256,7 +1270,7 @@ pub mod node {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -1290,8 +1304,15 @@ pub mod node {
                 )
             }
             #[inline]
-            pub fn set_name(&mut self, value: crate::text::Reader<'_>) {
-                self.builder.reborrow().get_pointer_field(0).set_text(value);
+            pub fn set_name<_T: crate::traits::SetPointerBuilder<crate::text::Owned>>(
+                &mut self,
+                value: _T,
+            ) {
+                let _ = crate::traits::SetPointerBuilder::set_pointer_builder(
+                    self.builder.reborrow().get_pointer_field(0),
+                    value,
+                    false,
+                );
             }
             #[inline]
             pub fn init_name(self, size: u32) -> crate::text::Builder<'a> {
@@ -1594,7 +1615,7 @@ pub mod node {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -1636,8 +1657,15 @@ pub mod node {
                 )
             }
             #[inline]
-            pub fn set_doc_comment(&mut self, value: crate::text::Reader<'_>) {
-                self.builder.reborrow().get_pointer_field(0).set_text(value);
+            pub fn set_doc_comment<_T: crate::traits::SetPointerBuilder<crate::text::Owned>>(
+                &mut self,
+                value: _T,
+            ) {
+                let _ = crate::traits::SetPointerBuilder::set_pointer_builder(
+                    self.builder.reborrow().get_pointer_field(0),
+                    value,
+                    false,
+                );
             }
             #[inline]
             pub fn init_doc_comment(self, size: u32) -> crate::text::Builder<'a> {
@@ -1989,7 +2017,7 @@ pub mod node {
                 }
             }
 
-            impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+            impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
                 fn set_pointer_builder(
                     mut pointer: crate::private::layout::PointerBuilder<'_>,
                     value: Self,
@@ -2023,8 +2051,15 @@ pub mod node {
                     )
                 }
                 #[inline]
-                pub fn set_doc_comment(&mut self, value: crate::text::Reader<'_>) {
-                    self.builder.reborrow().get_pointer_field(0).set_text(value);
+                pub fn set_doc_comment<_T: crate::traits::SetPointerBuilder<crate::text::Owned>>(
+                    &mut self,
+                    value: _T,
+                ) {
+                    let _ = crate::traits::SetPointerBuilder::set_pointer_builder(
+                        self.builder.reborrow().get_pointer_field(0),
+                        value,
+                        false,
+                    );
                 }
                 #[inline]
                 pub fn init_doc_comment(self, size: u32) -> crate::text::Builder<'a> {
@@ -2314,7 +2349,7 @@ pub mod node {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -2783,7 +2818,7 @@ pub mod node {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -3112,7 +3147,7 @@ pub mod node {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -3492,7 +3527,7 @@ pub mod node {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -3892,7 +3927,7 @@ pub mod node {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -4534,7 +4569,7 @@ pub mod field {
         }
     }
 
-    impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: crate::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -4568,8 +4603,15 @@ pub mod field {
             )
         }
         #[inline]
-        pub fn set_name(&mut self, value: crate::text::Reader<'_>) {
-            self.builder.reborrow().get_pointer_field(0).set_text(value);
+        pub fn set_name<_T: crate::traits::SetPointerBuilder<crate::text::Owned>>(
+            &mut self,
+            value: _T,
+        ) {
+            let _ = crate::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.reborrow().get_pointer_field(0),
+                value,
+                false,
+            );
         }
         #[inline]
         pub fn init_name(self, size: u32) -> crate::text::Builder<'a> {
@@ -5030,7 +5072,7 @@ pub mod field {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -5428,7 +5470,7 @@ pub mod field {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -5707,7 +5749,7 @@ pub mod field {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -6038,7 +6080,7 @@ pub mod enumerant {
         }
     }
 
-    impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: crate::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -6072,8 +6114,15 @@ pub mod enumerant {
             )
         }
         #[inline]
-        pub fn set_name(&mut self, value: crate::text::Reader<'_>) {
-            self.builder.reborrow().get_pointer_field(0).set_text(value);
+        pub fn set_name<_T: crate::traits::SetPointerBuilder<crate::text::Owned>>(
+            &mut self,
+            value: _T,
+        ) {
+            let _ = crate::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.reborrow().get_pointer_field(0),
+                value,
+                false,
+            );
         }
         #[inline]
         pub fn init_name(self, size: u32) -> crate::text::Builder<'a> {
@@ -6408,7 +6457,7 @@ pub mod superclass {
         }
     }
 
-    impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: crate::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -6797,7 +6846,7 @@ pub mod method {
         }
     }
 
-    impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: crate::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -6831,8 +6880,15 @@ pub mod method {
             )
         }
         #[inline]
-        pub fn set_name(&mut self, value: crate::text::Reader<'_>) {
-            self.builder.reborrow().get_pointer_field(0).set_text(value);
+        pub fn set_name<_T: crate::traits::SetPointerBuilder<crate::text::Owned>>(
+            &mut self,
+            value: _T,
+        ) {
+            let _ = crate::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.reborrow().get_pointer_field(0),
+                value,
+                false,
+            );
         }
         #[inline]
         pub fn init_name(self, size: u32) -> crate::text::Builder<'a> {
@@ -7381,7 +7437,7 @@ pub mod type_ {
         }
     }
 
-    impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: crate::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -8064,7 +8120,7 @@ pub mod type_ {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -8375,7 +8431,7 @@ pub mod type_ {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -8707,7 +8763,7 @@ pub mod type_ {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -9040,7 +9096,7 @@ pub mod type_ {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -9369,7 +9425,7 @@ pub mod type_ {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -9715,7 +9771,7 @@ pub mod type_ {
                 }
             }
 
-            impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+            impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
                 fn set_pointer_builder(
                     mut pointer: crate::private::layout::PointerBuilder<'_>,
                     value: Self,
@@ -10078,7 +10134,7 @@ pub mod type_ {
                 }
             }
 
-            impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+            impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
                 fn set_pointer_builder(
                     mut pointer: crate::private::layout::PointerBuilder<'_>,
                     value: Self,
@@ -10386,7 +10442,7 @@ pub mod type_ {
                 }
             }
 
-            impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+            impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
                 fn set_pointer_builder(
                     mut pointer: crate::private::layout::PointerBuilder<'_>,
                     value: Self,
@@ -10672,7 +10728,7 @@ pub mod brand {
         }
     }
 
-    impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: crate::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -11000,7 +11056,7 @@ pub mod brand {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -11390,7 +11446,7 @@ pub mod brand {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -11797,7 +11853,7 @@ pub mod value {
         }
     }
 
-    impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: crate::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -11883,9 +11939,16 @@ pub mod value {
             self.builder.set_data_field::<f64>(1, value);
         }
         #[inline]
-        pub fn set_text(&mut self, value: crate::text::Reader<'_>) {
+        pub fn set_text<_T: crate::traits::SetPointerBuilder<crate::text::Owned>>(
+            &mut self,
+            value: _T,
+        ) {
             self.builder.set_data_field::<u16>(0, 12);
-            self.builder.reborrow().get_pointer_field(0).set_text(value);
+            let _ = crate::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.reborrow().get_pointer_field(0),
+                value,
+                false,
+            );
         }
         #[inline]
         pub fn init_text(self, size: u32) -> crate::text::Builder<'a> {
@@ -12595,7 +12658,7 @@ pub mod annotation {
         }
     }
 
-    impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: crate::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -13094,7 +13157,7 @@ pub mod capnp_version {
         }
     }
 
-    impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: crate::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -13469,7 +13532,7 @@ pub mod code_generator_request {
         }
     }
 
-    impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+    impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
         fn set_pointer_builder(
             mut pointer: crate::private::layout::PointerBuilder<'_>,
             value: Self,
@@ -13971,7 +14034,7 @@ pub mod code_generator_request {
             }
         }
 
-        impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+        impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
             fn set_pointer_builder(
                 mut pointer: crate::private::layout::PointerBuilder<'_>,
                 value: Self,
@@ -14013,8 +14076,15 @@ pub mod code_generator_request {
                 )
             }
             #[inline]
-            pub fn set_filename(&mut self, value: crate::text::Reader<'_>) {
-                self.builder.reborrow().get_pointer_field(0).set_text(value);
+            pub fn set_filename<_T: crate::traits::SetPointerBuilder<crate::text::Owned>>(
+                &mut self,
+                value: _T,
+            ) {
+                let _ = crate::traits::SetPointerBuilder::set_pointer_builder(
+                    self.builder.reborrow().get_pointer_field(0),
+                    value,
+                    false,
+                );
             }
             #[inline]
             pub fn init_filename(self, size: u32) -> crate::text::Builder<'a> {
@@ -14372,7 +14442,7 @@ pub mod code_generator_request {
                 }
             }
 
-            impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+            impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
                 fn set_pointer_builder(
                     mut pointer: crate::private::layout::PointerBuilder<'_>,
                     value: Self,
@@ -14414,8 +14484,15 @@ pub mod code_generator_request {
                     )
                 }
                 #[inline]
-                pub fn set_name(&mut self, value: crate::text::Reader<'_>) {
-                    self.builder.reborrow().get_pointer_field(0).set_text(value);
+                pub fn set_name<_T: crate::traits::SetPointerBuilder<crate::text::Owned>>(
+                    &mut self,
+                    value: _T,
+                ) {
+                    let _ = crate::traits::SetPointerBuilder::set_pointer_builder(
+                        self.builder.reborrow().get_pointer_field(0),
+                        value,
+                        false,
+                    );
                 }
                 #[inline]
                 pub fn init_name(self, size: u32) -> crate::text::Builder<'a> {

--- a/capnp/src/struct_list.rs
+++ b/capnp/src/struct_list.rs
@@ -256,7 +256,7 @@ where
     }
 }
 
-impl<'a, T> crate::traits::SetPointerBuilder for Reader<'a, T>
+impl<'a, T> crate::traits::SetPointerBuilder<Owned<T>> for Reader<'a, T>
 where
     T: crate::traits::OwnedStruct,
 {

--- a/capnp/src/text.rs
+++ b/capnp/src/text.rs
@@ -306,7 +306,7 @@ impl<'a> crate::traits::FromPointerBuilder<'a> for Builder<'a> {
     }
 }
 
-impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
     fn set_pointer_builder<'b>(
         mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: Reader<'a>,
@@ -317,15 +317,33 @@ impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
     }
 }
 
-// Extra impl to make any_pointer::Builder::set_as() and similar methods work
-// more smoothly.
-impl<'a> crate::traits::SetPointerBuilder for &'a str {
+// Text field setters are generated with a signature like
+// ```
+//   set_foo<T : SetPointerBuilder<text::Owned>>(&mut self, value: T)
+// ```
+// Combined with the below impls of `SetPointerBuilder`, this
+// allows text fields to be conveniently set from values
+// of type `&str`.
+
+impl<'a> crate::traits::SetPointerBuilder<Owned> for &'a str {
     fn set_pointer_builder<'b>(
         mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: &'a str,
         _canonicalize: bool,
     ) -> Result<()> {
         pointer.set_text(value.into());
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> crate::traits::SetPointerBuilder<Owned> for &'a alloc::string::String {
+    fn set_pointer_builder<'b>(
+        mut pointer: crate::private::layout::PointerBuilder<'b>,
+        value: &'a alloc::string::String,
+        _canonicalize: bool,
+    ) -> Result<()> {
+        pointer.set_text(value.as_str().into());
         Ok(())
     }
 }

--- a/capnp/src/text.rs
+++ b/capnp/src/text.rs
@@ -307,6 +307,7 @@ impl<'a> crate::traits::FromPointerBuilder<'a> for Builder<'a> {
 }
 
 impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
+    #[inline]
     fn set_pointer_builder<'b>(
         mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: Reader<'a>,
@@ -326,6 +327,7 @@ impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
 // of type `&str`.
 
 impl<'a> crate::traits::SetPointerBuilder<Owned> for &'a str {
+    #[inline]
     fn set_pointer_builder<'b>(
         mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: &'a str,
@@ -338,6 +340,7 @@ impl<'a> crate::traits::SetPointerBuilder<Owned> for &'a str {
 
 #[cfg(feature = "alloc")]
 impl<'a> crate::traits::SetPointerBuilder<Owned> for &'a alloc::string::String {
+    #[inline]
     fn set_pointer_builder<'b>(
         mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: &'a alloc::string::String,

--- a/capnp/src/text_list.rs
+++ b/capnp/src/text_list.rs
@@ -194,6 +194,38 @@ impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
     }
 }
 
+impl<'a, T: AsRef<str>> crate::traits::SetPointerBuilder<Owned> for &'a [T] {
+    #[inline]
+    fn set_pointer_builder<'b>(
+        pointer: PointerBuilder<'b>,
+        value: &'a [T],
+        _canonicalize: bool,
+    ) -> Result<()> {
+        let mut builder = pointer.init_list(
+            crate::private::layout::ElementSize::Pointer,
+            value.len() as u32,
+        );
+        for (idx, v) in value.iter().enumerate() {
+            builder
+                .reborrow()
+                .get_pointer_element(idx as u32)
+                .set_text(v.as_ref().into());
+        }
+        Ok(())
+    }
+}
+
+impl<'a, T: AsRef<str>, const N: usize> crate::traits::SetPointerBuilder<Owned> for &'a [T; N] {
+    #[inline]
+    fn set_pointer_builder<'b>(
+        pointer: PointerBuilder<'b>,
+        value: &'a [T; N],
+        canonicalize: bool,
+    ) -> Result<()> {
+        crate::traits::SetPointerBuilder::set_pointer_builder(pointer, &value[..], canonicalize)
+    }
+}
+
 impl<'a> ::core::iter::IntoIterator for Reader<'a> {
     type Item = Result<crate::text::Reader<'a>>;
     type IntoIter = ListIter<Reader<'a>, Self::Item>;

--- a/capnp/src/text_list.rs
+++ b/capnp/src/text_list.rs
@@ -184,7 +184,7 @@ impl<'a> Builder<'a> {
     }
 }
 
-impl<'a> crate::traits::SetPointerBuilder for Reader<'a> {
+impl<'a> crate::traits::SetPointerBuilder<Owned> for Reader<'a> {
     fn set_pointer_builder<'b>(
         mut pointer: crate::private::layout::PointerBuilder<'b>,
         value: Reader<'a>,

--- a/capnp/src/traits.rs
+++ b/capnp/src/traits.rs
@@ -59,12 +59,12 @@ pub trait FromPointerReader<'a>: Sized {
 /// nonetheless as a type parameter, e.g. for a generic container that owns a Cap'n Proto
 /// message of type `T: capnp::traits::Owned`.
 pub trait Owned: crate::introspect::Introspect {
-    type Reader<'a>: FromPointerReader<'a> + SetPointerBuilder;
+    type Reader<'a>: FromPointerReader<'a> + SetPointerBuilder<Self>;
     type Builder<'a>: FromPointerBuilder<'a>;
 }
 
 pub trait OwnedStruct: crate::introspect::Introspect {
-    type Reader<'a>: From<StructReader<'a>> + SetPointerBuilder + IntoInternalStructReader<'a>;
+    type Reader<'a>: From<StructReader<'a>> + SetPointerBuilder<Self> + IntoInternalStructReader<'a>;
     type Builder<'a>: From<StructBuilder<'a>> + HasStructSize;
 }
 
@@ -80,7 +80,7 @@ pub trait FromPointerBuilder<'a>: Sized {
     ) -> Result<Self>;
 }
 
-pub trait SetPointerBuilder {
+pub trait SetPointerBuilder<Receiver: ?Sized> {
     fn set_pointer_builder(
         builder: PointerBuilder<'_>,
         from: Self,

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1219,7 +1219,7 @@ fn generate_setter(
             result.push(indent(setter_interior));
             result.push(line("}"));
         }
-        MaybeReader::Generic(reader_type) => {
+        MaybeReader::Generic(owned_type) => {
             let return_type = if return_result {
                 fmt!(ctx, "-> {capnp}::Result<()>")
             } else {
@@ -1227,7 +1227,7 @@ fn generate_setter(
             };
             result.push(line("#[inline]"));
             result.push(Line(fmt!(ctx,
-                "pub fn set_{styled_name}<_T: {capnp}::traits::SetPointerBuilder<{reader_type}>>(&mut self, {setter_param}: _T) {return_type} {{"
+                "pub fn set_{styled_name}<_T: {capnp}::traits::SetPointerBuilder<{owned_type}>>(&mut self, {setter_param}: _T) {return_type} {{"
             )));
             result.push(indent(setter_interior));
             result.push(line("}"));

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1119,12 +1119,28 @@ fn generate_setter(
                     initter_interior.push(
                         Line(fmt!(ctx,"{capnp}::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field({offset}), size)")));
 
-                    let mr = if et.is_prim()? {
-                        MaybeReader::Generic(reg_field.get_type()?.type_string(ctx, Leaf::Owned)?)
-                    } else {
-                        MaybeReader::Nongeneric(
+                    let mr = match et.which()? {
+                        type_::Void(())
+                        | type_::Bool(())
+                        | type_::Int8(())
+                        | type_::Int16(())
+                        | type_::Int32(())
+                        | type_::Int64(())
+                        | type_::Uint8(())
+                        | type_::Uint16(())
+                        | type_::Uint32(())
+                        | type_::Uint64(())
+                        | type_::Float32(())
+                        | type_::Float64(())
+                        | type_::Text(()) => {
+                            // There are multiple SetPointerBuilder impls.
+                            MaybeReader::Generic(
+                                reg_field.get_type()?.type_string(ctx, Leaf::Owned)?,
+                            )
+                        }
+                        _ => MaybeReader::Nongeneric(
                             reg_field.get_type()?.type_string(ctx, Leaf::Reader("'_"))?,
-                        )
+                        ),
                     };
 
                     (

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1083,8 +1083,9 @@ fn generate_setter(
                     (MaybeReader::Nongeneric(tstr), None)
                 }
                 type_::Text(()) => {
+                    // The text::Reader impl of SetPointerBuilder never fails, so we can unwrap().
                     setter_interior.push(Line(fmt!(ctx,
-                        "let _ = {capnp}::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field({offset}), value, false);"
+                        "{capnp}::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field({offset}), value, false).unwrap()"
                     )));
                     initter_interior.push(Line(format!(
                         "self.builder.get_pointer_field({offset}).init_text(size)"

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -1132,6 +1132,7 @@ fn generate_setter(
                         | type_::Uint64(())
                         | type_::Float32(())
                         | type_::Float64(())
+                        | type_::Enum(_)
                         | type_::Text(()) => {
                             // There are multiple SetPointerBuilder impls.
                             MaybeReader::Generic(

--- a/capnpc/src/pointer_constants.rs
+++ b/capnpc/src/pointer_constants.rs
@@ -30,7 +30,9 @@ pub struct WordArrayDeclarationOptions {
     pub public: bool,
 }
 
-fn word_array_declaration_aux<T: ::capnp::traits::SetPointerBuilder>(
+fn word_array_declaration_aux<
+    T: ::capnp::traits::SetPointerBuilder<impl ::capnp::traits::Owned>,
+>(
     ctx: &GeneratorContext,
     name: &str,
     value: T,

--- a/capnpc/test/dynamic.rs
+++ b/capnpc/test/dynamic.rs
@@ -57,7 +57,7 @@ fn test_unions() {
     let mut message = message::Builder::new_default();
     let mut root: test_union::Builder<'_> = message.init_root();
     root.reborrow().get_union0().set_u0f1s32(1234567);
-    root.reborrow().get_union1().set_u1f1sp("foo".into());
+    root.reborrow().get_union1().set_u1f1sp("foo");
     root.reborrow().get_union2().set_u2f0s1(true);
     root.reborrow()
         .get_union3()
@@ -241,7 +241,7 @@ fn test_stringify() {
     let mut root: test_all_types::Builder<'_> = message.init_root();
     root.set_int8_field(3);
     root.set_enum_field(TestEnum::Bar);
-    root.set_text_field("hello world".into());
+    root.set_text_field("hello world");
     root.set_data_field(&[1, 2, 3, 4, 5, 127, 255]);
     let mut bool_list = root.reborrow().init_bool_list(2);
     bool_list.set(0, false);

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -245,7 +245,7 @@ mod tests {
         let mut test_blob = message.init_root::<test_blob::Builder<'_>>();
 
         assert_eq!(test_blob.has_text_field(), false);
-        test_blob.set_text_field("abcdefghi".into());
+        test_blob.set_text_field("abcdefghi");
         assert_eq!(test_blob.has_text_field(), true);
 
         assert_eq!(test_blob.has_data_field(), false);
@@ -571,7 +571,7 @@ mod tests {
 
             {
                 let mut sub_builder = test_defaults.reborrow().get_struct_field().unwrap();
-                sub_builder.set_text_field("garply".into());
+                sub_builder.set_text_field("garply");
             }
 
             assert_eq!(test_defaults.reborrow().get_bool_field(), false);
@@ -778,7 +778,7 @@ mod tests {
 
         // Check setters
 
-        test_set.set_text("foo".into());
+        test_set.set_text("foo");
         test_set.set_data(&[42]);
         {
             let mut b = test_set.reborrow().init_list(3);
@@ -787,10 +787,7 @@ mod tests {
             b.set(2, 3);
         }
         test_set.reborrow().init_empty_struct();
-        test_set
-            .reborrow()
-            .init_simple_struct()
-            .set_field("buzz".into());
+        test_set.reborrow().init_simple_struct().set_field("buzz");
         {
             let mut b = test_set.reborrow().init_any();
             b.set_as("dyn")?;
@@ -861,7 +858,7 @@ mod tests {
         {
             let branded_field = branded.reborrow().init_branded_field();
             let mut foo = branded_field.init_generic_field();
-            foo.set_text_field("blah".into());
+            foo.set_text_field("blah");
         }
 
         let reader = branded.into_reader();
@@ -885,9 +882,9 @@ mod tests {
         let mut branded = message_for_brand.init_root::<brand_twice::Builder<'_>>();
         {
             let mut baz = branded.reborrow().init_baz_field();
-            baz.set_foo_field("blah".into()).unwrap();
+            baz.set_foo_field("blah").unwrap();
             let mut bar = baz.init_bar_field();
-            bar.set_text_field("some text".into());
+            bar.set_text_field("some text");
             bar.set_data_field(b"some data");
         }
 
@@ -926,11 +923,7 @@ mod tests {
         let mut root: test_generics::Builder<'_, test_all_types::Owned, text::Owned> =
             message.init_root();
         init_test_message(root.reborrow().get_foo().unwrap());
-        root.reborrow()
-            .get_dub()
-            .unwrap()
-            .set_foo("Hello".into())
-            .unwrap();
+        root.reborrow().get_dub().unwrap().set_foo("Hello").unwrap();
         {
             let mut bar: ::capnp::primitive_list::Builder<'_, u8> =
                 root.reborrow().get_dub().unwrap().initn_bar(1);
@@ -1090,10 +1083,7 @@ mod tests {
         }
 
         assert_eq!(union_struct.reborrow().get_union0().has_u0f0sp(), false);
-        union_struct
-            .reborrow()
-            .init_union0()
-            .set_u0f0sp("abcdef".into());
+        union_struct.reborrow().init_union0().set_u0f0sp("abcdef");
         assert_eq!(union_struct.get_union0().has_u0f0sp(), true);
     }
 
@@ -1269,8 +1259,8 @@ mod tests {
             let mut new_version = message.init_root::<test_new_version::Builder<'_>>();
             new_version.set_old1(123);
             let mut names = new_version.init_old4(2);
-            names.reborrow().get(0).set_text_field("alice".into());
-            names.get(1).set_text_field("bob".into());
+            names.reborrow().get(0).set_text_field("alice");
+            names.get(1).set_text_field("bob");
         }
         {
             let old_version = message
@@ -1938,7 +1928,7 @@ mod tests {
         let mut message = message::Builder::new_default();
         {
             let mut test = message.init_root::<test_all_types::Builder<'_>>();
-            test.set_text_field("Hello".into());
+            test.set_text_field("Hello");
         }
         let reader = message
             .get_root::<test_all_types::Builder<'_>>()

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -923,6 +923,7 @@ mod tests {
         let mut root: test_generics::Builder<'_, test_all_types::Owned, text::Owned> =
             message.init_root();
         init_test_message(root.reborrow().get_foo().unwrap());
+        root.reborrow().set_bar("garply").unwrap();
         root.reborrow().get_dub().unwrap().set_foo("Hello").unwrap();
         {
             let mut bar: ::capnp::primitive_list::Builder<'_, u8> =
@@ -940,6 +941,7 @@ mod tests {
         CheckTestMessage::check_test_message(root.reborrow().get_foo().unwrap());
         let root_reader = root.into_reader();
         CheckTestMessage::check_test_message(root_reader.get_foo().unwrap());
+        assert_eq!("garply", root_reader.get_bar().unwrap());
         let dub_reader = root_reader.get_dub().unwrap();
         assert_eq!("Hello", dub_reader.get_foo().unwrap());
         let bar_reader = dub_reader.get_bar().unwrap();

--- a/capnpc/test/test_util.rs
+++ b/capnpc/test/test_util.rs
@@ -134,10 +134,9 @@ pub fn init_test_message(mut builder: test_all_types::Builder<'_>) {
                 .set_text_field("x structlist 3");
         }
 
-        let mut enum_list = sub_builder.reborrow().init_enum_list(3);
-        enum_list.set(0, TestEnum::Qux);
-        enum_list.set(1, TestEnum::Bar);
-        enum_list.set(2, TestEnum::Grault);
+        sub_builder
+            .set_enum_list(&[TestEnum::Qux, TestEnum::Bar, TestEnum::Grault])
+            .unwrap();
     }
     builder.set_enum_field(TestEnum::Corge);
 

--- a/capnpc/test/test_util.rs
+++ b/capnpc/test/test_util.rs
@@ -153,12 +153,7 @@ pub fn init_test_message(mut builder: test_all_types::Builder<'_>) {
 
     // ...
 
-    {
-        let mut text_list = builder.reborrow().init_text_list(3);
-        text_list.set(0, "plugh".into());
-        text_list.set(1, "xyzzy".into());
-        text_list.set(2, "thud".into());
-    }
+    builder.set_text_list(&["plugh", "xyzzy", "thud"]).unwrap();
 
     {
         let mut data_list = builder.reborrow().init_data_list(3);

--- a/capnpc/test/test_util.rs
+++ b/capnpc/test/test_util.rs
@@ -62,14 +62,10 @@ pub fn init_test_message(mut builder: test_all_types::Builder<'_>) {
         sub_builder.set_enum_field(TestEnum::Baz);
 
         sub_builder.reborrow().init_void_list(3);
-        {
-            let mut bool_list = sub_builder.reborrow().init_bool_list(5);
-            bool_list.set(0, false);
-            bool_list.set(1, true);
-            bool_list.set(2, false);
-            bool_list.set(3, true);
-            bool_list.set(4, true);
-        }
+        sub_builder
+            .set_bool_list(&[false, true, false, true, true])
+            .unwrap();
+
         {
             let mut int8_list = sub_builder.reborrow().init_int8_list(4);
             int8_list.set(0, 12);
@@ -99,13 +95,7 @@ pub fn init_test_message(mut builder: test_all_types::Builder<'_>) {
             int64_list.set(3, 0x7fffffffffffffff);
         }
 
-        {
-            let mut uint8_list = sub_builder.reborrow().init_u_int8_list(4);
-            uint8_list.set(0, 12);
-            uint8_list.set(1, 34);
-            uint8_list.set(2, 0);
-            uint8_list.set(3, 0xff);
-        }
+        sub_builder.set_u_int8_list(&[12, 34, 0, 0xff]).unwrap();
 
         {
             let mut uint16_list = sub_builder.reborrow().init_u_int16_list(4);

--- a/capnpc/test/test_util.rs
+++ b/capnpc/test/test_util.rs
@@ -34,7 +34,7 @@ pub fn init_test_message(mut builder: test_all_types::Builder<'_>) {
     builder.set_u_int64_field(12345678901234567890);
     builder.set_float32_field(1234.5);
     builder.set_float64_field(-123e45);
-    builder.set_text_field("foo".into());
+    builder.set_text_field("foo");
     builder.set_data_field(b"bar");
     {
         let mut sub_builder = builder.reborrow().init_struct_field();
@@ -50,14 +50,14 @@ pub fn init_test_message(mut builder: test_all_types::Builder<'_>) {
         sub_builder.set_u_int64_field(345678901234567890);
         sub_builder.set_float32_field(-1.25e-10);
         sub_builder.set_float64_field(345f64);
-        sub_builder.set_text_field("baz".into());
+        sub_builder.set_text_field("baz");
         sub_builder.set_data_field(b"qux");
         {
             let mut sub_sub_builder = sub_builder.reborrow().init_struct_field();
-            sub_sub_builder.set_text_field("nested".into());
+            sub_sub_builder.set_text_field("nested");
             sub_sub_builder
                 .init_struct_field()
-                .set_text_field("really nested".into());
+                .set_text_field("really nested");
         }
         sub_builder.set_enum_field(TestEnum::Baz);
 
@@ -157,15 +157,15 @@ pub fn init_test_message(mut builder: test_all_types::Builder<'_>) {
             struct_list
                 .reborrow()
                 .get(0)
-                .set_text_field("x structlist 1".into());
+                .set_text_field("x structlist 1");
             struct_list
                 .reborrow()
                 .get(1)
-                .set_text_field("x structlist 2".into());
+                .set_text_field("x structlist 2");
             struct_list
                 .reborrow()
                 .get(2)
-                .set_text_field("x structlist 3".into());
+                .set_text_field("x structlist 3");
         }
 
         let mut enum_list = sub_builder.reborrow().init_enum_list(3);
@@ -203,18 +203,9 @@ pub fn init_test_message(mut builder: test_all_types::Builder<'_>) {
 
     {
         let mut struct_list = builder.reborrow().init_struct_list(3);
-        struct_list
-            .reborrow()
-            .get(0)
-            .set_text_field("structlist 1".into());
-        struct_list
-            .reborrow()
-            .get(1)
-            .set_text_field("structlist 2".into());
-        struct_list
-            .reborrow()
-            .get(2)
-            .set_text_field("structlist 3".into());
+        struct_list.reborrow().get(0).set_text_field("structlist 1");
+        struct_list.reborrow().get(1).set_text_field("structlist 2");
+        struct_list.reborrow().get(2).set_text_field("structlist 3");
     }
 
     // ...

--- a/capnpc/test/test_util.rs
+++ b/capnpc/test/test_util.rs
@@ -66,44 +66,26 @@ pub fn init_test_message(mut builder: test_all_types::Builder<'_>) {
             .set_bool_list(&[false, true, false, true, true])
             .unwrap();
 
-        {
-            let mut int8_list = sub_builder.reborrow().init_int8_list(4);
-            int8_list.set(0, 12);
-            int8_list.set(1, -34);
-            int8_list.set(2, -0x80);
-            int8_list.set(3, 0x7f);
-        }
-        {
-            let mut int16_list = sub_builder.reborrow().init_int16_list(4);
-            int16_list.set(0, 1234);
-            int16_list.set(1, -5678);
-            int16_list.set(2, -0x8000);
-            int16_list.set(3, 0x7fff);
-        }
-        {
-            let mut int32_list = sub_builder.reborrow().init_int32_list(4);
-            int32_list.set(0, 12345678);
-            int32_list.set(1, -90123456);
-            int32_list.set(2, -0x80000000);
-            int32_list.set(3, 0x7fffffff);
-        }
-        {
-            let mut int64_list = sub_builder.reborrow().init_int64_list(4);
-            int64_list.set(0, 123456789012345);
-            int64_list.set(1, -678901234567890);
-            int64_list.set(2, -0x8000000000000000);
-            int64_list.set(3, 0x7fffffffffffffff);
-        }
+        sub_builder.set_int8_list(&[12, -34, -0x80, 0x7f]).unwrap();
+        sub_builder
+            .set_int16_list(&[1234, -5678, -0x8000, 0x7fff])
+            .unwrap();
+        sub_builder
+            .set_int32_list(&[12345678, -90123456, -0x80000000, 0x7fffffff])
+            .unwrap();
+        sub_builder
+            .set_int64_list(&[
+                123456789012345,
+                -678901234567890,
+                -0x8000000000000000,
+                0x7fffffffffffffff,
+            ])
+            .unwrap();
 
         sub_builder.set_u_int8_list(&[12, 34, 0, 0xff]).unwrap();
-
-        {
-            let mut uint16_list = sub_builder.reborrow().init_u_int16_list(4);
-            uint16_list.set(0, 1234);
-            uint16_list.set(1, 5678);
-            uint16_list.set(2, 0);
-            uint16_list.set(3, 0xffff);
-        }
+        sub_builder
+            .set_u_int16_list(&[1234, 5678, 0, 0xffff])
+            .unwrap();
 
         {
             let mut uint32_list = sub_builder.reborrow().init_u_int32_list(4);
@@ -121,15 +103,9 @@ pub fn init_test_message(mut builder: test_all_types::Builder<'_>) {
             uint64_list.set(3, 0xffffffffffffffff);
         }
 
-        {
-            let mut float32_list = sub_builder.reborrow().init_float32_list(6);
-            float32_list.set(0, 0f32);
-            float32_list.set(1, 1234567f32);
-            float32_list.set(2, 1e37);
-            float32_list.set(3, -1e37);
-            float32_list.set(4, 1e-37);
-            float32_list.set(5, -1e-37);
-        }
+        sub_builder
+            .set_float32_list(&[0f32, 1234567f32, 1e37, -1e37, 1e-37, -1e-37])
+            .unwrap();
 
         {
             let mut float64_list = sub_builder.reborrow().init_float64_list(6);

--- a/example/addressbook/addressbook.rs
+++ b/example/addressbook/addressbook.rs
@@ -37,32 +37,32 @@ pub mod addressbook {
             {
                 let mut alice = people.reborrow().get(0);
                 alice.set_id(123);
-                alice.set_name("Alice".into());
-                alice.set_email("alice@example.com".into());
+                alice.set_name("Alice");
+                alice.set_email("alice@example.com");
                 {
                     let mut alice_phones = alice.reborrow().init_phones(1);
-                    alice_phones.reborrow().get(0).set_number("555-1212".into());
+                    alice_phones.reborrow().get(0).set_number("555-1212");
                     alice_phones
                         .reborrow()
                         .get(0)
                         .set_type(person::phone_number::Type::Mobile);
                 }
-                alice.get_employment().set_school("MIT".into());
+                alice.get_employment().set_school("MIT");
             }
 
             {
                 let mut bob = people.get(1);
                 bob.set_id(456);
-                bob.set_name("Bob".into());
-                bob.set_email("bob@example.com".into());
+                bob.set_name("Bob");
+                bob.set_email("bob@example.com");
                 {
                     let mut bob_phones = bob.reborrow().init_phones(2);
-                    bob_phones.reborrow().get(0).set_number("555-4567".into());
+                    bob_phones.reborrow().get(0).set_number("555-4567");
                     bob_phones
                         .reborrow()
                         .get(0)
                         .set_type(person::phone_number::Type::Home);
-                    bob_phones.reborrow().get(1).set_number("555-7654".into());
+                    bob_phones.reborrow().get(1).set_number("555-7654");
                     bob_phones
                         .reborrow()
                         .get(1)

--- a/example/addressbook_send/addressbook_send.rs
+++ b/example/addressbook_send/addressbook_send.rs
@@ -41,32 +41,32 @@ pub mod addressbook {
             {
                 let mut alice = people.reborrow().get(0);
                 alice.set_id(123);
-                alice.set_name("Alice".into());
-                alice.set_email("alice@example.com".into());
+                alice.set_name("Alice");
+                alice.set_email("alice@example.com");
                 {
                     let mut alice_phones = alice.reborrow().init_phones(1);
-                    alice_phones.reborrow().get(0).set_number("555-1212".into());
+                    alice_phones.reborrow().get(0).set_number("555-1212");
                     alice_phones
                         .reborrow()
                         .get(0)
                         .set_type(person::phone_number::Type::Mobile);
                 }
-                alice.get_employment().set_school("MIT".into());
+                alice.get_employment().set_school("MIT");
             }
 
             {
                 let mut bob = people.get(1);
                 bob.set_id(456);
-                bob.set_name("Bob".into());
-                bob.set_email("bob@example.com".into());
+                bob.set_name("Bob");
+                bob.set_email("bob@example.com");
                 {
                     let mut bob_phones = bob.reborrow().init_phones(2);
-                    bob_phones.reborrow().get(0).set_number("555-4567".into());
+                    bob_phones.reborrow().get(0).set_number("555-4567");
                     bob_phones
                         .reborrow()
                         .get(0)
                         .set_type(person::phone_number::Type::Home);
-                    bob_phones.reborrow().get(1).set_number("555-7654".into());
+                    bob_phones.reborrow().get(1).set_number("555-7654");
                     bob_phones
                         .reborrow()
                         .get(1)


### PR DESCRIPTION
This allows us to support setting text fields with either a text::Reader or a &str.

Unfortunately, this also means that much of the user code that broke on the v0.17 -> v0.18 upgrade (due to #433) will break again (because the common fix was to insert a `.into()` call, and now such `into()` calls need to be deleted). The hope is that the long-term ergonomics gains outweigh the short term pain.