### PR TITLE
Forbid use of as_slice when unaligned feature is enabled

### DIFF
--- a/capnp/src/primitive_list.rs
+++ b/capnp/src/primitive_list.rs
@@ -112,9 +112,14 @@ impl<'a, T: PrimitiveElement> Reader<'a, T> {
         }
     }
 
-    #[cfg(target_endian = "little")]
+    const _CHECK_SLICE: () = check_slice_supported::<T>();
+
     /// Returns something if the slice is as expected in memory.
+    ///
+    /// If the target is not little-endian or the `unaligned` feature is enabled, this function
+    /// will only be available for types that are 1 byte or smaller.
     pub fn as_slice(&self) -> Option<&[T]> {
+        let () = Self::_CHECK_SLICE;
         if self.reader.get_element_size() == T::element_size() {
             let bytes = self.reader.into_raw_bytes();
             let bits_per_element = data_bits_per_element(T::element_size()) as usize;
@@ -127,6 +132,17 @@ impl<'a, T: PrimitiveElement> Reader<'a, T> {
             Some(unsafe { core::slice::from_raw_parts(bytes.as_ptr() as *mut T, slice_length) })
         } else {
             None
+        }
+    }
+}
+
+const fn check_slice_supported<T: PrimitiveElement>() {
+    if core::mem::size_of::<T>() > 1 {
+        if !cfg!(target_endian = "little") {
+            panic!("cannot call as_slice on primitive list of multi-byte elements on non-little endian targets");
+        }
+        if cfg!(feature = "unaligned") {
+            panic!("cannot call as_slice on primitive list of multi-byte elements when unaligned feature is enabled");
         }
     }
 }
@@ -172,8 +188,10 @@ where
         PrimitiveElement::set(&self.builder, index, value);
     }
 
-    #[cfg(target_endian = "little")]
+    const _CHECK_SLICE: () = check_slice_supported::<T>();
+
     pub fn as_slice(&mut self) -> Option<&mut [T]> {
+        let () = Self::_CHECK_SLICE;
         if self.builder.get_element_size() == T::element_size() {
             let bytes = self.builder.as_raw_bytes();
             let bits_per_element = data_bits_per_element(T::element_size()) as usize;

--- a/capnp/tests/primitive_list_as_slice.rs
+++ b/capnp/tests/primitive_list_as_slice.rs
@@ -1,4 +1,8 @@
-#![cfg(all(target_endian = "little", feature = "alloc"))]
+#![cfg(all(
+    target_endian = "little",
+    feature = "alloc",
+    not(feature = "unaligned")
+))]
 
 use capnp::{message, primitive_list};
 

--- a/capnp/tests/primitive_list_as_slice_unaligned.rs
+++ b/capnp/tests/primitive_list_as_slice_unaligned.rs
@@ -1,0 +1,37 @@
+#![cfg(feature = "alloc")]
+
+use capnp::{message, primitive_list};
+
+#[test]
+pub fn primitive_list_as_slice_small_values() {
+    let mut msg = message::Builder::new_default();
+
+    {
+        let mut void_list = msg.initn_root::<primitive_list::Builder<()>>(0);
+        assert_eq!(void_list.as_slice().unwrap().len(), 0);
+        assert_eq!(void_list.into_reader().as_slice().unwrap().len(), 0);
+    }
+
+    {
+        let mut void_list = msg.initn_root::<primitive_list::Builder<()>>(5);
+        assert_eq!(void_list.as_slice().unwrap(), &[(), (), (), (), ()]);
+        assert_eq!(
+            void_list.into_reader().as_slice().unwrap(),
+            &[(), (), (), (), ()]
+        );
+    }
+
+    {
+        let mut u8list = msg.initn_root::<primitive_list::Builder<u8>>(0);
+        assert_eq!(u8list.as_slice().unwrap().len(), 0);
+        assert_eq!(u8list.into_reader().as_slice().unwrap().len(), 0);
+    }
+
+    {
+        let mut u8list = msg.initn_root::<primitive_list::Builder<u8>>(3);
+        u8list.set(0, 0);
+        u8list.set(1, 1);
+        u8list.set(2, 2);
+        assert_eq!(u8list.as_slice().unwrap(), &[0, 1, 2]);
+    }
+}


### PR DESCRIPTION
Somewhat related to #496 - if the user enables the `unaligned` feature, undefined behavior may result from use of `as_slice()` if the type is larger than 1 byte.

I added a compile-time check that panics in a const fn for a more useful error message and to keep the API the same. This also adds support for `as_slice()` on big-endian targets so long as the lists' elements are 1 byte or less.

Possible alternatives include:

- Returning `None` if the buffer is unaligned, but still returning a slice if it happens to be aligned
- Always returning `None` if the `unaligned` feature is enabled for lists of multi-byte elements
- `#[cfg(...)]`-gating the entire method