### PR TITLE
add dynamic_value::Reader::downcast_struct()

### DIFF
--- a/capnp/src/data_list.rs
+++ b/capnp/src/data_list.rs
@@ -215,12 +215,36 @@ impl<'a> From<Reader<'a>> for crate::dynamic_value::Reader<'a> {
     }
 }
 
+impl<'a> crate::dynamic_value::DowncastReader<'a> for Reader<'a> {
+    fn downcast_reader(v: crate::dynamic_value::Reader<'a>) -> Self {
+        let dl: crate::dynamic_list::Reader = v.downcast();
+        assert_eq!(
+            dl.element_type(),
+            crate::introspect::TypeVariant::Data.into()
+        );
+        Reader { reader: dl.reader }
+    }
+}
+
 impl<'a> From<Builder<'a>> for crate::dynamic_value::Builder<'a> {
     fn from(t: Builder<'a>) -> crate::dynamic_value::Builder<'a> {
         crate::dynamic_value::Builder::List(crate::dynamic_list::Builder {
             builder: t.builder,
             element_type: crate::introspect::TypeVariant::Data.into(),
         })
+    }
+}
+
+impl<'a> crate::dynamic_value::DowncastBuilder<'a> for Builder<'a> {
+    fn downcast_builder(v: crate::dynamic_value::Builder<'a>) -> Self {
+        let dl: crate::dynamic_list::Builder = v.downcast();
+        assert_eq!(
+            dl.element_type(),
+            crate::introspect::TypeVariant::Data.into()
+        );
+        Builder {
+            builder: dl.builder,
+        }
     }
 }
 

--- a/capnp/src/dynamic_struct.rs
+++ b/capnp/src/dynamic_struct.rs
@@ -232,6 +232,18 @@ impl<'a> Reader<'a> {
         let field = self.schema.get_field_by_name(field_name)?;
         self.has(field)
     }
+
+    /// Downcasts the `Reader` into a specific struct type. Panics if the
+    /// expected type does not match the value.
+    pub fn downcast<T: crate::traits::OwnedStruct>(self) -> T::Reader<'a> {
+        assert!(
+            Into::<crate::introspect::Type>::into(crate::introspect::TypeVariant::Struct(
+                self.schema.raw
+            ))
+            .may_downcast_to(T::introspect())
+        );
+        self.reader.into()
+    }
 }
 
 /// A mutable dynamically-typed struct.
@@ -772,6 +784,18 @@ impl<'a> Builder<'a> {
             );
         }
         Ok(())
+    }
+
+    /// Downcasts the `Builder` into a specific struct type. Panics if the
+    /// expected type does not match the value.
+    pub fn downcast<T: crate::traits::OwnedStruct>(self) -> T::Builder<'a> {
+        assert!(
+            Into::<crate::introspect::Type>::into(crate::introspect::TypeVariant::Struct(
+                self.schema.raw
+            ))
+            .may_downcast_to(T::introspect())
+        );
+        self.builder.into()
     }
 }
 

--- a/capnp/src/dynamic_struct.rs
+++ b/capnp/src/dynamic_struct.rs
@@ -26,7 +26,7 @@ pub(crate) fn struct_size_from_schema(schema: StructSchema) -> Result<layout::St
 #[derive(Clone, Copy)]
 pub struct Reader<'a> {
     pub(crate) reader: layout::StructReader<'a>,
-    schema: StructSchema,
+    pub(crate) schema: StructSchema,
 }
 
 impl<'a> From<Reader<'a>> for dynamic_value::Reader<'a> {
@@ -236,8 +236,8 @@ impl<'a> Reader<'a> {
 
 /// A mutable dynamically-typed struct.
 pub struct Builder<'a> {
-    builder: layout::StructBuilder<'a>,
-    schema: StructSchema,
+    pub(crate) builder: layout::StructBuilder<'a>,
+    pub(crate) schema: StructSchema,
 }
 
 impl<'a> From<Builder<'a>> for dynamic_value::Builder<'a> {

--- a/capnp/src/dynamic_value.rs
+++ b/capnp/src/dynamic_value.rs
@@ -77,14 +77,14 @@ impl<'a> Reader<'a> {
     /// the current way the `Introspect` and `OwnedStruct` traits are set up does not
     /// seem to allow this.
     pub fn downcast_struct<T: crate::traits::OwnedStruct>(self) -> T::Reader<'a> {
-        let sr: dynamic_struct::Reader = self.downcast();
-        let TypeVariant::Struct(rs) = T::introspect().which() else {
-            panic!("not a struct");
-        };
-        if sr.schema.raw != rs {
-            panic!("tried to downcast to wrong struct type");
-        }
-        sr.reader.into()
+        let sb: dynamic_struct::Reader = self.downcast();
+        assert!(
+            Into::<crate::introspect::Type>::into(crate::introspect::TypeVariant::Struct(
+                sb.schema.raw
+            ))
+            .may_downcast_to(T::introspect())
+        );
+        sb.reader.into()
     }
 }
 
@@ -243,12 +243,12 @@ impl<'a> Builder<'a> {
     /// seem to allow this.
     pub fn downcast_struct<T: crate::traits::OwnedStruct>(self) -> T::Builder<'a> {
         let sb: dynamic_struct::Builder = self.downcast();
-        let TypeVariant::Struct(rs) = T::introspect().which() else {
-            panic!("not a struct");
-        };
-        if sb.schema.raw != rs {
-            panic!("tried to downcast to wrong struct type");
-        }
+        assert!(
+            Into::<crate::introspect::Type>::into(crate::introspect::TypeVariant::Struct(
+                sb.schema.raw
+            ))
+            .may_downcast_to(T::introspect())
+        );
         sb.builder.into()
     }
 }

--- a/capnp/src/dynamic_value.rs
+++ b/capnp/src/dynamic_value.rs
@@ -77,14 +77,8 @@ impl<'a> Reader<'a> {
     /// the current way the `Introspect` and `OwnedStruct` traits are set up does not
     /// seem to allow this.
     pub fn downcast_struct<T: crate::traits::OwnedStruct>(self) -> T::Reader<'a> {
-        let sb: dynamic_struct::Reader = self.downcast();
-        assert!(
-            Into::<crate::introspect::Type>::into(crate::introspect::TypeVariant::Struct(
-                sb.schema.raw
-            ))
-            .may_downcast_to(T::introspect())
-        );
-        sb.reader.into()
+        let sr: dynamic_struct::Reader = self.downcast();
+        sr.downcast::<T>()
     }
 }
 
@@ -243,13 +237,7 @@ impl<'a> Builder<'a> {
     /// seem to allow this.
     pub fn downcast_struct<T: crate::traits::OwnedStruct>(self) -> T::Builder<'a> {
         let sb: dynamic_struct::Builder = self.downcast();
-        assert!(
-            Into::<crate::introspect::Type>::into(crate::introspect::TypeVariant::Struct(
-                sb.schema.raw
-            ))
-            .may_downcast_to(T::introspect())
-        );
-        sb.builder.into()
+        sb.downcast::<T>()
     }
 }
 

--- a/capnp/src/enum_list.rs
+++ b/capnp/src/enum_list.rs
@@ -260,7 +260,7 @@ impl<'a, T: TryFrom<u16, Error = NotInSchema> + crate::introspect::Introspect>
 {
     fn downcast_reader(v: crate::dynamic_value::Reader<'a>) -> Self {
         let dl: crate::dynamic_list::Reader = v.downcast();
-        assert_eq!(dl.element_type(), T::introspect());
+        assert!(dl.element_type().may_downcast_to(T::introspect()));
         Reader {
             reader: dl.reader,
             marker: PhantomData,
@@ -284,7 +284,7 @@ impl<'a, T: TryFrom<u16, Error = NotInSchema> + crate::introspect::Introspect>
 {
     fn downcast_builder(v: crate::dynamic_value::Builder<'a>) -> Self {
         let dl: crate::dynamic_list::Builder = v.downcast();
-        assert_eq!(dl.element_type(), T::introspect());
+        assert!(dl.element_type().may_downcast_to(T::introspect()));
         Builder {
             builder: dl.builder,
             marker: PhantomData,

--- a/capnp/src/enum_list.rs
+++ b/capnp/src/enum_list.rs
@@ -255,6 +255,19 @@ impl<'a, T: TryFrom<u16, Error = NotInSchema> + crate::introspect::Introspect> F
     }
 }
 
+impl<'a, T: TryFrom<u16, Error = NotInSchema> + crate::introspect::Introspect>
+    crate::dynamic_value::DowncastReader<'a> for Reader<'a, T>
+{
+    fn downcast_reader(v: crate::dynamic_value::Reader<'a>) -> Self {
+        let dl: crate::dynamic_list::Reader = v.downcast();
+        assert_eq!(dl.element_type(), T::introspect());
+        Reader {
+            reader: dl.reader,
+            marker: PhantomData,
+        }
+    }
+}
+
 impl<'a, T: TryFrom<u16, Error = NotInSchema> + crate::introspect::Introspect> From<Builder<'a, T>>
     for crate::dynamic_value::Builder<'a>
 {
@@ -263,6 +276,19 @@ impl<'a, T: TryFrom<u16, Error = NotInSchema> + crate::introspect::Introspect> F
             t.builder,
             T::introspect(),
         ))
+    }
+}
+
+impl<'a, T: TryFrom<u16, Error = NotInSchema> + crate::introspect::Introspect>
+    crate::dynamic_value::DowncastBuilder<'a> for Builder<'a, T>
+{
+    fn downcast_builder(v: crate::dynamic_value::Builder<'a>) -> Self {
+        let dl: crate::dynamic_list::Builder = v.downcast();
+        assert_eq!(dl.element_type(), T::introspect());
+        Builder {
+            builder: dl.builder,
+            marker: PhantomData,
+        }
     }
 }
 

--- a/capnp/src/introspect.rs
+++ b/capnp/src/introspect.rs
@@ -13,7 +13,7 @@ pub trait Introspect {
 /// optimized to avoid heap allocation.
 ///
 /// To examine a `Type`, you should call the `which()` method.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Type {
     /// The type, minus any outer `List( )`.
     base: BaseType,

--- a/capnp/src/list_list.rs
+++ b/capnp/src/list_list.rs
@@ -284,12 +284,34 @@ impl<'a, T: crate::traits::Owned> From<Reader<'a, T>> for crate::dynamic_value::
     }
 }
 
+impl<'a, T: crate::traits::Owned> crate::dynamic_value::DowncastReader<'a> for Reader<'a, T> {
+    fn downcast_reader(v: crate::dynamic_value::Reader<'a>) -> Self {
+        let dl: crate::dynamic_list::Reader = v.downcast();
+        assert_eq!(dl.element_type(), T::introspect());
+        Reader {
+            reader: dl.reader,
+            marker: core::marker::PhantomData,
+        }
+    }
+}
+
 impl<'a, T: crate::traits::Owned> From<Builder<'a, T>> for crate::dynamic_value::Builder<'a> {
     fn from(t: Builder<'a, T>) -> crate::dynamic_value::Builder<'a> {
         crate::dynamic_value::Builder::List(crate::dynamic_list::Builder::new(
             t.builder,
             T::introspect(),
         ))
+    }
+}
+
+impl<'a, T: crate::traits::Owned> crate::dynamic_value::DowncastBuilder<'a> for Builder<'a, T> {
+    fn downcast_builder(v: crate::dynamic_value::Builder<'a>) -> Self {
+        let dl: crate::dynamic_list::Builder = v.downcast();
+        assert_eq!(dl.element_type(), T::introspect());
+        Builder {
+            builder: dl.builder,
+            marker: core::marker::PhantomData,
+        }
     }
 }
 

--- a/capnp/src/list_list.rs
+++ b/capnp/src/list_list.rs
@@ -287,7 +287,7 @@ impl<'a, T: crate::traits::Owned> From<Reader<'a, T>> for crate::dynamic_value::
 impl<'a, T: crate::traits::Owned> crate::dynamic_value::DowncastReader<'a> for Reader<'a, T> {
     fn downcast_reader(v: crate::dynamic_value::Reader<'a>) -> Self {
         let dl: crate::dynamic_list::Reader = v.downcast();
-        assert_eq!(dl.element_type(), T::introspect());
+        assert!(dl.element_type().may_downcast_to(T::introspect()));
         Reader {
             reader: dl.reader,
             marker: core::marker::PhantomData,
@@ -307,7 +307,7 @@ impl<'a, T: crate::traits::Owned> From<Builder<'a, T>> for crate::dynamic_value:
 impl<'a, T: crate::traits::Owned> crate::dynamic_value::DowncastBuilder<'a> for Builder<'a, T> {
     fn downcast_builder(v: crate::dynamic_value::Builder<'a>) -> Self {
         let dl: crate::dynamic_list::Builder = v.downcast();
-        assert_eq!(dl.element_type(), T::introspect());
+        assert!(dl.element_type().may_downcast_to(T::introspect()));
         Builder {
             builder: dl.builder,
             marker: core::marker::PhantomData,

--- a/capnp/src/primitive_list.rs
+++ b/capnp/src/primitive_list.rs
@@ -349,7 +349,7 @@ impl<'a, T: PrimitiveElement + crate::introspect::Introspect>
 {
     fn downcast_reader(v: crate::dynamic_value::Reader<'a>) -> Self {
         let dl: crate::dynamic_list::Reader = v.downcast();
-        assert_eq!(dl.element_type(), T::introspect());
+        assert!(dl.element_type().may_downcast_to(T::introspect()));
         Reader {
             reader: dl.reader,
             marker: marker::PhantomData,
@@ -373,7 +373,7 @@ impl<'a, T: PrimitiveElement + crate::introspect::Introspect>
 {
     fn downcast_builder(v: crate::dynamic_value::Builder<'a>) -> Self {
         let dl: crate::dynamic_list::Builder = v.downcast();
-        assert_eq!(dl.element_type(), T::introspect());
+        assert!(dl.element_type().may_downcast_to(T::introspect()));
         Builder {
             builder: dl.builder,
             marker: marker::PhantomData,

--- a/capnp/src/primitive_list.rs
+++ b/capnp/src/primitive_list.rs
@@ -344,6 +344,19 @@ impl<'a, T: PrimitiveElement + crate::introspect::Introspect> From<Reader<'a, T>
     }
 }
 
+impl<'a, T: PrimitiveElement + crate::introspect::Introspect>
+    crate::dynamic_value::DowncastReader<'a> for Reader<'a, T>
+{
+    fn downcast_reader(v: crate::dynamic_value::Reader<'a>) -> Self {
+        let dl: crate::dynamic_list::Reader = v.downcast();
+        assert_eq!(dl.element_type(), T::introspect());
+        Reader {
+            reader: dl.reader,
+            marker: marker::PhantomData,
+        }
+    }
+}
+
 impl<'a, T: PrimitiveElement + crate::introspect::Introspect> From<Builder<'a, T>>
     for crate::dynamic_value::Builder<'a>
 {
@@ -352,6 +365,19 @@ impl<'a, T: PrimitiveElement + crate::introspect::Introspect> From<Builder<'a, T
             t.builder,
             T::introspect(),
         ))
+    }
+}
+
+impl<'a, T: PrimitiveElement + crate::introspect::Introspect>
+    crate::dynamic_value::DowncastBuilder<'a> for Builder<'a, T>
+{
+    fn downcast_builder(v: crate::dynamic_value::Builder<'a>) -> Self {
+        let dl: crate::dynamic_list::Builder = v.downcast();
+        assert_eq!(dl.element_type(), T::introspect());
+        Builder {
+            builder: dl.builder,
+            marker: marker::PhantomData,
+        }
     }
 }
 

--- a/capnp/src/struct_list.rs
+++ b/capnp/src/struct_list.rs
@@ -294,7 +294,7 @@ impl<'a, T: crate::traits::OwnedStruct> From<Reader<'a, T>> for crate::dynamic_v
 impl<'a, T: crate::traits::OwnedStruct> crate::dynamic_value::DowncastReader<'a> for Reader<'a, T> {
     fn downcast_reader(v: crate::dynamic_value::Reader<'a>) -> Self {
         let dl: crate::dynamic_list::Reader = v.downcast();
-        assert_eq!(dl.element_type(), T::introspect());
+        assert!(dl.element_type().may_downcast_to(T::introspect()));
         Reader {
             reader: dl.reader,
             marker: PhantomData,
@@ -316,7 +316,7 @@ impl<'a, T: crate::traits::OwnedStruct> crate::dynamic_value::DowncastBuilder<'a
 {
     fn downcast_builder(v: crate::dynamic_value::Builder<'a>) -> Self {
         let dl: crate::dynamic_list::Builder = v.downcast();
-        assert_eq!(dl.element_type(), T::introspect());
+        assert!(dl.element_type().may_downcast_to(T::introspect()));
         Builder {
             builder: dl.builder,
             marker: PhantomData,

--- a/capnp/src/struct_list.rs
+++ b/capnp/src/struct_list.rs
@@ -291,12 +291,36 @@ impl<'a, T: crate::traits::OwnedStruct> From<Reader<'a, T>> for crate::dynamic_v
     }
 }
 
+impl<'a, T: crate::traits::OwnedStruct> crate::dynamic_value::DowncastReader<'a> for Reader<'a, T> {
+    fn downcast_reader(v: crate::dynamic_value::Reader<'a>) -> Self {
+        let dl: crate::dynamic_list::Reader = v.downcast();
+        assert_eq!(dl.element_type(), T::introspect());
+        Reader {
+            reader: dl.reader,
+            marker: PhantomData,
+        }
+    }
+}
+
 impl<'a, T: crate::traits::OwnedStruct> From<Builder<'a, T>> for crate::dynamic_value::Builder<'a> {
     fn from(t: Builder<'a, T>) -> crate::dynamic_value::Builder<'a> {
         crate::dynamic_value::Builder::List(crate::dynamic_list::Builder::new(
             t.builder,
             T::introspect(),
         ))
+    }
+}
+
+impl<'a, T: crate::traits::OwnedStruct> crate::dynamic_value::DowncastBuilder<'a>
+    for Builder<'a, T>
+{
+    fn downcast_builder(v: crate::dynamic_value::Builder<'a>) -> Self {
+        let dl: crate::dynamic_list::Builder = v.downcast();
+        assert_eq!(dl.element_type(), T::introspect());
+        Builder {
+            builder: dl.builder,
+            marker: PhantomData,
+        }
     }
 }
 

--- a/capnp/src/text_list.rs
+++ b/capnp/src/text_list.rs
@@ -250,12 +250,36 @@ impl<'a> From<Reader<'a>> for crate::dynamic_value::Reader<'a> {
     }
 }
 
+impl<'a> crate::dynamic_value::DowncastReader<'a> for Reader<'a> {
+    fn downcast_reader(v: crate::dynamic_value::Reader<'a>) -> Self {
+        let dl: crate::dynamic_list::Reader = v.downcast();
+        assert_eq!(
+            dl.element_type(),
+            crate::introspect::TypeVariant::Text.into()
+        );
+        Reader { reader: dl.reader }
+    }
+}
+
 impl<'a> From<Builder<'a>> for crate::dynamic_value::Builder<'a> {
     fn from(t: Builder<'a>) -> crate::dynamic_value::Builder<'a> {
         crate::dynamic_value::Builder::List(crate::dynamic_list::Builder {
             builder: t.builder,
             element_type: crate::introspect::TypeVariant::Text.into(),
         })
+    }
+}
+
+impl<'a> crate::dynamic_value::DowncastBuilder<'a> for Builder<'a> {
+    fn downcast_builder(v: crate::dynamic_value::Builder<'a>) -> Self {
+        let dl: crate::dynamic_list::Builder = v.downcast();
+        assert_eq!(
+            dl.element_type(),
+            crate::introspect::TypeVariant::Text.into()
+        );
+        Builder {
+            builder: dl.builder,
+        }
     }
 }
 

--- a/capnpc/test/dynamic.rs
+++ b/capnpc/test/dynamic.rs
@@ -408,3 +408,101 @@ fn test_get_named_missing() {
     assert!(root.get_named("zzzzzzz").is_err());
     assert!(root.has_named("zzzzzzz").is_err());
 }
+
+#[test]
+fn test_downcasts() {
+    let mut builder = message::Builder::new_default();
+    let root: test_all_types::Builder<'_> = builder.init_root();
+    let mut root: dynamic_value::Builder<'_> = root.into();
+
+    test_util::dynamic_init_test_message(root.reborrow().downcast());
+
+    {
+        let root_typed = root.reborrow().downcast_struct::<test_all_types::Owned>();
+        assert_eq!(root_typed.get_int16_field(), -12345);
+
+        let root_typed_reader = root
+            .reborrow()
+            .into_reader()
+            .downcast_struct::<test_all_types::Owned>();
+        assert_eq!(root_typed_reader.get_int16_field(), -12345);
+    }
+    let mut root_struct: dynamic_struct::Builder<'_> = root.reborrow().downcast();
+    {
+        let int8_list: capnp::primitive_list::Builder<'_, i8> = root_struct
+            .reborrow()
+            .get_named("int8List")
+            .unwrap()
+            .downcast();
+        assert_eq!(int8_list.len(), 2);
+    }
+
+    {
+        let struct_list: capnp::struct_list::Builder<'_, test_all_types::Owned> = root_struct
+            .reborrow()
+            .get_named("structList")
+            .unwrap()
+            .downcast();
+        assert_eq!(struct_list.len(), 3);
+    }
+
+    {
+        let enum_list: capnp::enum_list::Builder<'_, crate::test_capnp::TestEnum> = root_struct
+            .reborrow()
+            .get_named("enumList")
+            .unwrap()
+            .downcast();
+        assert_eq!(enum_list.len(), 2);
+    }
+
+    {
+        let text_list: capnp::text_list::Builder<'_> = root_struct
+            .reborrow()
+            .get_named("textList")
+            .unwrap()
+            .downcast();
+        assert_eq!(text_list.len(), 3);
+        assert_eq!(text_list.get(1).unwrap().to_str().unwrap(), "xyzzy");
+    }
+
+    {
+        let data_list: capnp::data_list::Builder<'_> = root_struct
+            .reborrow()
+            .get_named("dataList")
+            .unwrap()
+            .downcast();
+        assert_eq!(data_list.len(), 3);
+    }
+
+    let root_struct: dynamic_struct::Reader<'_> = root_struct.into_reader();
+    {
+        let int8_list: capnp::primitive_list::Reader<'_, i8> =
+            root_struct.get_named("int8List").unwrap().downcast();
+        assert_eq!(int8_list.len(), 2);
+    }
+
+    {
+        let struct_list: capnp::struct_list::Reader<'_, test_all_types::Owned> =
+            root_struct.get_named("structList").unwrap().downcast();
+        assert_eq!(struct_list.len(), 3);
+    }
+
+    {
+        let enum_list: capnp::enum_list::Reader<'_, crate::test_capnp::TestEnum> =
+            root_struct.get_named("enumList").unwrap().downcast();
+        assert_eq!(enum_list.len(), 2);
+    }
+
+    {
+        let text_list: capnp::text_list::Reader<'_> =
+            root_struct.get_named("textList").unwrap().downcast();
+        assert_eq!(text_list.len(), 3);
+        assert_eq!(text_list.get(1).unwrap().to_str().unwrap(), "xyzzy");
+    }
+
+    {
+        let data_list: capnp::data_list::Reader<'_> =
+            root_struct.get_named("dataList").unwrap().downcast();
+        assert_eq!(data_list.len(), 3);
+    }
+}

--- a/capnpc/test/test_util.rs
+++ b/capnpc/test/test_util.rs
@@ -430,6 +430,76 @@ pub fn dynamic_init_test_message(mut builder: ::capnp::dynamic_struct::Builder<'
         substruct.set_named("boolField", true.into()).unwrap();
         substruct.set_named("int8Field", (-12i8).into()).unwrap();
         substruct.set_named("int16Field", (3456i16).into()).unwrap();
+        substruct
+            .set_named("int32Field", (-78901234i32).into())
+            .unwrap();
+        substruct
+            .set_named("int64Field", (56789012345678i64).into())
+            .unwrap();
+        substruct.set_named("uInt8Field", (90u8).into()).unwrap();
+        substruct
+            .set_named("uInt16Field", (1234u16).into())
+            .unwrap();
+        substruct
+            .set_named("uInt32Field", (56789012u32).into())
+            .unwrap();
+        substruct
+            .set_named("uInt64Field", (345678901234567890u64).into())
+            .unwrap();
+        substruct
+            .set_named("float32Field", (-1.25e-10f32).into())
+            .unwrap();
+        substruct
+            .set_named("float64Field", (345f64).into())
+            .unwrap();
+        substruct.set_named("textField", "baz".into()).unwrap();
+        substruct.set_named("dataField", b"qux"[..].into()).unwrap();
+        {
+            let mut subsubstruct = substruct
+                .reborrow()
+                .init_named("structField")
+                .unwrap()
+                .downcast::<::capnp::dynamic_struct::Builder<'_>>();
+            subsubstruct
+                .set_named("textField", "nested".into())
+                .unwrap();
+            subsubstruct
+                .init_named("structField")
+                .unwrap()
+                .downcast::<::capnp::dynamic_struct::Builder<'_>>()
+                .set_named("textField", "really nested".into())
+                .unwrap();
+        }
+        substruct
+            .set_named("enumField", TestEnum::Baz.into())
+            .unwrap();
+
+        substruct.reborrow().initn_named("voidList", 3).unwrap();
+
+        {
+            let mut bool_list = substruct
+                .reborrow()
+                .initn_named("boolList", 5)
+                .unwrap()
+                .downcast::<::capnp::dynamic_list::Builder<'_>>();
+            bool_list.set(0, false.into()).unwrap();
+            bool_list.set(1, true.into()).unwrap();
+            bool_list.set(2, false.into()).unwrap();
+            bool_list.set(3, true.into()).unwrap();
+            bool_list.set(4, true.into()).unwrap();
+        }
+
+        {
+            let mut int8_list = substruct
+                .reborrow()
+                .initn_named("int8List", 4)
+                .unwrap()
+                .downcast::<::capnp::dynamic_list::Builder<'_>>();
+            int8_list.set(0, 12i8.into()).unwrap();
+            int8_list.set(1, (-34i8).into()).unwrap();
+            int8_list.set(2, (-0x80i8).into()).unwrap();
+            int8_list.set(3, (0x7fi8).into()).unwrap();
+        }
     }
     builder
         .set_named("enumField", TestEnum::Corge.into())


### PR DESCRIPTION
I wanted to make a blanket impl of the `DowncastReader` trait for all structs, but I don't see a way to get all the trait bounds/associated types to work out. So this is the next-best thing.