### PR TITLE
bump versions to 0.22.0-alpha

### DIFF
--- a/capnp-futures/Cargo.toml
+++ b/capnp-futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "capnp-futures"
-version = "0.21.0"
+version = "0.22.0-alpha"
 authors = [ "David Renshaw <drenshaw@gmail.com>" ]
 license = "MIT"
 
@@ -12,7 +12,7 @@ edition = "2021"
 keywords = ["async"]
 
 [dependencies]
-capnp = { version = "0.21.0", path = "../capnp" }
+capnp = { version = "0.22.0-alpha", path = "../capnp" }
 
 [dependencies.futures-channel]
 version = "0.3.0"
@@ -30,7 +30,7 @@ default-features = false
 features = ["executor"]
 
 [dev-dependencies]
-capnp = { version = "0.21.0", path = "../capnp", features = ["quickcheck"] }
+capnp = { version = "0.22.0-alpha", path = "../capnp", features = ["quickcheck"] }
 quickcheck = "1"
 
 [lints]

--- a/capnp-rpc/Cargo.toml
+++ b/capnp-rpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "capnp-rpc"
-version = "0.21.0"
+version = "0.22.0-alpha"
 authors = [ "David Renshaw <dwrenshaw@gmail.com>" ]
 license = "MIT"
 description = "implementation of the Cap'n Proto remote procedure call protocol"
@@ -19,8 +19,8 @@ default-features = false
 features = ["std"]
 
 [dependencies]
-capnp-futures = { version = "0.21.0", path = "../capnp-futures" }
-capnp = {version = "0.21.0", path = "../capnp"}
+capnp-futures = { version = "0.22.0-alpha", path = "../capnp-futures" }
+capnp = {version = "0.22.0-alpha", path = "../capnp"}
 
 #[lints]
 #workspace = true

--- a/capnp/Cargo.toml
+++ b/capnp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "capnp"
-version = "0.21.7"
+version = "0.22.0-alpha"
 authors = [ "David Renshaw <dwrenshaw@gmail.com>" ]
 license = "MIT"
 description = "runtime library for Cap'n Proto data encoding"

--- a/capnpc/Cargo.toml
+++ b/capnpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "capnpc"
-version = "0.21.4"
+version = "0.22.0-alpha"
 authors = [ "David Renshaw <dwrenshaw@gmail.com>" ]
 license = "MIT"
 description = "Cap'n Proto code generation"
@@ -25,7 +25,7 @@ path = "src/capnpc-rust-bootstrap.rs"
 
 
 [dependencies.capnp]
-version = "0.21.5"
+version = "0.22.0-alpha"
 path = "../capnp"
 
 [lints]


### PR DESCRIPTION
This is to prepare for landing breaking changes.