### PR TITLE
restore reason string behaviour pre 0.18

### DIFF
--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -356,7 +356,7 @@ fn to_pipeline_ops(
 }
 
 fn from_error(error: &Error, mut builder: exception::Builder) {
-    builder.set_reason(error.to_string());
+    builder.set_reason(&error.extra);
     let typ = match error.kind {
         ::capnp::ErrorKind::Failed => exception::Type::Failed,
         ::capnp::ErrorKind::Overloaded => exception::Type::Overloaded,

--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -412,7 +412,7 @@ fn pipelining_return_null() {
         match cap.foo_request().send().promise.await {
             Err(ref e) => {
                 if e.extra
-                    .contains("Pipeline call on a request that returned no capabilities")
+                     == "remote exception: Pipeline call on a request that returned no capabilities or was already closed."
                 {
                     Ok(())
                 } else {


### PR DESCRIPTION
Before 0.18.0 the reason string for an RPC error did not interpolate the kind inside. This makes sense because the type already has its own attribute.

This patch restores the original behaviour so that clients that rely on inspecting this error string can continue to operate as before.