### PR TITLE
More ergonomic which

### DIFF
--- a/benchmark/eval.rs
+++ b/benchmark/eval.rs
@@ -57,11 +57,11 @@ fn make_expression(rng: &mut FastRand, mut exp: expression::Builder, depth: u32)
 fn evaluate_expression(exp: expression::Reader) -> ::capnp::Result<i32> {
     let left = match exp.get_left().which()? {
         expression::left::Value(v) => v,
-        expression::left::Expression(e) => evaluate_expression(e?)?,
+        expression::left::Expression(e) => evaluate_expression(e)?,
     };
     let right = match exp.get_right().which()? {
         expression::right::Value(v) => v,
-        expression::right::Expression(e) => evaluate_expression(e?)?,
+        expression::right::Expression(e) => evaluate_expression(e)?,
     };
 
     match exp.get_op()? {

--- a/capnp-rpc/examples/calculator/server.rs
+++ b/capnp-rpc/examples/calculator/server.rs
@@ -62,8 +62,7 @@ fn evaluate_impl(
     match pry!(expression.which()) {
         calculator::expression::Literal(v) => Promise::ok(v),
         calculator::expression::PreviousResult(p) => Promise::from_future(
-            pry!(p)
-                .read_request()
+            p.read_request()
                 .send()
                 .promise
                 .map(|v| Ok(v?.get()?.get_value())),

--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -709,27 +709,24 @@ impl<VatId> ConnectionState<VatId> {
         message: message::Reader,
     ) -> capnp::Result<()> {
         match message.which()? {
-            message::Resolve(resolve) => {
-                let resolve = resolve?;
-                match resolve.which()? {
-                    resolve::Cap(c) => match c?.which()? {
-                        cap_descriptor::None(()) => (),
-                        cap_descriptor::SenderHosted(export_id) => {
-                            connection_state.release_export(export_id, 1)?;
-                        }
-                        cap_descriptor::SenderPromise(export_id) => {
-                            connection_state.release_export(export_id, 1)?;
-                        }
-                        cap_descriptor::ReceiverAnswer(_) | cap_descriptor::ReceiverHosted(_) => (),
-                        cap_descriptor::ThirdPartyHosted(_) => {
-                            return Err(Error::failed(
-                                "Peer claims we resolved a ThirdPartyHosted cap.".to_string(),
-                            ));
-                        }
-                    },
-                    resolve::Exception(_) => (),
-                }
-            }
+            message::Resolve(resolve) => match resolve.which()? {
+                resolve::Cap(c) => match c.which()? {
+                    cap_descriptor::None(()) => (),
+                    cap_descriptor::SenderHosted(export_id) => {
+                        connection_state.release_export(export_id, 1)?;
+                    }
+                    cap_descriptor::SenderPromise(export_id) => {
+                        connection_state.release_export(export_id, 1)?;
+                    }
+                    cap_descriptor::ReceiverAnswer(_) | cap_descriptor::ReceiverHosted(_) => (),
+                    cap_descriptor::ThirdPartyHosted(_) => {
+                        return Err(Error::failed(
+                            "Peer claims we resolved a ThirdPartyHosted cap.".to_string(),
+                        ));
+                    }
+                },
+                resolve::Exception(_) => (),
+            },
             _ => {
                 return Err(Error::failed(
                     "Peer did not implement required RPC message type.".to_string(),
@@ -826,7 +823,7 @@ impl<VatId> ConnectionState<VatId> {
 
     fn handle_resolve(connection_state: &Rc<Self>, resolve: resolve::Reader) -> capnp::Result<()> {
         let replacement_or_error = match resolve.which()? {
-            resolve::Cap(c) => match Self::receive_cap(connection_state, c?)? {
+            resolve::Cap(c) => match Self::receive_cap(connection_state, c)? {
                 Some(cap) => Ok(cap),
                 None => {
                     return Err(Error::failed(
@@ -839,7 +836,7 @@ impl<VatId> ConnectionState<VatId> {
                 // confuse PromiseClient::Resolve() into thinking that the remote
                 // promise resolved to a local capability and therefore a Disembargo is
                 // needed. We must actually reject the promise.
-                Err(remote_exception_to_error(e?))
+                Err(remote_exception_to_error(e))
             }
         };
 
@@ -946,14 +943,13 @@ impl<VatId> ConnectionState<VatId> {
         let reader = message.get_body()?.get_as::<message::Reader>()?;
         match reader.which() {
             Ok(message::Unimplemented(message)) => {
-                Self::handle_unimplemented(&connection_state, message?)?
+                Self::handle_unimplemented(&connection_state, message)?
             }
-            Ok(message::Abort(abort)) => return Err(remote_exception_to_error(abort?)),
+            Ok(message::Abort(abort)) => return Err(remote_exception_to_error(abort)),
             Ok(message::Bootstrap(bootstrap)) => {
-                Self::handle_bootstrap(&connection_state, bootstrap?)?
+                Self::handle_bootstrap(&connection_state, bootstrap)?
             }
             Ok(message::Call(call)) => {
-                let call = call?;
                 let capability = connection_state.get_message_target(call.get_target()?)?;
                 let (interface_id, method_id, question_id, cap_table_array, redirect_results) = {
                     let redirect_results = match call.get_send_results_to().which()? {
@@ -1063,7 +1059,7 @@ impl<VatId> ConnectionState<VatId> {
                 }
             }
             Ok(message::Return(oret)) => {
-                let ret = oret?;
+                let ret = oret;
                 let question_id = ret.get_answer_id();
 
                 let mut questions = connection_state.questions.borrow_mut();
@@ -1078,7 +1074,7 @@ impl<VatId> ConnectionState<VatId> {
                                 return_::Results(results) => {
                                     let cap_table = Self::receive_caps(
                                         &connection_state,
-                                        results?.get_cap_table()?,
+                                        results.get_cap_table()?,
                                     )?;
 
                                     let question_ref =
@@ -1094,7 +1090,7 @@ impl<VatId> ConnectionState<VatId> {
                                 return_::Exception(e) => {
                                     let tmp =
                                         question_ref.upgrade().expect("dangling question ref?");
-                                    tmp.borrow_mut().reject(remote_exception_to_error(e?));
+                                    tmp.borrow_mut().reject(remote_exception_to_error(e));
                                 }
                                 return_::Canceled(_) => {
                                     Self::send_unimplemented(&connection_state, message.as_ref())?;
@@ -1149,14 +1145,13 @@ impl<VatId> ConnectionState<VatId> {
                     }
                 }
             }
-            Ok(message::Finish(finish)) => Self::handle_finish(&connection_state, finish?)?,
-            Ok(message::Resolve(resolve)) => Self::handle_resolve(&connection_state, resolve?)?,
+            Ok(message::Finish(finish)) => Self::handle_finish(&connection_state, finish)?,
+            Ok(message::Resolve(resolve)) => Self::handle_resolve(&connection_state, resolve)?,
             Ok(message::Release(release)) => {
-                let release = release?;
                 connection_state.release_export(release.get_id(), release.get_reference_count())?;
             }
             Ok(message::Disembargo(disembargo)) => {
-                Self::handle_disembargo(&connection_state, disembargo?)?
+                Self::handle_disembargo(&connection_state, disembargo)?
             }
             Ok(
                 message::Provide(_)
@@ -1165,7 +1160,7 @@ impl<VatId> ConnectionState<VatId> {
                 | message::ObsoleteSave(_)
                 | message::ObsoleteDelete(_),
             )
-            | Err(::capnp::NotInSchema(_)) => {
+            | Err(_) => {
                 Self::send_unimplemented(&connection_state, message.as_ref())?;
             }
         }
@@ -1234,7 +1229,6 @@ impl<VatId> ConnectionState<VatId> {
                 }
             }
             message_target::PromisedAnswer(promised_answer) => {
-                let promised_answer = promised_answer?;
                 let question_id = promised_answer.get_question_id();
 
                 let pipeline = match self.answers.borrow().slots.get(&question_id) {
@@ -1578,7 +1572,7 @@ impl<VatId> ConnectionState<VatId> {
                 }
             }
             cap_descriptor::ReceiverAnswer(receiver_answer) => {
-                let promised_answer = receiver_answer?;
+                let promised_answer = receiver_answer;
                 let question_id = promised_answer.get_question_id();
                 if let Some(answer) = state.answers.borrow().slots.get(&question_id) {
                     if let Some(ref pipeline) = answer.pipeline {
@@ -1737,8 +1731,8 @@ impl<VatId> ResponseHook for Response<VatId> {
                     .get_as::<message::Reader>()?
                     .which()?
                 {
-                    message::Return(Ok(ret)) => match ret.which()? {
-                        return_::Results(Ok(mut payload)) => {
+                    message::Return(ret) => match ret.which()? {
+                        return_::Results(mut payload) => {
                             use ::capnp::traits::Imbue;
                             payload.imbue(&state.cap_table);
                             Ok(payload.get_content())
@@ -1766,7 +1760,7 @@ where
 fn get_call(message: &mut Box<dyn crate::OutgoingMessage>) -> ::capnp::Result<call::Builder<'_>> {
     let message_root: message::Builder = message.get_body()?.get_as()?;
     match message_root.which()? {
-        message::Call(call) => call,
+        message::Call(call) => Ok(call),
         _ => {
             unimplemented!()
         }
@@ -2270,7 +2264,7 @@ impl ParamsHook for Params {
             unreachable!()
         };
         use ::capnp::traits::Imbue;
-        let mut content = call?.get_params()?.get_content();
+        let mut content = call.get_params()?.get_content();
         content.imbue(&self.cap_table);
         Ok(content)
     }
@@ -2393,10 +2387,10 @@ impl<VatId> ResultsHook for Results<VatId> {
                 let message::Return(ret) = root.which()? else {
                     unreachable!();
                 };
-                let return_::Results(payload) = ret?.which()? else {
+                let return_::Results(payload) = ret.which()? else {
                     unreachable!()
                 };
-                let mut content = payload?.get_content();
+                let mut content = payload.get_content();
                 content.imbue_mut(cap_table);
                 Ok(content)
             }
@@ -2547,14 +2541,14 @@ impl ResultsDone {
                             (false, Ok(())) => {
                                 let exports = {
                                     let root: message::Builder = message.get_body()?.get_as()?;
-                                    let message::Return(Ok(mut ret)) = root.which()? else {
+                                    let message::Return(mut ret) = root.which()? else {
                                         unreachable!()
                                     };
                                     if cap_table.is_empty() {
                                         ret.set_no_finish_needed(true);
                                         finish_received.set(true);
                                     }
-                                    let crate::rpc_capnp::return_::Results(Ok(payload)) =
+                                    let crate::rpc_capnp::return_::Results(payload) =
                                         ret.which()?
                                     else {
                                         unreachable!()
@@ -2645,10 +2639,10 @@ impl ResultsDoneHook for ResultsDone {
                 let message::Return(ret) = root.which()? else {
                     unreachable!();
                 };
-                let crate::rpc_capnp::return_::Results(payload) = ret?.which()? else {
+                let crate::rpc_capnp::return_::Results(payload) = ret.which()? else {
                     unreachable!();
                 };
-                let mut content = payload?.get_content();
+                let mut content = payload.get_content();
                 content.imbue(cap_table);
                 Ok(content)
             }

--- a/capnp-rpc/src/rpc_capnp.rs
+++ b/capnp-rpc/src/rpc_capnp.rs
@@ -207,49 +207,49 @@ pub mod message {
             !self.reader.get_pointer_field(0).is_null()
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::Error> {
             match self.reader.get_data_field::<u16>(0) {
                 0 => ::core::result::Result::Ok(Unimplemented(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 1 => ::core::result::Result::Ok(Abort(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 2 => ::core::result::Result::Ok(Call(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 3 => ::core::result::Result::Ok(Return(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 4 => ::core::result::Result::Ok(Finish(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 5 => ::core::result::Result::Ok(Resolve(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 6 => ::core::result::Result::Ok(Release(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 7 => ::core::result::Result::Ok(ObsoleteSave(::capnp::any_pointer::Reader::new(
                     self.reader.get_pointer_field(0),
@@ -258,7 +258,7 @@ pub mod message {
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 9 => ::core::result::Result::Ok(ObsoleteDelete(::capnp::any_pointer::Reader::new(
                     self.reader.get_pointer_field(0),
@@ -267,27 +267,27 @@ pub mod message {
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 11 => ::core::result::Result::Ok(Accept(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 12 => ::core::result::Result::Ok(Join(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 13 => ::core::result::Result::Ok(Disembargo(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
-                x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
             }
         }
     }
@@ -695,49 +695,49 @@ pub mod message {
             !self.builder.is_pointer_field_null(0)
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::Error> {
             match self.builder.get_data_field::<u16>(0) {
                 0 => ::core::result::Result::Ok(Unimplemented(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 1 => ::core::result::Result::Ok(Abort(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 2 => ::core::result::Result::Ok(Call(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 3 => ::core::result::Result::Ok(Return(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 4 => ::core::result::Result::Ok(Finish(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 5 => ::core::result::Result::Ok(Resolve(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 6 => ::core::result::Result::Ok(Release(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 7 => ::core::result::Result::Ok(ObsoleteSave(::capnp::any_pointer::Builder::new(
                     self.builder.get_pointer_field(0),
@@ -746,7 +746,7 @@ pub mod message {
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 9 => ::core::result::Result::Ok(ObsoleteDelete(
                     ::capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0)),
@@ -755,27 +755,27 @@ pub mod message {
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 11 => ::core::result::Result::Ok(Accept(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 12 => ::core::result::Result::Ok(Join(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 13 => ::core::result::Result::Ok(Disembargo(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
-                x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
             }
         }
     }
@@ -1083,36 +1083,36 @@ pub mod message {
         Disembargo(A13),
     }
     pub type WhichReader<'a> = Which<
-        ::capnp::Result<crate::rpc_capnp::message::Reader<'a>>,
-        ::capnp::Result<crate::rpc_capnp::exception::Reader<'a>>,
-        ::capnp::Result<crate::rpc_capnp::call::Reader<'a>>,
-        ::capnp::Result<crate::rpc_capnp::return_::Reader<'a>>,
-        ::capnp::Result<crate::rpc_capnp::finish::Reader<'a>>,
-        ::capnp::Result<crate::rpc_capnp::resolve::Reader<'a>>,
-        ::capnp::Result<crate::rpc_capnp::release::Reader<'a>>,
+        crate::rpc_capnp::message::Reader<'a>,
+        crate::rpc_capnp::exception::Reader<'a>,
+        crate::rpc_capnp::call::Reader<'a>,
+        crate::rpc_capnp::return_::Reader<'a>,
+        crate::rpc_capnp::finish::Reader<'a>,
+        crate::rpc_capnp::resolve::Reader<'a>,
+        crate::rpc_capnp::release::Reader<'a>,
         ::capnp::any_pointer::Reader<'a>,
-        ::capnp::Result<crate::rpc_capnp::bootstrap::Reader<'a>>,
+        crate::rpc_capnp::bootstrap::Reader<'a>,
         ::capnp::any_pointer::Reader<'a>,
-        ::capnp::Result<crate::rpc_capnp::provide::Reader<'a>>,
-        ::capnp::Result<crate::rpc_capnp::accept::Reader<'a>>,
-        ::capnp::Result<crate::rpc_capnp::join::Reader<'a>>,
-        ::capnp::Result<crate::rpc_capnp::disembargo::Reader<'a>>,
+        crate::rpc_capnp::provide::Reader<'a>,
+        crate::rpc_capnp::accept::Reader<'a>,
+        crate::rpc_capnp::join::Reader<'a>,
+        crate::rpc_capnp::disembargo::Reader<'a>,
     >;
     pub type WhichBuilder<'a> = Which<
-        ::capnp::Result<crate::rpc_capnp::message::Builder<'a>>,
-        ::capnp::Result<crate::rpc_capnp::exception::Builder<'a>>,
-        ::capnp::Result<crate::rpc_capnp::call::Builder<'a>>,
-        ::capnp::Result<crate::rpc_capnp::return_::Builder<'a>>,
-        ::capnp::Result<crate::rpc_capnp::finish::Builder<'a>>,
-        ::capnp::Result<crate::rpc_capnp::resolve::Builder<'a>>,
-        ::capnp::Result<crate::rpc_capnp::release::Builder<'a>>,
+        crate::rpc_capnp::message::Builder<'a>,
+        crate::rpc_capnp::exception::Builder<'a>,
+        crate::rpc_capnp::call::Builder<'a>,
+        crate::rpc_capnp::return_::Builder<'a>,
+        crate::rpc_capnp::finish::Builder<'a>,
+        crate::rpc_capnp::resolve::Builder<'a>,
+        crate::rpc_capnp::release::Builder<'a>,
         ::capnp::any_pointer::Builder<'a>,
-        ::capnp::Result<crate::rpc_capnp::bootstrap::Builder<'a>>,
+        crate::rpc_capnp::bootstrap::Builder<'a>,
         ::capnp::any_pointer::Builder<'a>,
-        ::capnp::Result<crate::rpc_capnp::provide::Builder<'a>>,
-        ::capnp::Result<crate::rpc_capnp::accept::Builder<'a>>,
-        ::capnp::Result<crate::rpc_capnp::join::Builder<'a>>,
-        ::capnp::Result<crate::rpc_capnp::disembargo::Builder<'a>>,
+        crate::rpc_capnp::provide::Builder<'a>,
+        crate::rpc_capnp::accept::Builder<'a>,
+        crate::rpc_capnp::join::Builder<'a>,
+        crate::rpc_capnp::disembargo::Builder<'a>,
     >;
 }
 
@@ -2113,14 +2113,14 @@ pub mod call {
                 !self.reader.get_pointer_field(2).is_null()
             }
             #[inline]
-            pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
+            pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::Error> {
                 match self.reader.get_data_field::<u16>(3) {
                     0 => ::core::result::Result::Ok(Caller(())),
                     1 => ::core::result::Result::Ok(Yourself(())),
                     2 => ::core::result::Result::Ok(ThirdParty(::capnp::any_pointer::Reader::new(
                         self.reader.get_pointer_field(2),
                     ))),
-                    x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                    x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
                 }
             }
         }
@@ -2240,14 +2240,14 @@ pub mod call {
                 !self.builder.is_pointer_field_null(2)
             }
             #[inline]
-            pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
+            pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::Error> {
                 match self.builder.get_data_field::<u16>(3) {
                     0 => ::core::result::Result::Ok(Caller(())),
                     1 => ::core::result::Result::Ok(Yourself(())),
                     2 => ::core::result::Result::Ok(ThirdParty(
                         ::capnp::any_pointer::Builder::new(self.builder.get_pointer_field(2)),
                     )),
-                    x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                    x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
                 }
             }
         }
@@ -2509,19 +2509,19 @@ pub mod return_ {
             self.reader.get_bool_field(33)
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::Error> {
             match self.reader.get_data_field::<u16>(3) {
                 0 => ::core::result::Result::Ok(Results(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 1 => ::core::result::Result::Ok(Exception(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 2 => ::core::result::Result::Ok(Canceled(())),
                 3 => ::core::result::Result::Ok(ResultsSentElsewhere(())),
@@ -2531,7 +2531,7 @@ pub mod return_ {
                 5 => ::core::result::Result::Ok(AcceptFromThirdParty(
                     ::capnp::any_pointer::Reader::new(self.reader.get_pointer_field(0)),
                 )),
-                x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
             }
         }
     }
@@ -2722,19 +2722,19 @@ pub mod return_ {
             self.builder.set_bool_field(33, value);
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::Error> {
             match self.builder.get_data_field::<u16>(3) {
                 0 => ::core::result::Result::Ok(Results(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 1 => ::core::result::Result::Ok(Exception(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 2 => ::core::result::Result::Ok(Canceled(())),
                 3 => ::core::result::Result::Ok(ResultsSentElsewhere(())),
@@ -2744,7 +2744,7 @@ pub mod return_ {
                 5 => ::core::result::Result::Ok(AcceptFromThirdParty(
                     ::capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0)),
                 )),
-                x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
             }
         }
     }
@@ -2970,13 +2970,13 @@ pub mod return_ {
         AcceptFromThirdParty(A2),
     }
     pub type WhichReader<'a> = Which<
-        ::capnp::Result<crate::rpc_capnp::payload::Reader<'a>>,
-        ::capnp::Result<crate::rpc_capnp::exception::Reader<'a>>,
+        crate::rpc_capnp::payload::Reader<'a>,
+        crate::rpc_capnp::exception::Reader<'a>,
         ::capnp::any_pointer::Reader<'a>,
     >;
     pub type WhichBuilder<'a> = Which<
-        ::capnp::Result<crate::rpc_capnp::payload::Builder<'a>>,
-        ::capnp::Result<crate::rpc_capnp::exception::Builder<'a>>,
+        crate::rpc_capnp::payload::Builder<'a>,
+        crate::rpc_capnp::exception::Builder<'a>,
         ::capnp::any_pointer::Builder<'a>,
     >;
 }
@@ -3439,21 +3439,21 @@ pub mod resolve {
             !self.reader.get_pointer_field(0).is_null()
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::Error> {
             match self.reader.get_data_field::<u16>(2) {
                 0 => ::core::result::Result::Ok(Cap(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 1 => ::core::result::Result::Ok(Exception(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
-                x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
             }
         }
     }
@@ -3601,21 +3601,21 @@ pub mod resolve {
             !self.builder.is_pointer_field_null(0)
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::Error> {
             match self.builder.get_data_field::<u16>(2) {
                 0 => ::core::result::Result::Ok(Cap(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 1 => ::core::result::Result::Ok(Exception(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
-                x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
             }
         }
     }
@@ -3731,12 +3731,12 @@ pub mod resolve {
         Exception(A1),
     }
     pub type WhichReader<'a> = Which<
-        ::capnp::Result<crate::rpc_capnp::cap_descriptor::Reader<'a>>,
-        ::capnp::Result<crate::rpc_capnp::exception::Reader<'a>>,
+        crate::rpc_capnp::cap_descriptor::Reader<'a>,
+        crate::rpc_capnp::exception::Reader<'a>,
     >;
     pub type WhichBuilder<'a> = Which<
-        ::capnp::Result<crate::rpc_capnp::cap_descriptor::Builder<'a>>,
-        ::capnp::Result<crate::rpc_capnp::exception::Builder<'a>>,
+        crate::rpc_capnp::cap_descriptor::Builder<'a>,
+        crate::rpc_capnp::exception::Builder<'a>,
     >;
 }
 
@@ -4479,7 +4479,7 @@ pub mod disembargo {
                 self.reader.total_size()
             }
             #[inline]
-            pub fn which(self) -> ::core::result::Result<WhichReader, ::capnp::NotInSchema> {
+            pub fn which(self) -> ::core::result::Result<WhichReader, ::capnp::Error> {
                 match self.reader.get_data_field::<u16>(2) {
                     0 => ::core::result::Result::Ok(SenderLoopback(
                         self.reader.get_data_field::<u32>(0),
@@ -4489,7 +4489,7 @@ pub mod disembargo {
                     )),
                     2 => ::core::result::Result::Ok(Accept(())),
                     3 => ::core::result::Result::Ok(Provide(self.reader.get_data_field::<u32>(0))),
-                    x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                    x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
                 }
             }
         }
@@ -4605,7 +4605,7 @@ pub mod disembargo {
                 self.builder.set_data_field::<u32>(0, value);
             }
             #[inline]
-            pub fn which(self) -> ::core::result::Result<WhichBuilder, ::capnp::NotInSchema> {
+            pub fn which(self) -> ::core::result::Result<WhichBuilder, ::capnp::Error> {
                 match self.builder.get_data_field::<u16>(2) {
                     0 => ::core::result::Result::Ok(SenderLoopback(
                         self.builder.get_data_field::<u32>(0),
@@ -4615,7 +4615,7 @@ pub mod disembargo {
                     )),
                     2 => ::core::result::Result::Ok(Accept(())),
                     3 => ::core::result::Result::Ok(Provide(self.builder.get_data_field::<u32>(0))),
-                    x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                    x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
                 }
             }
         }
@@ -5958,16 +5958,16 @@ pub mod message_target {
             !self.reader.get_pointer_field(0).is_null()
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::Error> {
             match self.reader.get_data_field::<u16>(2) {
                 0 => ::core::result::Result::Ok(ImportedCap(self.reader.get_data_field::<u32>(0))),
                 1 => ::core::result::Result::Ok(PromisedAnswer(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
-                x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
             }
         }
     }
@@ -6088,16 +6088,16 @@ pub mod message_target {
             !self.builder.is_pointer_field_null(0)
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::Error> {
             match self.builder.get_data_field::<u16>(2) {
                 0 => ::core::result::Result::Ok(ImportedCap(self.builder.get_data_field::<u32>(0))),
                 1 => ::core::result::Result::Ok(PromisedAnswer(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
-                x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
             }
         }
     }
@@ -6196,10 +6196,8 @@ pub mod message_target {
         ImportedCap(u32),
         PromisedAnswer(A0),
     }
-    pub type WhichReader<'a> =
-        Which<::capnp::Result<crate::rpc_capnp::promised_answer::Reader<'a>>>;
-    pub type WhichBuilder<'a> =
-        Which<::capnp::Result<crate::rpc_capnp::promised_answer::Builder<'a>>>;
+    pub type WhichReader<'a> = Which<crate::rpc_capnp::promised_answer::Reader<'a>>;
+    pub type WhichBuilder<'a> = Which<crate::rpc_capnp::promised_answer::Builder<'a>>;
 }
 
 pub mod payload {
@@ -6685,7 +6683,7 @@ pub mod cap_descriptor {
             self.reader.get_data_field_mask::<u8>(2, 255)
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::Error> {
             match self.reader.get_data_field::<u16>(0) {
                 0 => ::core::result::Result::Ok(None(())),
                 1 => ::core::result::Result::Ok(SenderHosted(self.reader.get_data_field::<u32>(1))),
@@ -6699,15 +6697,15 @@ pub mod cap_descriptor {
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 5 => ::core::result::Result::Ok(ThirdPartyHosted(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
-                x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
             }
         }
     }
@@ -6876,7 +6874,7 @@ pub mod cap_descriptor {
             self.builder.set_data_field_mask::<u8>(2, value, 255);
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::Error> {
             match self.builder.get_data_field::<u16>(0) {
                 0 => ::core::result::Result::Ok(None(())),
                 1 => {
@@ -6892,15 +6890,15 @@ pub mod cap_descriptor {
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 5 => ::core::result::Result::Ok(ThirdPartyHosted(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
-                x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
             }
         }
     }
@@ -7089,12 +7087,12 @@ pub mod cap_descriptor {
         ThirdPartyHosted(A1),
     }
     pub type WhichReader<'a> = Which<
-        ::capnp::Result<crate::rpc_capnp::promised_answer::Reader<'a>>,
-        ::capnp::Result<crate::rpc_capnp::third_party_cap_descriptor::Reader<'a>>,
+        crate::rpc_capnp::promised_answer::Reader<'a>,
+        crate::rpc_capnp::third_party_cap_descriptor::Reader<'a>,
     >;
     pub type WhichBuilder<'a> = Which<
-        ::capnp::Result<crate::rpc_capnp::promised_answer::Builder<'a>>,
-        ::capnp::Result<crate::rpc_capnp::third_party_cap_descriptor::Builder<'a>>,
+        crate::rpc_capnp::promised_answer::Builder<'a>,
+        crate::rpc_capnp::third_party_cap_descriptor::Builder<'a>,
     >;
 }
 
@@ -7556,13 +7554,13 @@ pub mod promised_answer {
                 self.reader.total_size()
             }
             #[inline]
-            pub fn which(self) -> ::core::result::Result<WhichReader, ::capnp::NotInSchema> {
+            pub fn which(self) -> ::core::result::Result<WhichReader, ::capnp::Error> {
                 match self.reader.get_data_field::<u16>(0) {
                     0 => ::core::result::Result::Ok(Noop(())),
                     1 => ::core::result::Result::Ok(GetPointerField(
                         self.reader.get_data_field::<u16>(1),
                     )),
-                    x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                    x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
                 }
             }
         }
@@ -7668,13 +7666,13 @@ pub mod promised_answer {
                 self.builder.set_data_field::<u16>(1, value);
             }
             #[inline]
-            pub fn which(self) -> ::core::result::Result<WhichBuilder, ::capnp::NotInSchema> {
+            pub fn which(self) -> ::core::result::Result<WhichBuilder, ::capnp::Error> {
                 match self.builder.get_data_field::<u16>(0) {
                     0 => ::core::result::Result::Ok(Noop(())),
                     1 => ::core::result::Result::Ok(GetPointerField(
                         self.builder.get_data_field::<u16>(1),
                     )),
-                    x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+                    x => ::core::result::Result::Err(::capnp::Error::from(::capnp::NotInSchema(x))),
                 }
             }
         }

--- a/capnp/src/dynamic_struct.rs
+++ b/capnp/src/dynamic_struct.rs
@@ -110,7 +110,7 @@ impl<'a> Reader<'a> {
                         // If the type is a generic, then the default value
                         // is always an empty AnyPointer. Ignore that case.
                         let t1 = if let (true, value::Text(t)) = (p.is_null(), dval) {
-                            t?
+                            t
                         } else {
                             p.get_text(None)?
                         };
@@ -121,7 +121,7 @@ impl<'a> Reader<'a> {
                         // If the type is a generic, then the default value
                         // is always an empty AnyPointer. Ignore that case.
                         let d1 = if let (true, value::Data(d)) = (p.is_null(), dval) {
-                            d?
+                            d
                         } else {
                             p.get_data(None)?
                         };
@@ -357,7 +357,7 @@ impl<'a> Builder<'a> {
                             // If the type is a generic, then the default value
                             // is always an empty AnyPointer. Ignore that case.
                             if let value::Text(t) = dval {
-                                p.set_text(t?);
+                                p.set_text(t);
                             }
                         }
                         Ok(dynamic_value::Builder::Text(p.get_text(None)?))
@@ -368,7 +368,7 @@ impl<'a> Builder<'a> {
                             // If the type is a generic, then the default value
                             // is always an empty AnyPointer. Ignore that case.
                             if let value::Data(d) = dval {
-                                p.set_data(d?);
+                                p.set_data(d);
                             }
                         }
                         Ok(dynamic_value::Builder::Data(p.get_data(None)?))

--- a/capnp/src/dynamic_value.rs
+++ b/capnp/src/dynamic_value.rs
@@ -45,8 +45,8 @@ impl<'a> Reader<'a> {
             (value::Float32(x), _) => Ok(Reader::Float32(x)),
             (value::Float64(x), _) => Ok(Reader::Float64(x)),
             (value::Enum(d), TypeVariant::Enum(e)) => Ok(Reader::Enum(Enum::new(d, e.into()))),
-            (value::Text(t), _) => Ok(Reader::Text(t?)),
-            (value::Data(d), _) => Ok(Reader::Data(d?)),
+            (value::Text(t), _) => Ok(Reader::Text(t)),
+            (value::Data(d), _) => Ok(Reader::Data(d)),
             (value::Struct(d), TypeVariant::Struct(schema)) => Ok(Reader::Struct(
                 dynamic_struct::Reader::new(d.reader.get_struct(None)?, schema.into()),
             )),

--- a/capnp/src/schema_capnp.rs
+++ b/capnp/src/schema_capnp.rs
@@ -177,7 +177,7 @@ pub mod node {
             self.reader.get_bool_field(288)
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, crate::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, crate::Error> {
             match self.reader.get_data_field::<u16>(6) {
                 0 => ::core::result::Result::Ok(File(())),
                 1 => ::core::result::Result::Ok(Struct(self.reader.into())),
@@ -185,7 +185,7 @@ pub mod node {
                 3 => ::core::result::Result::Ok(Interface(self.reader.into())),
                 4 => ::core::result::Result::Ok(Const(self.reader.into())),
                 5 => ::core::result::Result::Ok(Annotation(self.reader.into())),
-                x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
             }
         }
     }
@@ -486,7 +486,7 @@ pub mod node {
             self.builder.set_bool_field(288, value);
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, crate::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, crate::Error> {
             match self.builder.get_data_field::<u16>(6) {
                 0 => ::core::result::Result::Ok(File(())),
                 1 => ::core::result::Result::Ok(Struct(self.builder.into())),
@@ -494,7 +494,7 @@ pub mod node {
                 3 => ::core::result::Result::Ok(Interface(self.builder.into())),
                 4 => ::core::result::Result::Ok(Const(self.builder.into())),
                 5 => ::core::result::Result::Ok(Annotation(self.builder.into())),
-                x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
             }
         }
     }
@@ -4524,11 +4524,11 @@ pub mod field {
             self.reader.into()
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, crate::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, crate::Error> {
             match self.reader.get_data_field::<u16>(4) {
                 0 => ::core::result::Result::Ok(Slot(self.reader.into())),
                 1 => ::core::result::Result::Ok(Group(self.reader.into())),
-                x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
             }
         }
     }
@@ -4714,11 +4714,11 @@ pub mod field {
             self.builder.into()
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, crate::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, crate::Error> {
             match self.builder.get_data_field::<u16>(4) {
                 0 => ::core::result::Result::Ok(Slot(self.builder.into())),
                 1 => ::core::result::Result::Ok(Group(self.builder.into())),
-                x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
             }
         }
     }
@@ -5705,11 +5705,11 @@ pub mod field {
                 self.reader.total_size()
             }
             #[inline]
-            pub fn which(self) -> ::core::result::Result<WhichReader, crate::NotInSchema> {
+            pub fn which(self) -> ::core::result::Result<WhichReader, crate::Error> {
                 match self.reader.get_data_field::<u16>(5) {
                     0 => ::core::result::Result::Ok(Implicit(())),
                     1 => ::core::result::Result::Ok(Explicit(self.reader.get_data_field::<u16>(6))),
-                    x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                    x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
                 }
             }
         }
@@ -5810,13 +5810,13 @@ pub mod field {
                 self.builder.set_data_field::<u16>(6, value);
             }
             #[inline]
-            pub fn which(self) -> ::core::result::Result<WhichBuilder, crate::NotInSchema> {
+            pub fn which(self) -> ::core::result::Result<WhichBuilder, crate::Error> {
                 match self.builder.get_data_field::<u16>(5) {
                     0 => ::core::result::Result::Ok(Implicit(())),
                     1 => {
                         ::core::result::Result::Ok(Explicit(self.builder.get_data_field::<u16>(6)))
                     }
-                    x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                    x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
                 }
             }
         }
@@ -7383,7 +7383,7 @@ pub mod type_ {
             self.reader.total_size()
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, crate::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, crate::Error> {
             match self.reader.get_data_field::<u16>(0) {
                 0 => ::core::result::Result::Ok(Void(())),
                 1 => ::core::result::Result::Ok(Bool(())),
@@ -7404,7 +7404,7 @@ pub mod type_ {
                 16 => ::core::result::Result::Ok(Struct(self.reader.into())),
                 17 => ::core::result::Result::Ok(Interface(self.reader.into())),
                 18 => ::core::result::Result::Ok(AnyPointer(self.reader.into())),
-                x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
             }
         }
     }
@@ -7586,7 +7586,7 @@ pub mod type_ {
             self.builder.into()
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, crate::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, crate::Error> {
             match self.builder.get_data_field::<u16>(0) {
                 0 => ::core::result::Result::Ok(Void(())),
                 1 => ::core::result::Result::Ok(Bool(())),
@@ -7607,7 +7607,7 @@ pub mod type_ {
                 16 => ::core::result::Result::Ok(Struct(self.builder.into())),
                 17 => ::core::result::Result::Ok(Interface(self.builder.into())),
                 18 => ::core::result::Result::Ok(AnyPointer(self.builder.into())),
-                x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
             }
         }
     }
@@ -9394,12 +9394,12 @@ pub mod type_ {
                 self.reader.total_size()
             }
             #[inline]
-            pub fn which(self) -> ::core::result::Result<WhichReader<'a>, crate::NotInSchema> {
+            pub fn which(self) -> ::core::result::Result<WhichReader<'a>, crate::Error> {
                 match self.reader.get_data_field::<u16>(4) {
                     0 => ::core::result::Result::Ok(Unconstrained(self.reader.into())),
                     1 => ::core::result::Result::Ok(Parameter(self.reader.into())),
                     2 => ::core::result::Result::Ok(ImplicitMethodParameter(self.reader.into())),
-                    x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                    x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
                 }
             }
         }
@@ -9517,12 +9517,12 @@ pub mod type_ {
                 self.builder.into()
             }
             #[inline]
-            pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, crate::NotInSchema> {
+            pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, crate::Error> {
                 match self.builder.get_data_field::<u16>(4) {
                     0 => ::core::result::Result::Ok(Unconstrained(self.builder.into())),
                     1 => ::core::result::Result::Ok(Parameter(self.builder.into())),
                     2 => ::core::result::Result::Ok(ImplicitMethodParameter(self.builder.into())),
-                    x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                    x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
                 }
             }
         }
@@ -9736,13 +9736,13 @@ pub mod type_ {
                     self.reader.total_size()
                 }
                 #[inline]
-                pub fn which(self) -> ::core::result::Result<WhichReader, crate::NotInSchema> {
+                pub fn which(self) -> ::core::result::Result<WhichReader, crate::Error> {
                     match self.reader.get_data_field::<u16>(5) {
                         0 => ::core::result::Result::Ok(AnyKind(())),
                         1 => ::core::result::Result::Ok(Struct(())),
                         2 => ::core::result::Result::Ok(List(())),
                         3 => ::core::result::Result::Ok(Capability(())),
-                        x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                        x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
                     }
                 }
             }
@@ -9855,13 +9855,13 @@ pub mod type_ {
                     self.builder.set_data_field::<u16>(5, 3);
                 }
                 #[inline]
-                pub fn which(self) -> ::core::result::Result<WhichBuilder, crate::NotInSchema> {
+                pub fn which(self) -> ::core::result::Result<WhichBuilder, crate::Error> {
                     match self.builder.get_data_field::<u16>(5) {
                         0 => ::core::result::Result::Ok(AnyKind(())),
                         1 => ::core::result::Result::Ok(Struct(())),
                         2 => ::core::result::Result::Ok(List(())),
                         3 => ::core::result::Result::Ok(Capability(())),
-                        x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                        x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
                     }
                 }
             }
@@ -11031,16 +11031,16 @@ pub mod brand {
                 !self.reader.get_pointer_field(0).is_null()
             }
             #[inline]
-            pub fn which(self) -> ::core::result::Result<WhichReader<'a>, crate::NotInSchema> {
+            pub fn which(self) -> ::core::result::Result<WhichReader<'a>, crate::Error> {
                 match self.reader.get_data_field::<u16>(4) {
                     0 => ::core::result::Result::Ok(Bind(
                         crate::traits::FromPointerReader::get_from_pointer(
                             &self.reader.get_pointer_field(0),
                             ::core::option::Option::None,
-                        ),
+                        )?,
                     )),
                     1 => ::core::result::Result::Ok(Inherit(())),
-                    x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                    x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
                 }
             }
         }
@@ -11175,16 +11175,16 @@ pub mod brand {
                 self.builder.set_data_field::<u16>(4, 1);
             }
             #[inline]
-            pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, crate::NotInSchema> {
+            pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, crate::Error> {
                 match self.builder.get_data_field::<u16>(4) {
                     0 => ::core::result::Result::Ok(Bind(
                         crate::traits::FromPointerBuilder::get_from_pointer(
                             self.builder.get_pointer_field(0),
                             ::core::option::Option::None,
-                        ),
+                        )?,
                     )),
                     1 => ::core::result::Result::Ok(Inherit(())),
-                    x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                    x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
                 }
             }
         }
@@ -11302,16 +11302,10 @@ pub mod brand {
             Bind(A0),
             Inherit(()),
         }
-        pub type WhichReader<'a> = Which<
-            crate::Result<
-                crate::struct_list::Reader<'a, crate::schema_capnp::brand::binding::Owned>,
-            >,
-        >;
-        pub type WhichBuilder<'a> = Which<
-            crate::Result<
-                crate::struct_list::Builder<'a, crate::schema_capnp::brand::binding::Owned>,
-            >,
-        >;
+        pub type WhichReader<'a> =
+            Which<crate::struct_list::Reader<'a, crate::schema_capnp::brand::binding::Owned>>;
+        pub type WhichBuilder<'a> =
+            Which<crate::struct_list::Builder<'a, crate::schema_capnp::brand::binding::Owned>>;
     }
 
     pub mod binding {
@@ -11423,16 +11417,16 @@ pub mod brand {
                 !self.reader.get_pointer_field(0).is_null()
             }
             #[inline]
-            pub fn which(self) -> ::core::result::Result<WhichReader<'a>, crate::NotInSchema> {
+            pub fn which(self) -> ::core::result::Result<WhichReader<'a>, crate::Error> {
                 match self.reader.get_data_field::<u16>(0) {
                     0 => ::core::result::Result::Ok(Unbound(())),
                     1 => ::core::result::Result::Ok(Type(
                         crate::traits::FromPointerReader::get_from_pointer(
                             &self.reader.get_pointer_field(0),
                             ::core::option::Option::None,
-                        ),
+                        )?,
                     )),
-                    x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                    x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
                 }
             }
         }
@@ -11555,16 +11549,16 @@ pub mod brand {
                 !self.builder.is_pointer_field_null(0)
             }
             #[inline]
-            pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, crate::NotInSchema> {
+            pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, crate::Error> {
                 match self.builder.get_data_field::<u16>(0) {
                     0 => ::core::result::Result::Ok(Unbound(())),
                     1 => ::core::result::Result::Ok(Type(
                         crate::traits::FromPointerBuilder::get_from_pointer(
                             self.builder.get_pointer_field(0),
                             ::core::option::Option::None,
-                        ),
+                        )?,
                     )),
-                    x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                    x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
                 }
             }
         }
@@ -11662,8 +11656,8 @@ pub mod brand {
             Unbound(()),
             Type(A0),
         }
-        pub type WhichReader<'a> = Which<crate::Result<crate::schema_capnp::type_::Reader<'a>>>;
-        pub type WhichBuilder<'a> = Which<crate::Result<crate::schema_capnp::type_::Builder<'a>>>;
+        pub type WhichReader<'a> = Which<crate::schema_capnp::type_::Reader<'a>>;
+        pub type WhichBuilder<'a> = Which<crate::schema_capnp::type_::Builder<'a>>;
     }
 }
 
@@ -11807,7 +11801,7 @@ pub mod value {
             !self.reader.get_pointer_field(0).is_null()
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, crate::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, crate::Error> {
             match self.reader.get_data_field::<u16>(0) {
                 0 => ::core::result::Result::Ok(Void(())),
                 1 => ::core::result::Result::Ok(Bool(self.reader.get_bool_field(16))),
@@ -11825,13 +11819,13 @@ pub mod value {
                     crate::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 13 => ::core::result::Result::Ok(Data(
                     crate::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 14 => ::core::result::Result::Ok(List(crate::any_pointer::Reader::new(
                     self.reader.get_pointer_field(0),
@@ -11844,7 +11838,7 @@ pub mod value {
                 18 => ::core::result::Result::Ok(AnyPointer(crate::any_pointer::Reader::new(
                     self.reader.get_pointer_field(0),
                 ))),
-                x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
             }
         }
     }
@@ -12082,7 +12076,7 @@ pub mod value {
             !self.builder.is_pointer_field_null(0)
         }
         #[inline]
-        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, crate::NotInSchema> {
+        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, crate::Error> {
             match self.builder.get_data_field::<u16>(0) {
                 0 => ::core::result::Result::Ok(Void(())),
                 1 => ::core::result::Result::Ok(Bool(self.builder.get_bool_field(16))),
@@ -12100,13 +12094,13 @@ pub mod value {
                     crate::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 13 => ::core::result::Result::Ok(Data(
                     crate::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    )?,
                 )),
                 14 => ::core::result::Result::Ok(List(crate::any_pointer::Builder::new(
                     self.builder.get_pointer_field(0),
@@ -12119,7 +12113,7 @@ pub mod value {
                 18 => ::core::result::Result::Ok(AnyPointer(crate::any_pointer::Builder::new(
                     self.builder.get_pointer_field(0),
                 ))),
-                x => ::core::result::Result::Err(crate::NotInSchema(x)),
+                x => ::core::result::Result::Err(crate::Error::from(crate::NotInSchema(x))),
             }
         }
     }
@@ -12512,15 +12506,15 @@ pub mod value {
         AnyPointer(A4),
     }
     pub type WhichReader<'a> = Which<
-        crate::Result<crate::text::Reader<'a>>,
-        crate::Result<crate::data::Reader<'a>>,
+        crate::text::Reader<'a>,
+        crate::data::Reader<'a>,
         crate::any_pointer::Reader<'a>,
         crate::any_pointer::Reader<'a>,
         crate::any_pointer::Reader<'a>,
     >;
     pub type WhichBuilder<'a> = Which<
-        crate::Result<crate::text::Builder<'a>>,
-        crate::Result<crate::data::Builder<'a>>,
+        crate::text::Builder<'a>,
+        crate::data::Builder<'a>,
         crate::any_pointer::Builder<'a>,
         crate::any_pointer::Builder<'a>,
         crate::any_pointer::Builder<'a>,

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -537,7 +537,7 @@ const STREAM_RESULT_ID: u64 = 0x995f9a3377c0b16e;
 
 fn name_annotation_value(annotation: schema_capnp::annotation::Reader<'_>) -> capnp::Result<&str> {
     if let schema_capnp::value::Text(t) = annotation.get_value()?.which()? {
-        let name = t?.to_str()?;
+        let name = t.to_str()?;
         for c in name.chars() {
             if !(c == '_' || c.is_alphanumeric()) {
                 return Err(capnp::Error::failed(
@@ -574,7 +574,7 @@ fn get_enumerant_name(enumerant: schema_capnp::enumerant::Reader<'_>) -> capnp::
 
 fn get_parent_module(annotation: schema_capnp::annotation::Reader) -> capnp::Result<Vec<String>> {
     if let schema_capnp::value::Text(t) = annotation.get_value()?.which()? {
-        let module = t?.to_str()?;
+        let module = t.to_str()?;
         Ok(module.split("::").map(|x| x.to_string()).collect())
     } else {
         Err(capnp::Error::failed(
@@ -687,7 +687,7 @@ pub fn getter_text(
     field: &schema_capnp::field::Reader,
     is_reader: bool,
     is_fn: bool,
-) -> ::capnp::Result<(String, FormattedText, Option<FormattedText>)> {
+) -> ::capnp::Result<(String, String, FormattedText, Option<FormattedText>)> {
     use capnp::schema_capnp::*;
 
     match field.which()? {
@@ -717,7 +717,8 @@ pub fn getter_text(
                 line("self.builder.into()")
             };
 
-            Ok((result_type, getter_code, None))
+            // For groups, inner type is same as result_type (no Result wrapper)
+            Ok((result_type.clone(), result_type, getter_code, None))
         }
         field::Slot(reg_field) => {
             let mut default_decl = None;
@@ -745,7 +746,11 @@ pub fn getter_text(
             }
 
             let raw_type = reg_field.get_type()?;
-            let inner_type = raw_type.type_string(ctx, module)?;
+            let inner_type = if matches!(raw_type.which()?, type_::Interface(_)) {
+                raw_type.type_string(ctx, Leaf::Client)?
+            } else {
+                raw_type.type_string(ctx, module)?
+            };
             let default_value = reg_field.get_default_value()?;
             let default = default_value.which()?;
             let default_name = format!(
@@ -894,7 +899,8 @@ pub fn getter_text(
                 Line(getter_fragment)
             };
 
-            Ok((result_type, getter_code, default_decl))
+            // typ is the inner type (without Result wrapper, may include Option)
+            Ok((result_type, typ, getter_code, default_decl))
         }
     }
 }
@@ -1353,14 +1359,13 @@ fn used_params_of_brand(
                         used_params.insert(param.get_name()?.to_string()?);
                     }
                 }
-                brand::scope::Bind(bindings_list_opt) => {
-                    let bindings_list = bindings_list_opt?;
+                brand::scope::Bind(bindings_list) => {
                     assert_eq!(bindings_list.len(), params.len());
                     for binding in bindings_list {
                         match binding.which()? {
                             brand::binding::Unbound(()) => (),
                             brand::binding::Type(t) => {
-                                used_params_of_type(ctx, t?, used_params)?;
+                                used_params_of_type(ctx, t, used_params)?;
                             }
                         }
                     }
@@ -1411,18 +1416,25 @@ fn generate_union(
         let field_name = get_field_name(*field)?;
         let enumerant_name = capitalize_first_letter(field_name);
 
-        let (ty, get, maybe_default_decl) = getter_text(ctx, field, is_reader, false)?;
+        let (ty, inner_ty, get, maybe_default_decl) = getter_text(ctx, field, is_reader, false)?;
         if let Some(default_decl) = maybe_default_decl {
             default_decls.push(default_decl)
         }
 
+        let is_fallible = inner_ty != ty;
+
+        let get_expr: FormattedText = if is_fallible {
+            Branch(vec![get, line("?")])
+        } else {
+            get
+        };
         getter_interior.push(Branch(vec![
             Line(format!("{dvalue} => {{")),
             indent(Line(format!(
                 "::core::result::Result::Ok({}(",
                 enumerant_name.clone()
             ))),
-            indent(indent(get)),
+            indent(indent(get_expr)),
             indent(line("))")),
             line("}"),
         ]));
@@ -1430,7 +1442,7 @@ fn generate_union(
         let ty1 = match field.which() {
             Ok(field::Group(group)) => {
                 used_params_of_group(ctx, group.get_type_id(), &mut used_params)?;
-                ty_args.push(ty);
+                ty_args.push(inner_ty.clone());
                 new_ty_param(&mut ty_params)
             }
             Ok(field::Slot(reg_field)) => {
@@ -1442,16 +1454,16 @@ fn generate_union(
                         | type_::Data(())
                         | type_::List(_)
                         | type_::Struct(_)
-                        | type_::AnyPointer(_),
+                        | type_::AnyPointer(_)
+                        | type_::Interface(_),
                     ) => {
-                        ty_args.push(ty);
+                        ty_args.push(inner_ty.clone());
                         new_ty_param(&mut ty_params)
                     }
-                    Ok(type_::Interface(_)) => ty,
-                    _ => ty,
+                    _ => inner_ty.clone(),
                 }
             }
-            _ => ty,
+            _ => inner_ty.clone(),
         };
 
         enum_interior.push(Line(format!("{enumerant_name}({ty1}),")));
@@ -1468,7 +1480,7 @@ fn generate_union(
 
     getter_interior.push(Line(fmt!(
         ctx,
-        "x => ::core::result::Result::Err({capnp}::NotInSchema(x))"
+        "x => ::core::result::Result::Err({capnp}::Error::from({capnp}::NotInSchema(x)))"
     )));
 
     interior.push(Branch(vec![
@@ -1511,8 +1523,9 @@ fn generate_union(
 
     let getter_result = Branch(vec![
         line("#[inline]"),
-        Line(fmt!(ctx,
-            "pub fn which(self) -> ::core::result::Result<{concrete_type}, {capnp}::NotInSchema> {{"
+        Line(fmt!(
+            ctx,
+            "pub fn which(self) -> ::core::result::Result<{concrete_type}, {capnp}::Error> {{"
         )),
         indent(vec![
             Line(format!(
@@ -1972,11 +1985,11 @@ fn get_ty_params_of_brand_helper(
         let scope_id = scope.get_scope_id();
         match scope.which()? {
             schema_capnp::brand::scope::Bind(bind) => {
-                for binding in bind? {
+                for binding in bind {
                     match binding.which()? {
                         schema_capnp::brand::binding::Unbound(()) => {}
                         schema_capnp::brand::binding::Type(t) => {
-                            get_ty_params_of_type_helper(ctx, accumulator, t?)?
+                            get_ty_params_of_type_helper(ctx, accumulator, t)?
                         }
                     }
                 }
@@ -2097,7 +2110,7 @@ fn generate_node(
 
                 if !is_union_field {
                     pipeline_impl_interior.push(generate_pipeline_getter(ctx, field)?);
-                    let (ty, get, default_decl) = getter_text(ctx, &field, true, true)?;
+                    let (ty, _inner_ty, get, default_decl) = getter_text(ctx, &field, true, true)?;
                     if let Some(default) = default_decl {
                         private_mod_interior.push(default.clone());
                     }
@@ -2108,7 +2121,7 @@ fn generate_node(
                         line("}"),
                     ]));
 
-                    let (ty_b, get_b, _) = getter_text(ctx, &field, false, true)?;
+                    let (ty_b, _inner_ty_b, get_b, _) = getter_text(ctx, &field, false, true)?;
                     builder_members.push(Branch(vec![
                         line("#[inline]"),
                         Line(format!("pub fn get_{styled_name}(self) {ty_b} {{")),
@@ -3067,10 +3080,10 @@ fn generate_node(
 
                 (type_::Text(()), value::Text(t)) => Line(format!(
                     "pub const {styled_name}: &str = {:?};",
-                    t?.to_str()?
+                    t.to_str()?
                 )),
                 (type_::Data(()), value::Data(d)) => {
-                    Line(format!("pub const {styled_name}: &[u8] = &{:?};", d?))
+                    Line(format!("pub const {styled_name}: &[u8] = &{:?};", d))
                 }
 
                 (type_::List(_), value::List(v)) => {

--- a/capnpc/src/codegen_types.rs
+++ b/capnpc/src/codegen_types.rs
@@ -377,8 +377,7 @@ pub fn do_branding(
                         arguments.push(param.get_name()?.to_string()?);
                     }
                 }
-                brand::scope::Bind(bindings_list_opt) => {
-                    let bindings_list = bindings_list_opt?;
+                brand::scope::Bind(bindings_list) => {
                     assert_eq!(bindings_list.len(), params.len());
                     for binding in bindings_list {
                         match binding.which()? {
@@ -386,7 +385,7 @@ pub fn do_branding(
                                 arguments.push(fmt!(ctx, "{capnp}::any_pointer::Owned"));
                             }
                             brand::binding::Type(t) => {
-                                arguments.push(t?.type_string(ctx, Leaf::Owned)?);
+                                arguments.push(t.type_string(ctx, Leaf::Owned)?);
                             }
                         }
                     }

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -941,7 +941,7 @@ mod tests {
             assert!(!root.has_foo2());
 
             match root.reborrow().which().unwrap() {
-                test_generics_union::Bar1(Ok(bar)) => {
+                test_generics_union::Bar1(bar) => {
                     assert_eq!(bar.len(), 10);
                     assert_eq!(bar.get(0), 0);
                     assert_eq!(bar.get(5), 100);
@@ -960,7 +960,7 @@ mod tests {
             assert!(root.has_foo2());
 
             match root.reborrow().which().unwrap() {
-                test_generics_union::Foo2(Ok(foo)) => {
+                test_generics_union::Foo2(foo) => {
                     assert_eq!(foo.get_int32_field(), 37);
                 }
                 _ => panic!("expected Foo2"),
@@ -1079,7 +1079,7 @@ mod tests {
                 panic!("")
             };
 
-            let test_union_defaults::inner2::C(Ok(capnp::text::Reader(b"grault"))) =
+            let test_union_defaults::inner2::C(capnp::text::Reader(b"grault")) =
                 reader.get_inner2().which().unwrap()
             else {
                 panic!("")

--- a/example/addressbook/addressbook.rs
+++ b/example/addressbook/addressbook.rs
@@ -95,15 +95,15 @@ pub mod addressbook {
                     println!("  unemployed");
                 }
                 Ok(person::employment::Employer(employer)) => {
-                    println!("  employer: {}", employer?.to_str()?);
+                    println!("  employer: {}", employer.to_str()?);
                 }
                 Ok(person::employment::School(school)) => {
-                    println!("  student at: {}", school?.to_str()?);
+                    println!("  student at: {}", school.to_str()?);
                 }
                 Ok(person::employment::SelfEmployed(())) => {
                     println!("  self-employed");
                 }
-                Err(::capnp::NotInSchema(_)) => {}
+                Err(_) => {}
             }
         }
         Ok(())


### PR DESCRIPTION
In `which()` return `Result<Which<Reader>, Error>` instead of `Result<Which<Result<Reader, Error>>, NotInSchema>`.

Extracting `NotInSchema` is tricker now, because it is now a variant of `Error`. Also it is not possible now have more detailed errors which variant is broken.

I think it's OK, because:
- in majority of cases people don't handle of every error in every enum
- being able to do exhaustive matching ergonomically is important, e.g.

```
match which? {
  Which::File(file) => { ... }
  Which::Directory(file) => { ... }
}
```

instead of

```
match which? {
  Which::File(Ok(file)) => { ... }
  Which::Directory(Ok(file)) => { ... }
  Which::File(Err(e)) | Which::Directory(Err(e)) => return Err(e),
}
```

- we should make errors more descriptive; I have a PR #634