### PR TITLE
add negative_pointer_offset test

### DIFF
--- a/capnp/tests/negative_pointer_offset.rs
+++ b/capnp/tests/negative_pointer_offset.rs
@@ -1,0 +1,26 @@
+/// Regression test for a bug where a struct pointer with a large negative
+/// signed offset would cause `ReaderArenaImpl::check_offset` to panic with
+/// a `TryFromIntError` (from `usize::try_from` on a negative `i64`) instead
+/// of returning `MessageContainsOutOfBoundsPointer`.
+///
+/// Originally discovered by `cargo fuzz run test_all_types`.
+#[test]
+pub fn negative_root_pointer_offset() {
+    // Root struct pointer whose signed 30-bit offset field decodes to a
+    // large negative value, pointing well before the start of the segment.
+    let segment: &[capnp::Word] = &[
+        capnp::word(0x00, 0x00, 0x6d, 0x97, 0x01, 0x00, 0x00, 0x00),
+        capnp::word(0x00, 0x00, 0x6d, 0x6d, 0x6d, 0x6d, 0xff, 0x00),
+    ];
+
+    let segments = &[capnp::Word::words_to_bytes(segment)];
+    let segment_array = capnp::message::SegmentArray::new(segments);
+    let message = capnp::message::Reader::new(segment_array, Default::default());
+    let root: capnp::any_pointer::Reader = message.get_root().unwrap();
+
+    // Before the fix, this panicked in `check_offset` instead of returning
+    // an out-of-bounds error.
+    let result = root.target_size();
+
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Adds a test that would have caught the bug fixed by https://github.com/capnproto/capnproto-rust/commit/735e82ed386208120513a78b9997b7c6a538969e.