### PR TITLE
Implement streaming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "capnp-rpc/examples/hello-world",
     "capnp-rpc/examples/calculator",
     "capnp-rpc/examples/pubsub",
+    "capnp-rpc/examples/streaming",
     "capnp-rpc/test",
     "example/addressbook",
     "example/addressbook_send",

--- a/capnp-rpc/examples/streaming/Cargo.toml
+++ b/capnp-rpc/examples/streaming/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "streaming"
+version = "0.1.0"
+edition = "2021"
+
+build = "build.rs"
+
+[[bin]]
+name = "streaming"
+path = "main.rs"
+
+[build-dependencies]
+capnpc = { path = "../../../capnpc" }
+
+[dependencies]
+capnp = { path = "../../../capnp" }
+futures = "0.3.0"
+rand = "0.8.5"
+sha2 = { version = "0.10.8" }
+tokio = { version = "1.0.0", features = ["net", "rt", "macros"]}
+tokio-util = { version = "0.7.4", features = ["compat"] }
+
+[dependencies.capnp-rpc]
+path = "../.."

--- a/capnp-rpc/examples/streaming/build.rs
+++ b/capnp-rpc/examples/streaming/build.rs
@@ -1,0 +1,6 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    capnpc::CompilerCommand::new()
+        .file("streaming.capnp")
+        .run()?;
+    Ok(())
+}

--- a/capnp-rpc/examples/streaming/client.rs
+++ b/capnp-rpc/examples/streaming/client.rs
@@ -1,0 +1,70 @@
+use crate::streaming_capnp::receiver;
+use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
+
+use futures::AsyncReadExt;
+use rand::Rng;
+use sha2::{Digest, Sha256};
+
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use std::net::ToSocketAddrs;
+    let args: Vec<String> = ::std::env::args().collect();
+    if args.len() != 5 {
+        println!(
+            "usage: {} client HOST:PORT STREAM_SIZE WINDOW_SIZE",
+            args[0]
+        );
+        return Ok(());
+    }
+
+    let stream_size: usize = str::parse(&args[3]).unwrap();
+    let window_size: usize = str::parse(&args[4]).unwrap();
+
+    let addr = args[2]
+        .to_socket_addrs()?
+        .next()
+        .expect("could not parse address");
+
+    tokio::task::LocalSet::new()
+        .run_until(async move {
+            let stream = tokio::net::TcpStream::connect(&addr).await?;
+            stream.set_nodelay(true)?;
+            let (reader, writer) =
+                tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
+            let mut rpc_network = Box::new(twoparty::VatNetwork::new(
+                futures::io::BufReader::new(reader),
+                futures::io::BufWriter::new(writer),
+                rpc_twoparty_capnp::Side::Client,
+                Default::default(),
+            ));
+            rpc_network.set_window_size(window_size);
+            let mut rpc_system = RpcSystem::new(rpc_network, None);
+            let receiver: receiver::Client = rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
+            tokio::task::spawn_local(rpc_system);
+
+            let capnp::capability::RemotePromise { promise, pipeline } =
+                receiver.write_stream_request().send();
+
+            let mut rng = rand::thread_rng();
+            let mut hasher = Sha256::new();
+            let bytestream = pipeline.get_stream();
+            let mut bytes_written: u32 = 0;
+            const CHUNK_SIZE: u32 = 4096;
+            while bytes_written < stream_size as u32 {
+                let mut request = bytestream.write_request();
+                let body = request.get();
+                let buf = body.init_bytes(CHUNK_SIZE);
+                rng.fill(buf);
+                hasher.update(buf);
+                request.send().await?;
+                bytes_written += CHUNK_SIZE;
+            }
+            bytestream.end_request().send().promise.await?;
+            let response = promise.await?;
+
+            let sha256 = response.get()?.get_sha256()?;
+            let local_sha256 = hasher.finalize();
+            assert_eq!(sha256, &local_sha256[..]);
+            Ok(())
+        })
+        .await
+}

--- a/capnp-rpc/examples/streaming/main.rs
+++ b/capnp-rpc/examples/streaming/main.rs
@@ -1,0 +1,21 @@
+pub mod streaming_capnp {
+    include!(concat!(env!("OUT_DIR"), "/streaming_capnp.rs"));
+}
+
+pub mod client;
+pub mod server;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = ::std::env::args().collect();
+    if args.len() >= 2 {
+        match &args[1][..] {
+            "client" => return client::main().await,
+            "server" => return server::main().await,
+            _ => (),
+        }
+    }
+
+    println!("usage: {} [client | server] ADDRESS", args[0]);
+    Ok(())
+}

--- a/capnp-rpc/examples/streaming/server.rs
+++ b/capnp-rpc/examples/streaming/server.rs
@@ -1,0 +1,112 @@
+use std::net::ToSocketAddrs;
+
+use crate::streaming_capnp::{byte_stream, receiver};
+use capnp_rpc::{pry, rpc_twoparty_capnp, twoparty, RpcSystem};
+
+use capnp::capability::Promise;
+use capnp::Error;
+
+use futures::channel::oneshot;
+use futures::AsyncReadExt;
+use sha2::{Digest, Sha256};
+
+struct ByteStreamImpl {
+    hasher: Sha256,
+    hash_sender: Option<oneshot::Sender<Vec<u8>>>,
+}
+
+impl ByteStreamImpl {
+    fn new(hash_sender: oneshot::Sender<Vec<u8>>) -> Self {
+        Self {
+            hasher: Sha256::new(),
+            hash_sender: Some(hash_sender),
+        }
+    }
+}
+
+impl byte_stream::Server for ByteStreamImpl {
+    fn write(&mut self, params: byte_stream::WriteParams) -> Promise<(), Error> {
+        let bytes = pry!(pry!(params.get()).get_bytes());
+        self.hasher.update(bytes);
+        Promise::ok(())
+    }
+
+    fn end(
+        &mut self,
+        _params: byte_stream::EndParams,
+        _results: byte_stream::EndResults,
+    ) -> Promise<(), Error> {
+        let hasher = std::mem::take(&mut self.hasher);
+        if let Some(sender) = self.hash_sender.take() {
+            let _ = sender.send(hasher.finalize()[..].to_vec());
+        }
+        Promise::ok(())
+    }
+}
+
+struct ReceiverImpl {}
+
+impl ReceiverImpl {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl receiver::Server for ReceiverImpl {
+    fn write_stream(
+        &mut self,
+        _params: receiver::WriteStreamParams,
+        mut results: receiver::WriteStreamResults,
+    ) -> Promise<(), Error> {
+        let (snd, rcv) = oneshot::channel();
+        let client: byte_stream::Client = capnp_rpc::new_client(ByteStreamImpl::new(snd));
+        results.get().set_stream(client);
+        pry!(results.set_pipeline());
+        Promise::from_future(async move {
+            match rcv.await {
+                Ok(v) => {
+                    results.get().set_sha256(&v[..]);
+                    Ok(())
+                }
+                Err(_) => Err(Error::failed("failed to get hash".into())),
+            }
+        })
+    }
+}
+
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = ::std::env::args().collect();
+    if args.len() != 3 {
+        println!("usage: {} server ADDRESS[:PORT]", args[0]);
+        return Ok(());
+    }
+
+    let addr = args[2]
+        .to_socket_addrs()?
+        .next()
+        .expect("could not parse address");
+
+    tokio::task::LocalSet::new()
+        .run_until(async move {
+            let listener = tokio::net::TcpListener::bind(&addr).await?;
+            let client: receiver::Client = capnp_rpc::new_client(ReceiverImpl::new());
+
+            loop {
+                let (stream, _) = listener.accept().await?;
+                stream.set_nodelay(true)?;
+                let (reader, writer) =
+                    tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
+                let network = twoparty::VatNetwork::new(
+                    futures::io::BufReader::new(reader),
+                    futures::io::BufWriter::new(writer),
+                    rpc_twoparty_capnp::Side::Server,
+                    Default::default(),
+                );
+
+                let rpc_system = RpcSystem::new(Box::new(network), Some(client.clone().client));
+
+                tokio::task::spawn_local(rpc_system);
+            }
+        })
+        .await
+}

--- a/capnp-rpc/examples/streaming/streaming.capnp
+++ b/capnp-rpc/examples/streaming/streaming.capnp
@@ -1,0 +1,16 @@
+@0x9fedc87e438cde81;
+
+interface ByteStream {
+   write @0 (bytes :Data) -> stream;
+   # Writes a chunk.
+
+   end @1 ();
+   # Ends the stream.
+}
+
+interface Receiver {
+   writeStream @0 () -> (stream :ByteStream, sha256 :Data);
+   # Uses set_pipeline() to set up `stream` immediately.
+   # Actually returns when `end()` is called on that stream.
+   # `sha256` is the SHA256 checksum of the received data.
+}

--- a/capnp-rpc/src/broken.rs
+++ b/capnp-rpc/src/broken.rs
@@ -81,6 +81,9 @@ impl RequestHook for Request {
             pipeline: any_pointer::Pipeline::new(Box::new(pipeline)),
         }
     }
+    fn send_streaming(self: Box<Self>) -> Promise<(), Error> {
+        Promise::err(self.error)
+    }
     fn tail_send(self: Box<Self>) -> Option<(u32, Promise<(), Error>, Box<dyn PipelineHook>)> {
         None
     }

--- a/capnp-rpc/src/flow_control.rs
+++ b/capnp-rpc/src/flow_control.rs
@@ -1,0 +1,162 @@
+use capnp::capability::Promise;
+use capnp::Error;
+
+use futures::channel::oneshot;
+use futures::TryFutureExt;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::task_set::{TaskReaper, TaskSet, TaskSetHandle};
+
+pub const DEFAULT_WINDOW_SIZE: usize = 65536;
+
+enum State {
+    Running(Vec<oneshot::Sender<Result<(), Error>>>),
+    Failed(Error),
+}
+
+struct FixedWindowFlowControllerInner {
+    window_size: usize,
+    in_flight: usize,
+    max_message_size: usize,
+    state: State,
+    empty_fulfiller: Option<oneshot::Sender<Promise<(), Error>>>,
+}
+
+impl FixedWindowFlowControllerInner {
+    fn is_ready(&self) -> bool {
+        // We extend the window by maxMessageSize to avoid a pathological situation when a message
+        // is larger than the window size. Otherwise, after sending that message, we would end up
+        // not sending any others until the ack was received, wasting a round trip's worth of
+        // bandwidth.
+
+        self.in_flight < self.window_size + self.max_message_size
+    }
+}
+
+pub struct FixedWindowFlowController {
+    inner: Rc<RefCell<FixedWindowFlowControllerInner>>,
+    tasks: TaskSetHandle<Error>,
+}
+
+struct Reaper {
+    inner: Rc<RefCell<FixedWindowFlowControllerInner>>,
+}
+
+impl TaskReaper<Error> for Reaper {
+    fn task_failed(&mut self, error: Error) {
+        let mut inner = self.inner.borrow_mut();
+        if let State::Running(ref mut blocked_sends) = &mut inner.state {
+            for s in std::mem::take(blocked_sends) {
+                let _ = s.send(Err(error.clone()));
+            }
+            inner.state = State::Failed(error)
+        }
+    }
+}
+
+impl FixedWindowFlowController {
+    pub fn new(window_size: usize) -> (Self, Promise<(), Error>) {
+        let inner = FixedWindowFlowControllerInner {
+            window_size,
+            in_flight: 0,
+            max_message_size: 0,
+            state: State::Running(vec![]),
+            empty_fulfiller: None,
+        };
+        let inner = Rc::new(RefCell::new(inner));
+        let (tasks, task_future) = TaskSet::new(Box::new(Reaper {
+            inner: inner.clone(),
+        }));
+        (Self { inner, tasks }, Promise::from_future(task_future))
+    }
+}
+
+impl crate::FlowController for FixedWindowFlowController {
+    fn send(
+        &mut self,
+        message: Box<dyn crate::OutgoingMessage>,
+        ack: Promise<(), Error>,
+    ) -> Promise<(), Error> {
+        let size = message.size_in_words() * 8;
+        {
+            let mut inner = self.inner.borrow_mut();
+            let prev_max_size = inner.max_message_size;
+            inner.max_message_size = usize::max(size, prev_max_size);
+
+            // We are REQUIRED to send the message NOW to maintain correct ordering.
+            let _ = message.send();
+
+            inner.in_flight += size;
+        }
+        let inner = self.inner.clone();
+        let mut tasks = self.tasks.clone();
+        self.tasks.add(async move {
+            ack.await?;
+            let mut inner = inner.borrow_mut();
+            inner.in_flight -= size;
+            let is_ready = inner.is_ready();
+            match inner.state {
+                State::Running(ref mut blocked_sends) => {
+                    if is_ready {
+                        for s in std::mem::take(blocked_sends) {
+                            let _ = s.send(Ok(()));
+                        }
+                    }
+
+                    if inner.in_flight == 0 {
+                        if let Some(f) = inner.empty_fulfiller.take() {
+                            let _ = f.send(Promise::from_future(
+                                tasks.on_empty().map_err(crate::canceled_to_error),
+                            ));
+                        }
+                    }
+                }
+                State::Failed(_) => {
+                    // A previous call failed, but this one -- which was already in-flight at the
+                    // time -- ended up succeeding. That may indicate that the server side is not
+                    // properly handling streaming error propagation. Nothing much we can do about
+                    // it here though.
+                }
+            }
+            Ok(())
+        });
+
+        let mut inner = self.inner.borrow_mut();
+        let is_ready = inner.is_ready();
+        match inner.state {
+            State::Running(ref mut blocked_sends) => {
+                if is_ready {
+                    Promise::ok(())
+                } else {
+                    let (snd, rcv) = oneshot::channel();
+                    blocked_sends.push(snd);
+                    Promise::from_future(async {
+                        match rcv.await {
+                            Ok(r) => r,
+                            Err(e) => Err(crate::canceled_to_error(e)),
+                        }
+                    })
+                }
+            }
+            State::Failed(ref e) => Promise::err(e.clone()),
+        }
+    }
+
+    fn wait_all_acked(&mut self) -> Promise<(), Error> {
+        let mut inner = self.inner.borrow_mut();
+        if let State::Running(ref blocked_sends) = inner.state {
+            if !blocked_sends.is_empty() {
+                let (snd, rcv) = oneshot::channel();
+                inner.empty_fulfiller = Some(snd);
+                return Promise::from_future(async move {
+                    match rcv.await {
+                        Ok(r) => r.await,
+                        Err(e) => Err(crate::canceled_to_error(e)),
+                    }
+                });
+            }
+        }
+        Promise::from_future(self.tasks.on_empty().map_err(crate::canceled_to_error))
+    }
+}

--- a/capnp-rpc/src/reconnect.rs
+++ b/capnp-rpc/src/reconnect.rs
@@ -203,6 +203,10 @@ where
         result
     }
 
+    fn send_streaming(self: Box<Self>) -> Promise<(), capnp::Error> {
+        todo!()
+    }
+
     fn tail_send(
         self: Box<Self>,
     ) -> Option<(

--- a/capnp-rpc/test/test.capnp
+++ b/capnp-rpc/test/test.capnp
@@ -133,6 +133,13 @@ interface TestTailCaller {
   foo @0 (i :Int32, callee :TestTailCallee) -> TestTailCallee.TailResult;
 }
 
+interface TestStreaming {
+  doStreamI @0 (i :UInt32, throwError :Bool) -> stream;
+  doStreamJ @1 (j :UInt32, throwError :Bool) -> stream;
+  finishStream @2 () -> (totalI :UInt32, totalJ :UInt32);
+  # Test streaming. finishStream() returns the totals of the values streamed to the other calls.
+}
+
 interface TestHandle {}
 
 interface TestMoreStuff extends(TestCallOrder) {
@@ -178,6 +185,8 @@ interface TestMoreStuff extends(TestCallOrder) {
 
   callEachCapability @13 (caps :List(TestInterface)) -> ();
   # Calls TestInterface::foo(123, true) on each cap.
+
+  getTestStreaming @14 () -> (cap :TestStreaming);
 }
 
 interface TestCapabilityServerSet {

--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -294,6 +294,10 @@ where
     pub fn into_typed<T: Owned>(self) -> TypedReader<S, T> {
         TypedReader::new(self)
     }
+
+    pub fn size_in_words(&self) -> usize {
+        self.arena.size_in_words()
+    }
 }
 
 /// A message reader whose value is known to be of type `T`.
@@ -519,6 +523,10 @@ where
     /// segments.
     pub fn into_allocator(self) -> A {
         self.arena.into_allocator()
+    }
+
+    pub fn size_in_words(&self) -> usize {
+        self.arena.size_in_words()
     }
 }
 

--- a/capnp/src/private/arena.rs
+++ b/capnp/src/private/arena.rs
@@ -45,6 +45,8 @@ pub trait ReaderArena {
 
     fn nesting_limit(&self) -> i32;
 
+    fn size_in_words(&self) -> usize;
+
     // TODO(apibump): Consider putting extract_cap(), inject_cap(), drop_cap() here
     //   and on message::Reader. Then we could get rid of Imbue and ImbueMut, and
     //   layout::StructReader, layout::ListReader, etc. could drop their `cap_table` fields.
@@ -145,6 +147,16 @@ where
 
     fn nesting_limit(&self) -> i32 {
         self.nesting_limit
+    }
+
+    fn size_in_words(&self) -> usize {
+        let mut result = 0;
+        for ii in 0..self.segments.len() {
+            if let Some(seg) = self.segments.get_segment(ii as u32) {
+                result += seg.len();
+            }
+        }
+        result
     }
 }
 
@@ -333,6 +345,14 @@ where
     fn nesting_limit(&self) -> i32 {
         0x7fffffff
     }
+
+    fn size_in_words(&self) -> usize {
+        let mut result = 0;
+        for ii in 0..self.inner.segments.len() {
+            result += self.inner.segments[ii].allocated as usize
+        }
+        result
+    }
 }
 
 impl<A> BuilderArenaImplInner<A>
@@ -463,5 +483,9 @@ impl ReaderArena for NullArena {
 
     fn nesting_limit(&self) -> i32 {
         0x7fffffff
+    }
+
+    fn size_in_words(&self) -> usize {
+        0
     }
 }

--- a/capnp/src/private/capability.rs
+++ b/capnp/src/private/capability.rs
@@ -33,6 +33,7 @@ pub trait RequestHook {
     fn get(&mut self) -> any_pointer::Builder<'_>;
     fn get_brand(&self) -> usize;
     fn send(self: alloc::boxed::Box<Self>) -> RemotePromise<any_pointer::Owned>;
+    fn send_streaming(self: alloc::boxed::Box<Self>) -> Promise<(), crate::Error>;
     fn tail_send(
         self: alloc::boxed::Box<Self>,
     ) -> Option<(


### PR DESCRIPTION
Updates code generation for methods declared with `-> stream`. For Server traits, these methods have no `Results` parameter. For `Client` objects, the methods go through a new `StreamingRequest` object.

Twoparty RPC connections get a fixed window size that can be configured via `twoparty::VatNetwork::set_window_size()`.

The implementation closely follows capnproto-c++. (See https://github.com/capnproto/capnproto/pull/825.)
One important difference: in capnproto-c++ streaming methods
are delivered one-by-one, without overlap. In Rust, overlapping method calls are less error-prone, so we don't bother with that extra built-in logic.

Adds a new example `streaming` that performs streaming method calls on a capability returned early via set_pipeline().