### PR TITLE
Allow to retrieve `ReaderSegments` object from reader objects

### DIFF
--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -298,6 +298,11 @@ where
     pub fn size_in_words(&self) -> usize {
         self.arena.size_in_words()
     }
+
+    /// Retrieves the underlying [`ReaderSegments`] object.
+    pub fn get_segments(&self) -> &S {
+        self.arena.get_segments()
+    }
 }
 
 /// A message reader whose value is known to be of type `T`.
@@ -329,6 +334,11 @@ where
 
     pub fn into_inner(self) -> Reader<S> {
         self.message
+    }
+
+    /// Retrieves the underlying [`ReaderSegments`] object.
+    pub fn get_segments(&self) -> &S {
+        self.message.get_segments()
     }
 }
 

--- a/capnp/src/private/arena.rs
+++ b/capnp/src/private/arena.rs
@@ -82,6 +82,10 @@ where
     pub fn into_segments(self) -> S {
         self.segments
     }
+
+    pub(crate) fn get_segments(&self) -> &S {
+        &self.segments
+    }
 }
 
 impl<S> ReaderArena for ReaderArenaImpl<S>


### PR DESCRIPTION
Closes #524 