### PR TITLE
Allow `ReaderSegments` to be implemented for references to unsized `ReaderSegments`

### DIFF
--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -167,7 +167,7 @@ pub trait ReaderSegments {
 
 impl<S> ReaderSegments for &S
 where
-    S: ReaderSegments,
+    S: ReaderSegments + ?Sized,
 {
     fn get_segment(&self, idx: u32) -> Option<&[u8]> {
         (**self).get_segment(idx)


### PR DESCRIPTION
Currently `&[&[u8]]` does not implement `ReaderSegments` despite `[&[u8]]` implementing it, because `[&[u8]]` is not `Sized`. `SegmentArray` exists to overcome this, but there's doesn't seem to be a need for forcing `Sized`, as all methods of `ReaderSegments` accept `Self` via a reference.