### PR TITLE
Expand ReaderSegments implementations

### DIFF
--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -237,7 +237,8 @@ where
     }
 }
 
-impl<I> ReaderSegments for Vec<I>
+#[cfg(feature = "alloc")]
+impl<I> ReaderSegments for alloc::vec::Vec<I>
 where
     I: AsRef<[u8]>,
 {


### PR DESCRIPTION
The motivation for this change is: I wanted to call `Reader::new` with a  `Vec<Vec<u8>>` as backing storage, without manually converting the vectors to slices.

To that end, the main change of this PR is that I implement `ReaderSegments` for vectors of `AsRef<[u8]>`.

I initially tried to make a fully generic implementation for `AsRef<[AsRef<[u8]>]>`, but Rust's lack of specializations interfered. However, one of the remaining artifacts of that attempt is the replacement of `impl ReaderSegments for [&[u8]]` with `impl<I: AsRef<[u8]>> ReaderSegments for [I]` — in human terms, for a slice of anything you can easily convert to `&[u8]`. I include that in this PR too.

I also noticed that `is_empty` was using the sub-optimal default implementation in these impls, so I correct that as well.

Finally, I add a bit of documentation to the impl for `&ReaderSegments`, to demonstrate (and enforce through doctests) that it is (still) possible to conveniently create a Reader from a static slice-of-slices.