### PR TITLE
capnpc-rust: make CLI plugin aware of `default_parent_module`

### DIFF
--- a/capnpc/src/capnpc-rust.rs
+++ b/capnpc/src/capnpc-rust.rs
@@ -28,8 +28,14 @@
 pub fn main() {
     //! Generates Rust code according to a `schema_capnp::code_generator_request` read from stdin.
 
-    ::capnpc::codegen::CodeGenerationCommand::new()
-        .output_directory(::std::path::Path::new("."))
-        .run(::std::io::stdin())
+    let mut cmd = ::capnpc::codegen::CodeGenerationCommand::new();
+    cmd.output_directory(::std::path::Path::new("."));
+
+    if let Ok(parent_module) = std::env::var("CAPNPC_RUST_DEFAULT_PARENT_MODULE") {
+        let modules = parent_module.split("::").map(ToString::to_string).collect();
+        cmd.default_parent_module(modules);
+    }
+
+    cmd.run(::std::io::stdin())
         .expect("failed to generate code");
 }


### PR DESCRIPTION
This enhances the `capnpc-rust` CLI plugin binary in order to make the default "parent module" value dynamic and controlled through an environment flag at runtime.

It matches the behavior which is already available for `build.rs` scripts through `CompilerCommand::default_parent_module()`.
This only affects the default value, which can be still overridden by `parentModule` schema annotations as usual.

When using the Rust plugin through the `capnp` compiler, it is now possible to set the default parent module like this:
```
CAPNPC_RUST_DEFAULT_PARENT_MODULE="generated" capnp \
  compile \
  -orust:./src/generated/ \
  --src-prefix=src/schema \
  ./src/schema/poc.capnp
```