### PR TITLE
capnp-futures: Use more fine-grained futures-* deps

### DIFF
--- a/capnp-futures/Cargo.toml
+++ b/capnp-futures/Cargo.toml
@@ -14,10 +14,15 @@ keywords = ["async"]
 [dependencies]
 capnp = { version = "0.20.0", path = "../capnp" }
 
-[dependencies.futures]
+[dependencies.futures-channel]
 version = "0.3.0"
 default-features = false
 features = ["std"]
+
+[dependencies.futures-util]
+version = "0.3.0"
+default-features = false
+features = ["io", "std"]
 
 [dev-dependencies.futures]
 version = "0.3.0"

--- a/capnp-futures/src/read_stream.rs
+++ b/capnp-futures/src/read_stream.rs
@@ -18,13 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use futures::future::Future;
-use futures::stream::Stream;
-use futures::AsyncRead;
+use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use capnp::{message, Error};
+use futures_util::stream::Stream;
+use futures_util::AsyncRead;
 
 async fn read_next_message<R>(
     mut reader: R,

--- a/capnp-futures/src/serialize.rs
+++ b/capnp-futures/src/serialize.rs
@@ -25,8 +25,7 @@
 
 use capnp::serialize::{OwnedSegments, SegmentLengthsBuilder};
 use capnp::{message, Error, OutputSegments, Result};
-
-use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use futures_util::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 /// Asynchronously reads a message from `reader`.
 pub async fn read_message<R>(

--- a/capnp-futures/src/serialize_packed.rs
+++ b/capnp-futures/src/serialize_packed.rs
@@ -27,7 +27,7 @@ use std::task::{Context, Poll};
 
 use capnp::serialize::OwnedSegments;
 use capnp::{message, Result};
-use futures::{AsyncRead, AsyncWrite};
+use futures_util::{AsyncRead, AsyncWrite};
 
 use crate::serialize::AsOutputSegments;
 

--- a/capnp-futures/src/write_queue.rs
+++ b/capnp-futures/src/write_queue.rs
@@ -18,9 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use futures::channel::oneshot;
-use futures::future::Future;
-use futures::{AsyncWrite, AsyncWriteExt, StreamExt, TryFutureExt};
+use std::future::Future;
+
+use futures_channel::oneshot;
+use futures_util::{AsyncWrite, AsyncWriteExt, StreamExt, TryFutureExt};
 
 use capnp::Error;
 
@@ -33,12 +34,13 @@ where
     Message(M, oneshot::Sender<M>),
     Done(Result<(), Error>, oneshot::Sender<()>),
 }
+
 /// A handle that allows messages to be sent to a write queue.
 pub struct Sender<M>
 where
     M: AsOutputSegments,
 {
-    sender: futures::channel::mpsc::UnboundedSender<Item<M>>,
+    sender: futures_channel::mpsc::UnboundedSender<Item<M>>,
     in_flight: std::sync::Arc<std::sync::atomic::AtomicI32>,
 }
 
@@ -65,7 +67,7 @@ where
     W: AsyncWrite + Unpin,
     M: AsOutputSegments,
 {
-    let (tx, mut rx) = futures::channel::mpsc::unbounded::<Item<M>>();
+    let (tx, mut rx) = futures_channel::mpsc::unbounded::<Item<M>>();
 
     let in_flight = std::sync::Arc::new(std::sync::atomic::AtomicI32::new(0));
 


### PR DESCRIPTION
The large futures crate pulls in a bunch of sub-crates that capnp-futures does not need. We can instead use only the subcrates that are actually required.