### PR TITLE
U32Ext::to_usize

### DIFF
--- a/capnp/src/message.rs
+++ b/capnp/src/message.rs
@@ -74,6 +74,7 @@ use crate::any_pointer;
 use crate::private::arena::{BuilderArena, BuilderArenaImpl};
 use crate::private::arena::{ReaderArena, ReaderArenaImpl};
 use crate::private::layout;
+use crate::private::u32_ext::U32Ext;
 use crate::private::units::BYTES_PER_WORD;
 use crate::traits::{FromPointerBuilder, SetterInput};
 use crate::traits::{FromPointerReader, Owned};
@@ -162,7 +163,7 @@ pub trait ReaderSegments {
     fn len(&self) -> usize {
         for i in 0u32.. {
             if self.get_segment(i).is_none() {
-                return usize::try_from(i).unwrap();
+                return i.to_usize();
             }
         }
         unreachable!()

--- a/capnp/src/private/arena.rs
+++ b/capnp/src/private/arena.rs
@@ -24,6 +24,7 @@ use crate::message;
 use crate::message::Allocator;
 use crate::message::ReaderSegments;
 use crate::private::read_limiter::ReadLimiter;
+use crate::private::u32_ext::U32Ext;
 use crate::private::units::*;
 use crate::OutputSegments;
 use crate::{Error, ErrorKind, Result};
@@ -42,7 +43,7 @@ pub unsafe trait ReaderArena {
     ) -> Result<*const u8> {
         let (segment_start, segment_len) = self.get_segment(segment_id)?;
         let this_start: usize = segment_start as usize;
-        let this_size: usize = usize::try_from(segment_len).unwrap() * BYTES_PER_WORD;
+        let this_size: usize = segment_len.to_usize() * BYTES_PER_WORD;
         let offset: i64 = i64::from(offset_in_words) * i64::try_from(BYTES_PER_WORD).unwrap();
         let start_idx = start as usize;
         if start_idx < this_start {

--- a/capnp/src/private/mod.rs
+++ b/capnp/src/private/mod.rs
@@ -29,6 +29,7 @@ pub mod layout;
 mod mask;
 mod primitive;
 mod read_limiter;
+pub(crate) mod u32_ext;
 pub mod units;
 mod zero;
 

--- a/capnp/src/private/u32_ext.rs
+++ b/capnp/src/private/u32_ext.rs
@@ -1,0 +1,10 @@
+pub(crate) trait U32Ext: Sized {
+    fn to_usize(self) -> usize;
+}
+
+impl U32Ext for u32 {
+    fn to_usize(self) -> usize {
+        const { assert!(size_of::<u32>() <= size_of::<usize>()) }
+        self.try_into().unwrap()
+    }
+}

--- a/capnp/src/serialize.rs
+++ b/capnp/src/serialize.rs
@@ -32,6 +32,7 @@ pub use no_alloc_buffer_segments::{
 use crate::io::{Read, Write};
 
 use crate::message;
+use crate::private::u32_ext::U32Ext;
 use crate::private::units::BYTES_PER_WORD;
 use crate::Result;
 use crate::{Error, ErrorKind};
@@ -144,7 +145,7 @@ impl<T: core::ops::Deref<Target = [u8]>> BufferSegments<T> {
 #[cfg(feature = "alloc")]
 impl<T: core::ops::Deref<Target = [u8]>> message::ReaderSegments for BufferSegments<T> {
     fn get_segment(&self, id: u32) -> Option<&[u8]> {
-        let id_usize = usize::try_from(id).unwrap();
+        let id_usize = id.to_usize();
         if id_usize < self.segment_indices.len() {
             let (a, b) = self.segment_indices[id_usize];
             Some(
@@ -190,7 +191,7 @@ impl core::ops::DerefMut for OwnedSegments {
 #[cfg(feature = "alloc")]
 impl crate::message::ReaderSegments for OwnedSegments {
     fn get_segment(&self, id: u32) -> Option<&[u8]> {
-        let id_usize = usize::try_from(id).unwrap();
+        let id_usize = id.to_usize();
         if id_usize < self.segment_indices.len() {
             let (a, b) = self.segment_indices[id_usize];
             Some(&self[(a * BYTES_PER_WORD)..(b * BYTES_PER_WORD)])
@@ -542,7 +543,7 @@ fn flatten_segments<R: message::ReaderSegments + ?Sized>(segments: &R) -> alloc:
     let segment_count: u32 = segments.len().try_into().unwrap();
     let table_size = segment_count / 2 + 1;
     let mut result = alloc::vec::Vec::with_capacity(word_count);
-    result.resize(usize::try_from(table_size).unwrap() * BYTES_PER_WORD, 0);
+    result.resize(table_size.to_usize() * BYTES_PER_WORD, 0);
     {
         let mut bytes = &mut result[..];
         write_segment_table_internal(&mut bytes, segments).expect("Failed to write segment table.");
@@ -616,12 +617,11 @@ where
     if segment_count > 1 {
         if segment_count < 4 {
             for idx in 1..segment_count {
-                buf[usize::try_from((idx - 1) * 4).unwrap()..usize::try_from(idx * 4).unwrap()]
-                    .copy_from_slice(
-                        &u32::try_from(segments.get_segment(idx).unwrap().len() / BYTES_PER_WORD)
-                            .unwrap()
-                            .to_le_bytes(),
-                    );
+                buf[((idx - 1) * 4).to_usize()..(idx * 4).to_usize()].copy_from_slice(
+                    &u32::try_from(segments.get_segment(idx).unwrap().len() / BYTES_PER_WORD)
+                        .unwrap()
+                        .to_le_bytes(),
+                );
             }
             if segment_count == 2 {
                 for b in &mut buf[4..8] {
@@ -632,16 +632,13 @@ where
         } else {
             #[cfg(feature = "alloc")]
             {
-                let mut buf = vec![0; (usize::try_from(segment_count).unwrap() & !1) * 4];
+                let mut buf = vec![0; (segment_count.to_usize() & !1) * 4];
                 for idx in 1..segment_count {
-                    buf[usize::try_from((idx - 1) * 4).unwrap()..usize::try_from(idx * 4).unwrap()]
-                        .copy_from_slice(
-                            &u32::try_from(
-                                segments.get_segment(idx).unwrap().len() / BYTES_PER_WORD,
-                            )
+                    buf[((idx - 1) * 4).to_usize()..(idx * 4).to_usize()].copy_from_slice(
+                        &u32::try_from(segments.get_segment(idx).unwrap().len() / BYTES_PER_WORD)
                             .unwrap()
                             .to_le_bytes(),
-                        );
+                    );
                 }
                 if segment_count % 2 == 0 {
                     let start_idx = buf.len() - 4;


### PR DESCRIPTION
`usize` is always greater than `u32` for capnp, but not generally in Rust.