### PR TITLE
Fix possible undefined behavior in primitive list as_slice

### DIFF
--- a/capnp/src/primitive_list.rs
+++ b/capnp/src/primitive_list.rs
@@ -22,6 +22,7 @@
 //! List of primitives.
 
 use core::marker;
+use core::ptr::NonNull;
 
 use crate::introspect;
 use crate::private::layout::{
@@ -124,7 +125,16 @@ impl<'a, T: PrimitiveElement> Reader<'a, T> {
                 // This is a List(Void).
                 self.len() as usize
             };
-            Some(unsafe { core::slice::from_raw_parts(bytes.as_ptr() as *mut T, slice_length) })
+            Some(unsafe {
+                core::slice::from_raw_parts(
+                    if slice_length == 0 {
+                        NonNull::dangling().as_ptr()
+                    } else {
+                        bytes.as_ptr() as *mut T
+                    },
+                    slice_length,
+                )
+            })
         } else {
             None
         }
@@ -184,7 +194,14 @@ where
                 self.len() as usize
             };
             Some(unsafe {
-                core::slice::from_raw_parts_mut(bytes.as_mut_ptr() as *mut T, slice_length)
+                core::slice::from_raw_parts_mut(
+                    if slice_length == 0 {
+                        NonNull::dangling().as_ptr()
+                    } else {
+                        bytes.as_mut_ptr() as *mut T
+                    },
+                    slice_length,
+                )
             })
         } else {
             None

--- a/capnp/tests/primitive_list_as_slice.rs
+++ b/capnp/tests/primitive_list_as_slice.rs
@@ -36,6 +36,12 @@ pub fn primitive_list_as_slice() {
     }
 
     {
+        let mut u16list = msg.initn_root::<primitive_list::Builder<u16>>(0);
+        assert_eq!(u16list.as_slice().unwrap().len(), 0);
+        assert_eq!(u16list.into_reader().as_slice().unwrap().len(), 0);
+    }
+
+    {
         let mut u16list = msg.initn_root::<primitive_list::Builder<u16>>(4);
         u16list.set(0, 0xab);
         u16list.set(1, 0xcd);
@@ -45,6 +51,90 @@ pub fn primitive_list_as_slice() {
         assert_eq!(
             u16list.into_reader().as_slice().unwrap(),
             &[0xab, 0xcd, 0xde, 0xff]
+        );
+    }
+
+    {
+        let mut u32list = msg.initn_root::<primitive_list::Builder<u32>>(0);
+        assert_eq!(u32list.as_slice().unwrap().len(), 0);
+        assert_eq!(u32list.into_reader().as_slice().unwrap().len(), 0);
+    }
+
+    {
+        let mut u32list = msg.initn_root::<primitive_list::Builder<u32>>(4);
+        u32list.set(0, 0xab);
+        u32list.set(1, 0xcd);
+        u32list.set(2, 0xde);
+        u32list.set(3, 0xff);
+        assert_eq!(u32list.as_slice().unwrap(), &[0xab, 0xcd, 0xde, 0xff]);
+        assert_eq!(
+            u32list.into_reader().as_slice().unwrap(),
+            &[0xab, 0xcd, 0xde, 0xff]
+        );
+    }
+
+    {
+        let mut u64list = msg.initn_root::<primitive_list::Builder<u64>>(0);
+        assert_eq!(u64list.as_slice().unwrap().len(), 0);
+        assert_eq!(u64list.into_reader().as_slice().unwrap().len(), 0);
+    }
+
+    {
+        let mut u64list = msg.initn_root::<primitive_list::Builder<u64>>(4);
+        u64list.set(0, 0xab);
+        u64list.set(1, 0xcd);
+        u64list.set(2, 0xde);
+        u64list.set(3, 0xff);
+        assert_eq!(u64list.as_slice().unwrap(), &[0xab, 0xcd, 0xde, 0xff]);
+        assert_eq!(
+            u64list.into_reader().as_slice().unwrap(),
+            &[0xab, 0xcd, 0xde, 0xff]
+        );
+    }
+
+    {
+        let mut f32list = msg.initn_root::<primitive_list::Builder<f32>>(0);
+        assert_eq!(f32list.as_slice().unwrap().len(), 0);
+        assert_eq!(f32list.into_reader().as_slice().unwrap().len(), 0);
+    }
+
+    {
+        let mut f32list = msg.initn_root::<primitive_list::Builder<f32>>(5);
+        f32list.set(0, 0.3);
+        f32list.set(1, 0.0);
+        f32list.set(2, f32::NEG_INFINITY);
+        f32list.set(3, -0.0);
+        f32list.set(4, f32::MAX);
+        assert_eq!(
+            f32list.as_slice().unwrap(),
+            &[0.3, 0.0, f32::NEG_INFINITY, -0.0, f32::MAX]
+        );
+        assert_eq!(
+            f32list.into_reader().as_slice().unwrap(),
+            &[0.3, 0.0, f32::NEG_INFINITY, -0.0, f32::MAX]
+        );
+    }
+
+    {
+        let mut f64list = msg.initn_root::<primitive_list::Builder<f64>>(0);
+        assert_eq!(f64list.as_slice().unwrap().len(), 0);
+        assert_eq!(f64list.into_reader().as_slice().unwrap().len(), 0);
+    }
+
+    {
+        let mut f64list = msg.initn_root::<primitive_list::Builder<f64>>(5);
+        f64list.set(0, 0.3);
+        f64list.set(1, 0.0);
+        f64list.set(2, f64::NEG_INFINITY);
+        f64list.set(3, -0.0);
+        f64list.set(4, f64::MAX);
+        assert_eq!(
+            f64list.as_slice().unwrap(),
+            &[0.3, 0.0, f64::NEG_INFINITY, -0.0, f64::MAX]
+        );
+        assert_eq!(
+            f64list.into_reader().as_slice().unwrap(),
+            &[0.3, 0.0, f64::NEG_INFINITY, -0.0, f64::MAX]
         );
     }
 


### PR DESCRIPTION
At least on my machine, calling `.as_slice()` on an empty primitive list with elements u16 or larger in Rust nightly in debug mode results in a panic like this:

```
thread 'primitive_list_as_slice' panicked at library\core\src\panicking.rs:219:5:
unsafe precondition(s) violated: slice::from_raw_parts_mut requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`
stack backtrace:
   0:     0x7ff759add69d - std::backtrace_rs::backtrace::dbghelp64::trace
                               at /rustc/e82c861d7e5ecd766cb0dab0bf622445dec999dc/library\std\src\..\..\backtrace\src\backtrace\dbghelp64.rs:91
[...]
  19:     0x7ff759b04be3 - core::panicking::panic_nounwind
                               at /rustc/e82c861d7e5ecd766cb0dab0bf622445dec999dc/library\core\src\panicking.rs:219
  20:     0x7ff759a77259 - core::slice::raw::from_raw_parts_mut::precondition_check
                               at /rustc/e82c861d7e5ecd766cb0dab0bf622445dec999dc\library\core\src\ub_checks.rs:68
  21:     0x7ff759a78c50 - core::slice::raw::from_raw_parts_mut<u16>
                               at /rustc/e82c861d7e5ecd766cb0dab0bf622445dec999dc\library\core\src\ub_checks.rs:75
  22:     0x7ff759a7b276 - capnp::primitive_list::Builder<u16>::as_slice<u16>
                               at F:\capnproto-rust\capnp\src\primitive_list.rs:187
  23:     0x7ff759a73768 - primitive_list_as_slice::primitive_list_as_slice
                               at F:\capnproto-rust\capnp\tests\primitive_list_as_slice.rs:40
  24:     0x7ff759a71458 - primitive_list_as_slice::primitive_list_as_slice::closure$0
                               at F:\capnproto-rust\capnp\tests\primitive_list_as_slice.rs:6
[...]
thread caused non-unwinding panic. aborting.
```

This is because `ListReader::into_raw_bytes` and `ListBuilder::as_raw_bytes` return an empty `&[u8]` when the list is empty, which has a pointer value of 1 in this version of Rust.

The [documentation](https://doc.rust-lang.org/nightly/std/slice/fn.from_raw_parts.html) for `std::slice::from_raw_parts` notes:
> data must be non-null and aligned even for zero-length slices. One reason for this is that enum layout optimizations may rely on references (including slices of any length) being aligned and non-null to distinguish them from other data. You can obtain a pointer that is usable as data for zero-length slices using [NonNull::dangling()](https://doc.rust-lang.org/nightly/std/ptr/struct.NonNull.html#method.dangling).

This PR adds a check to avoid creating an invalid empty slice and and adds some test cases for empty primitive lists of larger types.