### PR TITLE
chore: allow(unsafe_code) in generated code

### DIFF
--- a/capnp/src/lib.rs
+++ b/capnp/src/lib.rs
@@ -85,6 +85,7 @@ macro_rules! generated_code {
     ($vis:vis mod $mod_name:ident, $file_name:expr) => {
         $vis mod $mod_name {
             #![allow(clippy::all)]
+            #![allow(unsafe_code)]
             include!(concat!(env!("OUT_DIR"), "/", $file_name));
         }
     };


### PR DESCRIPTION
`capnpc-rust` starts generating code with `unsafe` block after https://github.com/capnproto/capnproto-rust/pull/607. Therefore, add `#[allow(unsafe_code)]` to avoid warnings or errors as much as possible.

However, IMHO, introducing `unsafe` block to generated code might be an obstacle for projects using `#![forbid(unsafe_code)]` to guarantee the use of safe Rust only. Some of the projects will need to relax their guarantee to be able to use capnproto-rust, like https://github.com/o1-labs/mina-network-debugger/blob/main/mina-ipc/src/lib.rs.

Additionally, I'm not sure about whether adding these `#![allow]` to the top of the generated file is a better idea, so I chose to follow the existing one.

P.S., Actually, we already have a `#![allow]` in generated file: https://github.com/capnproto/capnproto-rust/blob/9c1058bae93a78798563c2df94de1147fbae3c24/capnpc/src/codegen.rs#L2555

^ I'm more than happy to move `#![allow]` to generated file if this is suitable.