### PR TITLE
Resolve Field type in creation

### DIFF
--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -132,6 +132,7 @@ impl From<RawBrandedStructSchema> for StructSchema {
 pub struct Field {
     proto: field::Reader<'static>,
     index: u16,
+    kind: introspect::Type,
     pub(crate) parent: StructSchema,
 }
 
@@ -141,7 +142,7 @@ impl Field {
     }
 
     pub fn get_type(&self) -> introspect::Type {
-        (self.parent.raw.field_types)(self.index)
+        self.kind
     }
 
     pub fn get_index(&self) -> u16 {
@@ -177,6 +178,7 @@ impl FieldList {
         Field {
             proto: self.fields.get(index as u32),
             index,
+            kind: (self.parent.raw.field_types)(index),
             parent: self.parent,
         }
     }
@@ -223,6 +225,7 @@ impl FieldSubset {
         Field {
             proto: self.fields.get(index as u32),
             index,
+            kind: (self.parent.raw.field_types)(index),
             parent: self.parent,
         }
     }


### PR DESCRIPTION
We have this loop to resolve arbitrary user supplied inner fields based on `foo.bar.baz` paths:

```rust
            for path in paths {
                let field = *fields.get(path).unwrap();

                if let TypeVariant::Struct(_) = field.get_type().which() {
                    builder = if builder.has(field)? {
                        builder.get(field).unwrap()
                    } else if init_inactive_fields {
                        builder.init(field).unwrap()
                    } else {
                        return Err(Error {
                            kind: ErrorKind::Failed,
                            extra: format!("field {path} exists, but is uninitialized"),
                        });
                    }
                    .downcast();
                } else {
                    return Err(Error {
                        kind: ErrorKind::NotAStruct,
                        extra: path.to_string(),
                    });
                }
            }
```

There are probably better ways to do this, but that's what we have.

If you get a flamegraph of a benchmark for this, you can see a bunch of calls into `Field::get_type()`:

<img width="1512" height="341" alt="image" src="https://github.com/user-attachments/assets/a4e329ba-fbda-4a12-8cff-a2920adcd71c" />

To enumerate:

* There's a direct call: `if let TypeVariant::Struct(_) = field.get_type().which() {`
* There's a call through `builder.has()`
* There's a call through `builder.get()`

It's about 10% of on-CPU time overall in a benchmark.

It's probably expected that `Field::get_type()` would be called at least once during `Field`'s lifetime, probably more, so we should front load this cost and have the type available immediately.

With this change applied the flamegraph has less CPU time spent in type resolution:

<img width="1512" height="340" alt="image" src="https://github.com/user-attachments/assets/d209c7c9-2937-47fc-91ff-d4cb6a859ff0" />

This lowers on-CPU time to about 1.3%.