### PR TITLE
docs: remove usage of deprecated tokio_core in docs

### DIFF
--- a/capnp-rpc/src/lib.rs
+++ b/capnp-rpc/src/lib.rs
@@ -164,8 +164,9 @@ pub trait VatNetwork<VatId> {
 /// will need to have more sophisticated `VatNetwork` implementations, in order to support
 /// [level 3](https://capnproto.org/rpc.html#protocol-features) features.
 ///
-/// An `RpcSystem` is a `Future` and needs to be driven by a task executor. A common way
-/// accomplish that is to pass the `RpcSystem` to `tokio_core::reactor::Handle::spawn()`.
+/// An `RpcSystem` is a non-`Send`able `Future` and needs to be driven by a task
+/// executor. A common way accomplish that is to pass the `RpcSystem` to 
+/// `tokio::task::spawn_local()`.
 #[must_use = "futures do nothing unless polled"]
 pub struct RpcSystem<VatId>
 where


### PR DESCRIPTION
### What does this PR do

Update the documentation of `RpcSystem`

1. `tokio_core` has been deprecated, so replace `tokio_core::reactor::handle::spawn()` with `tokio::task::spawn_local()`.
2. Explicitly document it that `RpcSystem` is not `Send` (so one needs `spawn_local()` rather than `spawn()`).