### PR TITLE
optimization: allow `Finish` message to be elided when not needed

### DIFF
--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -384,7 +384,7 @@ fn pipelining_return_null() {
         let cap = request.send().pipeline.get_cap();
         match cap.foo_request().send().promise.await {
             Err(ref e) => {
-                if e.extra.contains("Message contains null capability pointer") {
+                if e.extra.contains("Pipeline call on a request that returned no capabilities") {
                     Ok(())
                 } else {
                     Err(Error::failed(format!(

--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -384,7 +384,9 @@ fn pipelining_return_null() {
         let cap = request.send().pipeline.get_cap();
         match cap.foo_request().send().promise.await {
             Err(ref e) => {
-                if e.extra.contains("Pipeline call on a request that returned no capabilities") {
+                if e.extra
+                    .contains("Pipeline call on a request that returned no capabilities")
+                {
                     Ok(())
                 } else {
                     Err(Error::failed(format!(


### PR DESCRIPTION
Follows this capnproto-c++ commit: https://github.com/capnproto/capnproto/commit/d8efac8788343cb29eee1ba5c5bbb9a7bd9e38ad