### PR TITLE
docs: document capnrpc/src/lib.rs

### DIFF
--- a/capnp-rpc/src/task_set.rs
+++ b/capnp-rpc/src/task_set.rs
@@ -114,6 +114,8 @@ where
     }
 }
 
+/// For a specific kind of task, `TaskReaper` defines the procedure that should
+/// be invoked when it succeeds or fails.
 pub trait TaskReaper<E>
 where
     E: 'static,

--- a/capnp-rpc/src/twoparty.rs
+++ b/capnp-rpc/src/twoparty.rs
@@ -19,7 +19,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//! An implementation of `VatNetwork` for the common case of a client-server connection.
+//! An implementation of [`VatNetwork`](crate::VatNetwork) for the common case
+//! of a client-server connection.
 
 use capnp::capability::Promise;
 use capnp::message::ReaderOptions;
@@ -205,6 +206,7 @@ where
     side: crate::rpc_twoparty_capnp::Side,
 }
 
+/// A two-party vat `VatNetwork` implementation.
 impl<T> VatNetwork<T>
 where
     T: AsyncRead + Unpin,


### PR DESCRIPTION
## What does this PR do

Document most types/interfaces in `capnp-rpc/src/lib.rs`.

## Why

I started working on #495, the first thing was to read the source code, then I found these are a lot of concepts that I am not aware of, and they do not have documents. Considering this is a Rust port is the C++ implementation, authors of this port should be already familiar with those concepts, this is understandable. 

But I am completely new to them, so I took a look at the C++ repo, found the concept I wanted to understand, and copied the documents into the Rust code.

For stuff that already exists in the C++ impl, the documents are directly pasted, documents of other things are added based on my understanding.