### PR TITLE
Set a smaller default traversal limit for targets with short pointers

### DIFF
--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -112,8 +112,15 @@ pub struct ReaderOptions {
     pub nesting_limit: i32,
 }
 
+#[cfg(not(target_pointer_width = "16"))]
 pub const DEFAULT_READER_OPTIONS: ReaderOptions = ReaderOptions {
     traversal_limit_in_words: Some(8 * 1024 * 1024),
+    nesting_limit: 64,
+};
+
+#[cfg(target_pointer_width = "16")]
+pub const DEFAULT_READER_OPTIONS: ReaderOptions = ReaderOptions {
+    traversal_limit_in_words: Some(1024),
     nesting_limit: 64,
 };
 

--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -120,7 +120,7 @@ pub const DEFAULT_READER_OPTIONS: ReaderOptions = ReaderOptions {
 
 #[cfg(target_pointer_width = "16")]
 pub const DEFAULT_READER_OPTIONS: ReaderOptions = ReaderOptions {
-    traversal_limit_in_words: Some(1024),
+    traversal_limit_in_words: Some(8 * 1024),
     nesting_limit: 64,
 };
 


### PR DESCRIPTION
The default traversal limit is set to `8 * 1024 * 1024`, which is substantially larger than the entire address space on a machine with 16-bit pointers. `rustc` therefore refuses to compile `capnpproto-rust` for such targets.

This patch adds a conditional compilation directive that sets the default traversal limit to `1024` when the `target_pointer_width` is 16. I chose this value by looking at the size of the default limit relative to the size of the address space for each pointer width; if I've done my math right, the normal default takes up 26 of the 32 bits of address space available to a 32-bit computer (2^3 bytes/word * 2^3 * 2^10 * 2^10 words), so I chose 1024 as the constant to take up 13 of the 16 bits in a system with 16-bit pointers (2^3 bytes/word * 2^10 words).

I will say that the default value should rarely matter for this sort of target in the first place. For example, my project is running capnproto out of a 128-byte single segment allocator, which should run out well before the traversal limit does, and that's if any malicious protos somehow manage to sneak onto the i2c bus in the first place.

(yes, this is a fairly absurd endeavor. i don't care, i'm having fun. :V )