### PR TITLE
Use SetterInput for more setters

### DIFF
--- a/capnp/src/data.rs
+++ b/capnp/src/data.rs
@@ -82,6 +82,21 @@ impl<'a> crate::traits::SetterInput<Owned> for Reader<'a> {
     }
 }
 
+impl<'a, const N: usize> crate::traits::SetterInput<Owned> for &'a [u8; N] {
+    #[inline]
+    fn set_pointer_builder<'b>(
+        pointer: PointerBuilder<'b>,
+        value: &'a [u8; N],
+        canonicalize: bool,
+    ) -> Result<()> {
+        <Reader<'a> as crate::traits::SetterInput<Owned>>::set_pointer_builder(
+            pointer,
+            &value[..],
+            canonicalize,
+        )
+    }
+}
+
 impl<'a> From<Reader<'a>> for crate::dynamic_value::Reader<'a> {
     fn from(d: Reader<'a>) -> crate::dynamic_value::Reader<'a> {
         crate::dynamic_value::Reader::Data(d)

--- a/capnp/src/data_list.rs
+++ b/capnp/src/data_list.rs
@@ -22,7 +22,7 @@
 //! List of sequences of bytes.
 
 use crate::private::layout::*;
-use crate::traits::{FromPointerBuilder, FromPointerReader, IndexMove, ListIter};
+use crate::traits::{FromPointerBuilder, FromPointerReader, IndexMove, ListIter, SetterInput};
 use crate::Result;
 
 #[derive(Copy, Clone)]
@@ -134,12 +134,17 @@ impl<'a> Builder<'a> {
         }
     }
 
-    pub fn set(&mut self, index: u32, value: crate::data::Reader) {
+    #[inline]
+    pub fn set(&mut self, index: u32, value: impl SetterInput<crate::data::Owned>) {
         assert!(index < self.len());
-        self.builder
-            .reborrow()
-            .get_pointer_element(index)
-            .set_data(value);
+        SetterInput::set_pointer_builder(
+            self.builder.reborrow().get_pointer_element(index),
+            value,
+            false,
+        )
+        .unwrap()
+        // The text impls of SetterInput never return an error, so
+        // the above unwrap() won't panic.
     }
 
     pub fn reborrow(&mut self) -> Builder<'_> {

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -1524,10 +1524,8 @@ mod tests {
                 .allocation_strategy(::capnp::message::AllocationStrategy::FixedSize);
             let mut message2 = message::Builder::new(builder_options);
             let mut all_types2 = message2.init_root::<test_all_types::Builder<'_>>();
-
-            all_types2
-                .set_struct_field(message.get_root_as_reader().unwrap())
-                .unwrap();
+            let root_reader: test_all_types::Reader<'_> = message.get_root_as_reader().unwrap();
+            all_types2.set_struct_field(root_reader).unwrap();
             CheckTestMessage::check_test_message(all_types2.reborrow().get_struct_field().unwrap());
 
             let reader = all_types2.into_reader().get_struct_field().unwrap();


### PR DESCRIPTION
This changes more of the setters both manually implemented and generated to accept a SetterInput.

This makes it useful to implement SetterInput on your own types to support using them with setters.

This is especially useful when you have plain rust structs the represent the capnp-struct and you just want convert one to the other and is my main use case.

I don't know if this is a breaking change like how originally implementing SetterInput was.