### PR TITLE
remove remaining async block from codegen

### DIFF
--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -2653,7 +2653,7 @@ fn generate_node(
 
                     server_interior.push(
                         Line(fmt!(ctx,
-                                  "fn {}(self: {capnp}::capability::Rc<Self>, _: {}Params<{}>) -> impl ::core::future::Future<Output = Result<(), {capnp}::Error>> + 'static {{ async {{ Err({capnp}::Error::unimplemented(\"method {}::Server::{} not implemented\".to_string())) }} }}",
+                                  "fn {}(self: {capnp}::capability::Rc<Self>, _: {}Params<{}>) -> impl ::core::future::Future<Output = Result<(), {capnp}::Error>> + 'static {{ ::core::future::ready(Err({capnp}::Error::unimplemented(\"method {}::Server::{} not implemented\".to_string()))) }}",
                                   module_name(name),
                                   capitalize_first_letter(name), params_ty_params,
                                   node_name, module_name(name)

--- a/capnpc/test/test.capnp
+++ b/capnpc/test/test.capnp
@@ -861,3 +861,7 @@ struct Issue260(T, Q) {
     val2 @3 :Int8;
   }
 }
+
+interface TestStream {
+  send @0 (data : Data) -> stream;
+}


### PR DESCRIPTION
This wasn't caught previously because the test schema didn't have any streaming methods, so the code path was never hit.