### PR TITLE
Properly size the destination in flatten_segments

### DIFF
--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -536,7 +536,7 @@ where
 
 #[cfg(feature = "alloc")]
 fn flatten_segments<R: message::ReaderSegments + ?Sized>(segments: &R) -> alloc::vec::Vec<u8> {
-    let word_count = compute_serialized_size(segments);
+    let word_count = compute_serialized_size(segments) * BYTES_PER_WORD;
     let segment_count = segments.len();
     let table_size = segment_count / 2 + 1;
     let mut result = alloc::vec::Vec::with_capacity(word_count);
@@ -549,6 +549,10 @@ fn flatten_segments<R: message::ReaderSegments + ?Sized>(segments: &R) -> alloc:
         let segment = segments.get_segment(i as u32).unwrap();
         result.extend(segment);
     }
+    debug_assert!(
+        result.capacity() == word_count,
+        "unexpected result capacity growth"
+    );
     result
 }
 


### PR DESCRIPTION
We've observed unexpected reallocations on some flamegraphs here.

<img width="1501" height="638" alt="image" src="https://github.com/user-attachments/assets/d3036f94-6f2a-4e39-902d-7b106a933048" />

Looks like it stems from 5afd805528ae8df5eb78407c926fb615e1e5fe97. cc @dwrensha

