### PR TITLE
restore old PartialEq impl and suppress warning

### DIFF
--- a/capnpc/test/dynamic.rs
+++ b/capnpc/test/dynamic.rs
@@ -507,6 +507,13 @@ fn test_downcasts() {
     }
 }
 
+// Function pointer equality is used in
+// `impl PartialEq for RawBrandedStructSchema`. On MIRI that implies
+// that all struct types are inequal.
+//
+// The plan is to remove that impl in the future, to avoid
+// unpleasant surprises.
+#[cfg_attr(miri, ignore)]
 #[test]
 fn introspect_equality() {
     use capnp::introspect::Introspect;

--- a/capnpc/test/dynamic.rs
+++ b/capnpc/test/dynamic.rs
@@ -1,4 +1,4 @@
-use crate::test_capnp::test_all_types;
+use crate::test_capnp::{test_all_types, test_defaults};
 use crate::test_util::{self};
 use capnp::message::{self};
 use capnp::{dynamic_list, dynamic_struct, dynamic_value};
@@ -505,4 +505,19 @@ fn test_downcasts() {
             root_struct.get_named("dataList").unwrap().downcast();
         assert_eq!(data_list.len(), 3);
     }
+}
+
+#[test]
+fn introspect_equality() {
+    use capnp::introspect::Introspect;
+
+    assert_eq!(
+        test_all_types::Owned::introspect(),
+        test_all_types::Owned::introspect()
+    );
+
+    assert_ne!(
+        test_all_types::Owned::introspect(),
+        test_defaults::Owned::introspect()
+    )
 }


### PR DESCRIPTION
Unfortunately, the approach in #537 fails for self-referential structs.

This PR restores the old impl, suppresses the rustc warning, and adds some comments explaining the situation.