### PR TITLE
docs: update 2 old links

### DIFF
--- a/capnp-rpc/src/lib.rs
+++ b/capnp-rpc/src/lib.rs
@@ -74,11 +74,11 @@ use crate::task_set::TaskSet;
 pub use crate::reconnect::{auto_reconnect, lazy_auto_reconnect, SetTarget};
 
 /// Code generated from
-/// [rpc.capnp](https://github.com/sandstorm-io/capnproto/blob/master/c%2B%2B/src/capnp/rpc.capnp).
+/// [rpc.capnp](https://github.com/capnproto/capnproto/blob/master/c%2B%2B/src/capnp/rpc.capnp).
 pub mod rpc_capnp;
 
 /// Code generated from
-/// [rpc-twoparty.capnp](https://github.com/sandstorm-io/capnproto/blob/master/c%2B%2B/src/capnp/rpc-twoparty.capnp).
+/// [rpc-twoparty.capnp](https://github.com/capnproto/capnproto/blob/master/c%2B%2B/src/capnp/rpc-twoparty.capnp).
 pub mod rpc_twoparty_capnp;
 
 /// Like `try!()`, but for functions that return a `Promise<T, E>` rather than a `Result<T, E>`.


### PR DESCRIPTION
## What does this PR do

Update 2 old links.

The old links are not dead, users will be redirected to the new links, but why not update them :>