### PR TITLE
Add get_proto() in schema::Annotation

### DIFF
--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -390,6 +390,10 @@ impl Annotation {
     pub fn get_type(&self) -> introspect::Type {
         self.ty
     }
+
+    pub fn get_proto(self) -> annotation::Reader<'static> {
+        self.proto
+    }
 }
 
 /// A list of annotations.


### PR DESCRIPTION
When you use introspection to look at schema annotations, you are stuck in the dynamic_struct world, which is awkward and error-prone.

Exposing get_proto allows converting the dynamic annotation reader into a typed reader:

    if let Some(annot) = x.get_annotations().unwrap().find(MY_ANNOT_ID) {
        let reader: my_annot::Reader = annot
            .get_proto()
            .into_internal_struct_reader()
            .get_pointer_field(0)
            .get_struct(None)
            .unwrap()
            .into();
        // now use the reader

There probably is a way to make the usage less verbose, like collapsing that chain of calls into a single method that returns the required typed reader. Would be grateful for any suggestions.