### PR TITLE
.offset() -> .add()

### DIFF
--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -446,7 +446,7 @@ mod wire_helpers {
                 let amount_plus_ref = amount + u32::try_from(POINTER_SIZE_IN_WORDS).unwrap();
                 let (segment_id, word_idx) = arena.allocate_anywhere(amount_plus_ref);
                 let (seg_start, _seg_len) = arena.get_segment_mut(segment_id);
-                let ptr = seg_start.offset(word_idx as isize * BYTES_PER_WORD as isize);
+                let ptr = seg_start.add(word_idx as usize * BYTES_PER_WORD);
 
                 //# Set up the original pointer to be a far pointer to
                 //# the new segment.
@@ -463,7 +463,7 @@ mod wire_helpers {
             }
             Some(idx) => {
                 let (seg_start, _seg_len) = arena.get_segment_mut(segment_id);
-                let ptr = (seg_start).offset(idx as isize * BYTES_PER_WORD as isize);
+                let ptr = seg_start.add(idx as usize * BYTES_PER_WORD);
                 (*reff).set_kind_and_target(kind, ptr);
                 (ptr, reff, segment_id)
             }
@@ -490,18 +490,18 @@ mod wire_helpers {
             let segment_id = (*reff).far_segment_id();
             let (seg_start, _seg_len) = arena.get_segment_mut(segment_id);
             let pad: *mut WirePointer =
-                (seg_start as *mut WirePointer).offset((*reff).far_position_in_segment() as isize);
+                (seg_start as *mut WirePointer).add((*reff).far_position_in_segment() as usize);
             if !(*reff).is_double_far() {
                 Ok((WirePointer::mut_target(pad), pad, segment_id))
             } else {
                 //# Landing pad is another far pointer. It is followed by a
                 //# tag describing the pointed-to object.
-                let reff = pad.offset(1);
+                let reff = pad.add(1);
 
                 let segment_id = (*pad).far_segment_id();
                 let (segment_start, _segment_len) = arena.get_segment_mut(segment_id);
-                let ptr = segment_start
-                    .offset((*pad).far_position_in_segment() as isize * BYTES_PER_WORD as isize);
+                let ptr =
+                    segment_start.add((*pad).far_position_in_segment() as usize * BYTES_PER_WORD);
                 Ok((ptr, reff, segment_id))
             }
         } else {
@@ -523,8 +523,7 @@ mod wire_helpers {
             let far_segment_id = (*reff).far_segment_id();
 
             let (seg_start, _seg_len) = arena.get_segment(far_segment_id)?;
-            let ptr = seg_start
-                .offset((*reff).far_position_in_segment() as isize * BYTES_PER_WORD as isize);
+            let ptr = seg_start.add((*reff).far_position_in_segment() as usize * BYTES_PER_WORD);
 
             let pad_words: usize = if (*reff).is_double_far() { 2 } else { 1 };
             bounds_check(arena, far_segment_id, ptr, pad_words, WirePointerKind::Far)?;
@@ -541,11 +540,11 @@ mod wire_helpers {
                 // Landing pad is another far pointer. It is followed by a tag describing the
                 // pointed-to object.
 
-                let tag = pad.offset(1);
+                let tag = pad.add(1);
                 let double_far_segment_id = (*pad).far_segment_id();
                 let (segment_start, _segment_len) = arena.get_segment(double_far_segment_id)?;
-                let ptr = segment_start
-                    .offset((*pad).far_position_in_segment() as isize * BYTES_PER_WORD as isize);
+                let ptr =
+                    segment_start.add((*pad).far_position_in_segment() as usize * BYTES_PER_WORD);
                 Ok((ptr, tag, double_far_segment_id))
             }
         } else {
@@ -573,17 +572,16 @@ mod wire_helpers {
             WirePointerKind::Far => {
                 let segment_id = (*reff).far_segment_id();
                 let (seg_start, _seg_len) = arena.get_segment_mut(segment_id);
-                let pad: *mut WirePointer = (seg_start as *mut WirePointer)
-                    .offset((*reff).far_position_in_segment() as isize);
+                let pad: *mut WirePointer =
+                    (seg_start as *mut WirePointer).add((*reff).far_position_in_segment() as usize);
 
                 if (*reff).is_double_far() {
                     let segment_id = (*pad).far_segment_id();
 
                     let (seg_start, _seg_len) = arena.get_segment_mut(segment_id);
-                    let ptr = seg_start.offset(
-                        (*pad).far_position_in_segment() as isize * BYTES_PER_WORD as isize,
-                    );
-                    zero_object_helper(arena, segment_id, pad.offset(1), ptr);
+                    let ptr =
+                        seg_start.add((*pad).far_position_in_segment() as usize * BYTES_PER_WORD);
+                    zero_object_helper(arena, segment_id, pad.add(1), ptr);
 
                     ptr::write_bytes(pad, 0u8, 2);
                 } else {
@@ -605,13 +603,12 @@ mod wire_helpers {
                 panic!("Don't know how to handle OTHER")
             }
             WirePointerKind::Struct => {
-                let pointer_section: *mut WirePointer = ptr
-                    .offset((*tag).struct_data_size() as isize * BYTES_PER_WORD as isize)
-                    as *mut _;
+                let pointer_section: *mut WirePointer =
+                    ptr.add((*tag).struct_data_size() as usize * BYTES_PER_WORD) as *mut _;
 
-                let count = (*tag).struct_ptr_count() as isize;
+                let count = (*tag).struct_ptr_count();
                 for i in 0..count {
-                    zero_object(arena, segment_id, pointer_section.offset(i));
+                    zero_object(arena, segment_id, pointer_section.add(i as usize));
                 }
                 ptr::write_bytes(
                     ptr,
@@ -632,12 +629,8 @@ mod wire_helpers {
                 ),
                 Pointer => {
                     let count = (*tag).list_element_count() as usize;
-                    for i in 0..count as isize {
-                        zero_object(
-                            arena,
-                            segment_id,
-                            ptr.offset(i * BYTES_PER_WORD as isize) as *mut _,
-                        );
+                    for i in 0..count {
+                        zero_object(arena, segment_id, ptr.add(i * BYTES_PER_WORD) as *mut _);
                     }
                     ptr::write_bytes(ptr, 0u8, count * BYTES_PER_WORD);
                 }
@@ -655,7 +648,7 @@ mod wire_helpers {
                     let count = (*element_tag).inline_composite_list_element_count();
                     if pointer_count > 0 {
                         for _ in 0..count {
-                            pos = pos.offset(data_size as isize * BYTES_PER_WORD as isize);
+                            pos = pos.add(data_size as usize * BYTES_PER_WORD);
                             for _ in 0..pointer_count {
                                 zero_object(arena, segment_id, pos as *mut WirePointer);
                                 pos = pos.add(BYTES_PER_WORD);
@@ -687,8 +680,7 @@ mod wire_helpers {
         if (*reff).kind() == WirePointerKind::Far {
             let far_segment_id = (*reff).far_segment_id();
             let (seg_start, _seg_len) = arena.get_segment_mut(far_segment_id);
-            let pad = seg_start
-                .offset((*reff).far_position_in_segment() as isize * BYTES_PER_WORD as isize);
+            let pad = seg_start.add((*reff).far_position_in_segment() as usize * BYTES_PER_WORD);
             let num_elements = if (*reff).is_double_far() { 2 } else { 1 };
             ptr::write_bytes(pad, 0, num_elements * BYTES_PER_WORD);
         }
@@ -730,13 +722,11 @@ mod wire_helpers {
                 )?;
                 result.word_count += u64::from((*reff).struct_word_size());
 
-                let pointer_section: *const WirePointer = ptr
-                    .offset((*reff).struct_data_size() as isize * BYTES_PER_WORD as isize)
-                    as *const _;
-                let count: isize = (*reff).struct_ptr_count() as isize;
+                let pointer_section: *const WirePointer =
+                    ptr.add((*reff).struct_data_size() as usize * BYTES_PER_WORD) as *const _;
+                let count: usize = (*reff).struct_ptr_count() as usize;
                 for i in 0..count {
-                    result +=
-                        total_size(arena, segment_id, pointer_section.offset(i), nesting_limit)?;
+                    result += total_size(arena, segment_id, pointer_section.add(i), nesting_limit)?;
                 }
             }
             WirePointerKind::List => {
@@ -768,11 +758,11 @@ mod wire_helpers {
 
                         result.word_count += u64::from(count) * WORDS_PER_POINTER as u64;
 
-                        for i in 0..count as isize {
+                        for i in 0..count as usize {
                             result += total_size(
                                 arena,
                                 segment_id,
-                                (ptr as *const WirePointer).offset(i),
+                                (ptr as *const WirePointer).add(i),
                                 nesting_limit,
                             )?;
                         }
@@ -814,7 +804,7 @@ mod wire_helpers {
                         if pointer_count > 0 {
                             let mut pos = ptr.add(BYTES_PER_WORD);
                             for _ in 0..count {
-                                pos = pos.offset(data_size as isize * BYTES_PER_WORD as isize);
+                                pos = pos.add(data_size as usize * BYTES_PER_WORD);
 
                                 for _ in 0..pointer_count {
                                     result += total_size(
@@ -852,21 +842,21 @@ mod wire_helpers {
         cap_table: CapTableBuilder,
         dst: *mut u8,
         src: *const u8,
-        data_size: isize,
-        pointer_count: isize,
+        data_size: usize,
+        pointer_count: usize,
     ) {
-        copy_nonoverlapping_check_zero(src, dst, data_size as usize * BYTES_PER_WORD);
+        copy_nonoverlapping_check_zero(src, dst, data_size * BYTES_PER_WORD);
 
-        let src_refs: *const WirePointer = (src as *const WirePointer).offset(data_size);
-        let dst_refs: *mut WirePointer = (dst as *mut WirePointer).offset(data_size);
+        let src_refs: *const WirePointer = (src as *const WirePointer).add(data_size);
+        let dst_refs: *mut WirePointer = (dst as *mut WirePointer).add(data_size);
 
         for ii in 0..pointer_count {
             copy_message(
                 arena,
                 segment_id,
                 cap_table,
-                dst_refs.offset(ii),
-                src_refs.offset(ii),
+                dst_refs.add(ii),
+                src_refs.add(ii),
             );
         }
     }
@@ -900,8 +890,8 @@ mod wire_helpers {
                         cap_table,
                         dst_ptr,
                         src_ptr,
-                        (*src).struct_data_size() as isize,
-                        (*src).struct_ptr_count() as isize,
+                        (*src).struct_data_size() as usize,
+                        (*src).struct_ptr_count() as usize,
                     );
                     (*dst).set_struct_size_from_pieces(
                         (*src).struct_data_size(),
@@ -945,13 +935,13 @@ mod wire_helpers {
                         (*src).list_element_count(),
                         WirePointerKind::List,
                     );
-                    for ii in 0..((*src).list_element_count() as isize) {
+                    for ii in 0..((*src).list_element_count() as usize) {
                         copy_message(
                             arena,
                             segment_id,
                             cap_table,
-                            dst_refs.offset(ii * BYTES_PER_WORD as isize) as *mut WirePointer,
-                            src_refs.offset(ii),
+                            dst_refs.add(ii * BYTES_PER_WORD) as *mut WirePointer,
+                            src_refs.add(ii),
                         );
                     }
                     (*dst)
@@ -986,15 +976,13 @@ mod wire_helpers {
                             cap_table,
                             dst_element,
                             src_element,
-                            (*src_tag).struct_data_size() as isize,
-                            (*src_tag).struct_ptr_count() as isize,
+                            (*src_tag).struct_data_size() as usize,
+                            (*src_tag).struct_ptr_count() as usize,
                         );
-                        src_element = src_element.offset(
-                            BYTES_PER_WORD as isize * (*src_tag).struct_word_size() as isize,
-                        );
-                        dst_element = dst_element.offset(
-                            BYTES_PER_WORD as isize * (*src_tag).struct_word_size() as isize,
-                        );
+                        src_element = src_element
+                            .add(BYTES_PER_WORD * (*src_tag).struct_word_size() as usize);
+                        dst_element = dst_element
+                            .add(BYTES_PER_WORD * (*src_tag).struct_word_size() as usize);
                     }
                     (dst_ptr, dst, segment_id)
                 }
@@ -1075,7 +1063,7 @@ mod wire_helpers {
                     let (far_segment_id, word_idx) = arena.allocate_anywhere(2);
                     let (seg_start, _seg_len) = arena.get_segment_mut(far_segment_id);
                     let landing_pad: *mut WirePointer =
-                        (seg_start as *mut WirePointer).offset(word_idx as isize);
+                        (seg_start as *mut WirePointer).add(word_idx as usize);
 
                     let (src_seg_start, _seg_len) = arena.get_segment_mut(src_segment_id);
 
@@ -1086,7 +1074,7 @@ mod wire_helpers {
                     );
                     (*landing_pad).set_far_segment_id(src_segment_id);
 
-                    let landing_pad1 = landing_pad.offset(1);
+                    let landing_pad1 = landing_pad.add(1);
                     (*landing_pad1).set_kind_with_zero_offset((*src_tag).kind());
 
                     ptr::copy_nonoverlapping(
@@ -1103,7 +1091,7 @@ mod wire_helpers {
                     let (seg_start, seg_len) = arena.get_segment_mut(src_segment_id);
                     assert!(landing_pad_word < seg_len);
                     let landing_pad: *mut WirePointer =
-                        (seg_start as *mut WirePointer).offset(landing_pad_word as isize);
+                        (seg_start as *mut WirePointer).add(landing_pad_word as usize);
                     (*landing_pad).set_kind_and_target((*src_tag).kind(), src_ptr);
                     ptr::copy_nonoverlapping(
                         &(*src_tag).upper32bits,
@@ -1140,7 +1128,7 @@ mod wire_helpers {
             segment_id,
             cap_table,
             data: ptr as *mut _,
-            pointers: ptr.offset((size.data as usize) as isize * BYTES_PER_WORD as isize) as *mut _,
+            pointers: ptr.add(size.data as usize * BYTES_PER_WORD) as *mut _,
             data_size: u32::from(size.data) * BitCount32::try_from(BITS_PER_WORD).unwrap(),
             pointer_count: size.pointers,
         }
@@ -1195,7 +1183,7 @@ mod wire_helpers {
         let old_data_size = (*old_ref).struct_data_size();
         let old_pointer_count = (*old_ref).struct_ptr_count();
         let old_pointer_section: *mut WirePointer =
-            old_ptr.offset(old_data_size as isize * BYTES_PER_WORD as isize) as *mut _;
+            old_ptr.add(old_data_size as usize * BYTES_PER_WORD) as *mut _;
 
         if old_data_size < size.data || old_pointer_count < size.pointers {
             //# The space allocated for this struct is too small.
@@ -1222,14 +1210,14 @@ mod wire_helpers {
 
             //# Copy pointer section.
             let new_pointer_section: *mut WirePointer =
-                ptr.offset(new_data_size as isize * BYTES_PER_WORD as isize) as *mut _;
-            for i in 0..old_pointer_count as isize {
+                ptr.add(new_data_size as usize * BYTES_PER_WORD) as *mut _;
+            for i in 0..old_pointer_count as usize {
                 transfer_pointer(
                     arena,
                     segment_id,
-                    new_pointer_section.offset(i),
+                    new_pointer_section.add(i),
                     old_segment_id,
-                    old_pointer_section.offset(i),
+                    old_pointer_section.add(i),
                 );
             }
 
@@ -1436,7 +1424,7 @@ mod wire_helpers {
                         ));
                     }
                     // Adjust the pointer to point at the reference segment.
-                    ptr = ptr.offset(data_size as isize * BYTES_PER_WORD as isize);
+                    ptr = ptr.add(data_size as usize * BYTES_PER_WORD);
                 }
                 InlineComposite => {
                     unreachable!()
@@ -1597,25 +1585,25 @@ mod wire_helpers {
                 copy_nonoverlapping_check_zero(src, dst, old_data_size as usize);
 
                 // Copy pointer section
-                let new_pointer_section = dst.offset(new_data_size as isize);
-                let old_pointer_section = src.offset(old_data_size as isize);
-                for jj in 0..(old_pointer_count as isize) {
+                let new_pointer_section = dst.add(new_data_size as usize);
+                let old_pointer_section = src.add(old_data_size as usize);
+                for jj in 0..(old_pointer_count as usize) {
                     transfer_pointer(
                         arena,
                         new_segment_id,
-                        new_pointer_section.offset(jj),
+                        new_pointer_section.add(jj),
                         old_segment_id,
-                        old_pointer_section.offset(jj),
+                        old_pointer_section.add(jj),
                     );
                 }
 
-                dst = dst.offset(new_step as isize);
-                src = src.offset(old_step as isize);
+                dst = dst.add(new_step as usize);
+                src = src.add(old_step as usize);
             }
 
             // Zero out the old location, making sure to include the tag word.
             ptr::write_bytes(
-                old_ptr.offset(-(BYTES_PER_WORD as isize)),
+                old_ptr.sub(BYTES_PER_WORD),
                 0,
                 usize::try_from(u64::from(old_step) * u64::from(element_count)).unwrap()
                     * BYTES_PER_WORD
@@ -1703,12 +1691,12 @@ mod wire_helpers {
                 new_ptr = new_ptr.add(BYTES_PER_WORD);
 
                 if old_size == ElementSize::Pointer {
-                    let mut dst = new_ptr.offset(new_data_size as isize * BYTES_PER_WORD as isize);
+                    let mut dst = new_ptr.add(new_data_size as usize * BYTES_PER_WORD);
                     let mut src: *mut WirePointer = old_ptr as *mut _;
                     for _ in 0..element_count {
                         transfer_pointer(arena, new_segment_id, dst as *mut _, old_segment_id, src);
-                        dst = dst.offset(new_step as isize * BYTES_PER_WORD as isize);
-                        src = src.offset(1);
+                        dst = dst.add(new_step as usize * BYTES_PER_WORD);
+                        src = src.add(1);
                     }
                 } else {
                     let mut dst = new_ptr;
@@ -1716,8 +1704,8 @@ mod wire_helpers {
                     let old_byte_step = old_data_size / u32::try_from(BITS_PER_BYTE).unwrap();
                     for _ in 0..element_count {
                         copy_nonoverlapping_check_zero(src, dst, old_byte_step as usize);
-                        src = src.offset(old_byte_step as isize);
-                        dst = dst.offset(new_step as isize * BYTES_PER_WORD as isize);
+                        src = src.add(old_byte_step as usize);
+                        dst = dst.add(new_step as usize * BYTES_PER_WORD);
                     }
                 }
 
@@ -1836,7 +1824,7 @@ mod wire_helpers {
         }
 
         let count = (*reff).list_element_count();
-        if count == 0 || *ptr.offset((count - 1) as isize) != 0 {
+        if count == 0 || *ptr.add((count - 1) as usize) != 0 {
             return Err(Error::from_kind(ErrorKind::TextBlobMissingNULTerminator));
         }
 
@@ -1998,17 +1986,17 @@ mod wire_helpers {
         }
 
         let pointer_section: *mut WirePointer =
-            ptr.offset(data_words as isize * BYTES_PER_WORD as isize) as *mut _;
-        for i in 0..ptr_count as isize {
+            ptr.add(data_words as usize * BYTES_PER_WORD) as *mut _;
+        for i in 0..ptr_count as usize {
             deep_copy_pointee(
                 arena,
                 segment_id,
                 cap_table,
-                pointer_section.offset(i),
+                pointer_section.add(i),
                 value.arena,
                 value.segment_id,
                 value.cap_table,
-                value.pointers.offset(i),
+                value.pointers.add(i),
                 value.nesting_limit,
                 canonicalize,
             )?;
@@ -2051,16 +2039,16 @@ mod wire_helpers {
             if value.struct_pointer_count == 1 {
                 //# List of pointers.
                 (*reff).set_list_size_and_count(Pointer, value.element_count);
-                for i in 0..value.element_count as isize {
+                for i in 0..value.element_count as usize {
                     deep_copy_pointee(
                         arena,
                         segment_id,
                         cap_table,
-                        (ptr as *mut WirePointer).offset(i),
+                        (ptr as *mut WirePointer).add(i),
                         value.arena,
                         value.segment_id,
                         value.cap_table,
-                        (value.ptr as *const WirePointer).offset(i),
+                        (value.ptr as *const WirePointer).add(i),
                         value.nesting_limit,
                         canonicalize,
                     )?;
@@ -2175,8 +2163,8 @@ mod wire_helpers {
             let mut src: *const u8 = value.ptr;
             for _ in 0..value.element_count {
                 copy_nonoverlapping_check_zero(src, dst, data_size as usize * BYTES_PER_WORD);
-                dst = dst.offset(data_size as isize * BYTES_PER_WORD as isize);
-                src = src.offset(decl_data_size as isize * BYTES_PER_WORD as isize);
+                dst = dst.add(data_size as usize * BYTES_PER_WORD);
+                src = src.add(decl_data_size as usize * BYTES_PER_WORD);
 
                 for _ in 0..ptr_count {
                     deep_copy_pointee(
@@ -2254,8 +2242,7 @@ mod wire_helpers {
                         segment_id: src_segment_id,
                         cap_table: src_cap_table,
                         data: ptr,
-                        pointers: ptr
-                            .offset((*src).struct_data_size() as isize * BYTES_PER_WORD as isize)
+                        pointers: ptr.add((*src).struct_data_size() as usize * BYTES_PER_WORD)
                             as *const _,
                         data_size: u32::from((*src).struct_data_size())
                             * u32::try_from(BITS_PER_WORD).unwrap(),
@@ -2281,7 +2268,7 @@ mod wire_helpers {
                     bounds_check(
                         src_arena,
                         src_segment_id,
-                        ptr.offset(-(BYTES_PER_WORD as isize)),
+                        ptr.sub(BYTES_PER_WORD),
                         word_count as usize + 1,
                         WirePointerKind::List,
                     )?;
@@ -2453,7 +2440,7 @@ mod wire_helpers {
             segment_id,
             cap_table,
             data: ptr,
-            pointers: ptr.offset(data_size_words as isize * BYTES_PER_WORD as isize) as *const _,
+            pointers: ptr.add(data_size_words as usize * BYTES_PER_WORD) as *const _,
             data_size: u32::from(data_size_words) * u32::try_from(BITS_PER_WORD).unwrap(),
             pointer_count: (*reff).struct_ptr_count(),
             nesting_limit: nesting_limit - 1,
@@ -2530,7 +2517,7 @@ mod wire_helpers {
                 bounds_check(
                     arena,
                     segment_id,
-                    ptr.offset(-(BYTES_PER_WORD as isize)),
+                    ptr.sub(BYTES_PER_WORD),
                     word_count as usize + 1,
                     WirePointerKind::List,
                 )?;
@@ -2716,7 +2703,7 @@ mod wire_helpers {
 
         let str_ptr = ptr;
 
-        if (*str_ptr.offset((size - 1) as isize)) != 0u8 {
+        if (*str_ptr.add((size - 1) as usize)) != 0u8 {
             return Err(Error::from_kind(
                 ErrorKind::MessageContainsTextThatIsNotNULTerminated,
             ));
@@ -3583,12 +3570,12 @@ impl<'a> StructReader<'a> {
             cap_count: 0,
         };
 
-        for i in 0..self.pointer_count as isize {
+        for i in 0..self.pointer_count as usize {
             unsafe {
                 result += wire_helpers::total_size(
                     self.arena,
                     self.segment_id,
-                    self.pointers.offset(i),
+                    self.pointers.add(i),
                     self.nesting_limit,
                 )?;
             }
@@ -3637,9 +3624,9 @@ impl<'a> StructReader<'a> {
         }
 
         read_head.set(unsafe {
-            (read_head.get()).offset(
-                (data_size as isize + self.pointer_count as isize) * (BYTES_PER_WORD as isize),
-            )
+            read_head
+                .get()
+                .add((data_size as usize + self.pointer_count as usize) * BYTES_PER_WORD)
         });
 
         for ptr_idx in 0..self.pointer_count {
@@ -3835,25 +3822,25 @@ impl<'a> StructBuilder<'a> {
             }
 
             // Zero out all pointers in the target.
-            for i in 0..self.pointer_count as isize {
+            for i in 0..self.pointer_count as usize {
                 wire_helpers::zero_object(
                     self.arena,
                     self.segment_id,
-                    self.pointers.offset(i) as *mut _,
+                    self.pointers.add(i) as *mut _,
                 );
             }
             ptr::write_bytes(self.pointers, 0u8, self.pointer_count as usize);
 
-            for i in 0..shared_pointer_count as isize {
+            for i in 0..shared_pointer_count as usize {
                 wire_helpers::deep_copy_pointee(
                     self.arena,
                     self.segment_id,
                     self.cap_table,
-                    self.pointers.offset(i),
+                    self.pointers.add(i),
                     other.arena,
                     other.segment_id,
                     other.cap_table,
-                    other.pointers.offset(i),
+                    other.pointers.add(i),
                     other.nesting_limit,
                     false,
                 )?;
@@ -4025,7 +4012,7 @@ impl<'a> ListReader<'a> {
                 read_head.set(unsafe {
                     read_head
                         .get()
-                        .offset(self.element_count as isize * BYTES_PER_WORD as isize)
+                        .add(self.element_count as usize * BYTES_PER_WORD)
                 });
                 for idx in 0..self.element_count {
                     if !self.get_pointer_element(idx).is_canonical(read_head)? {
@@ -4062,14 +4049,14 @@ impl<'a> ListReader<'a> {
                     if partial_byte & mask != 0 {
                         return Ok(false);
                     }
-                    byte_read_head = unsafe { byte_read_head.offset(1_isize) };
+                    byte_read_head = unsafe { byte_read_head.add(1) };
                 }
 
                 while byte_read_head != read_head_end {
                     if unsafe { *byte_read_head } != 0 {
                         return Ok(false);
                     }
-                    byte_read_head = unsafe { byte_read_head.offset(1_isize) };
+                    byte_read_head = unsafe { byte_read_head.add(1) };
                 }
 
                 read_head.set(read_head_end);

--- a/capnp/src/serialize_packed.rs
+++ b/capnp/src/serialize_packed.rs
@@ -116,7 +116,7 @@ where
                     //# slowly, doing a bounds check on each byte.
 
                     tag = *in_ptr;
-                    in_ptr = in_ptr.offset(1);
+                    in_ptr = in_ptr.add(1);
 
                     for i in 0..8 {
                         if (tag & (1u8 << i)) != 0 {
@@ -132,11 +132,11 @@ where
                                 );
                             }
                             *out = *in_ptr;
-                            out = out.offset(1);
-                            in_ptr = in_ptr.offset(1);
+                            out = out.add(1);
+                            in_ptr = in_ptr.add(1);
                         } else {
                             *out = 0;
-                            out = out.offset(1);
+                            out = out.add(1);
                         }
                     }
 
@@ -145,13 +145,13 @@ where
                     }
                 } else {
                     tag = *in_ptr;
-                    in_ptr = in_ptr.offset(1);
+                    in_ptr = in_ptr.add(1);
 
                     for n in 0..8 {
                         let is_nonzero = (tag & (1u8 << n)) != 0;
                         *out = (*in_ptr) & ((-i8::from(is_nonzero)) as u8);
-                        out = out.offset(1);
-                        in_ptr = in_ptr.offset(isize::from(is_nonzero));
+                        out = out.add(1);
+                        in_ptr = in_ptr.add(is_nonzero as usize);
                     }
                 }
                 if tag == 0 {
@@ -161,7 +161,7 @@ where
                     );
 
                     let run_length: usize = (*in_ptr) as usize * 8;
-                    in_ptr = in_ptr.offset(1);
+                    in_ptr = in_ptr.add(1);
 
                     if run_length > ptr_sub(out_end, out) {
                         return Err(Error::from_kind(
@@ -178,7 +178,7 @@ where
                     );
 
                     let mut run_length: usize = (*in_ptr) as usize * 8;
-                    in_ptr = in_ptr.offset(1);
+                    in_ptr = in_ptr.add(1);
 
                     if run_length > ptr_sub(out_end, out) {
                         return Err(Error::from_kind(
@@ -324,42 +324,42 @@ where
                 let bit0 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit0 as usize;
-                in_ptr = in_ptr.offset(1);
+                in_ptr = in_ptr.add(1);
 
                 let bit1 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit1 as usize;
-                in_ptr = in_ptr.offset(1);
+                in_ptr = in_ptr.add(1);
 
                 let bit2 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit2 as usize;
-                in_ptr = in_ptr.offset(1);
+                in_ptr = in_ptr.add(1);
 
                 let bit3 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit3 as usize;
-                in_ptr = in_ptr.offset(1);
+                in_ptr = in_ptr.add(1);
 
                 let bit4 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit4 as usize;
-                in_ptr = in_ptr.offset(1);
+                in_ptr = in_ptr.add(1);
 
                 let bit5 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit5 as usize;
-                in_ptr = in_ptr.offset(1);
+                in_ptr = in_ptr.add(1);
 
                 let bit6 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit6 as usize;
-                in_ptr = in_ptr.offset(1);
+                in_ptr = in_ptr.add(1);
 
                 let bit7 = u8::from(*in_ptr != 0);
                 *buf.get_unchecked_mut(buf_idx) = *in_ptr;
                 buf_idx += bit7 as usize;
-                in_ptr = in_ptr.offset(1);
+                in_ptr = in_ptr.add(1);
 
                 let tag: u8 = bit0
                     | (bit1 << 1)
@@ -380,10 +380,10 @@ where
                     let mut in_word: *const [u8; 8] = in_ptr as *const [u8; 8];
                     let mut limit: *const [u8; 8] = in_end as *const [u8; 8];
                     if ptr_sub(limit, in_word) > 255 {
-                        limit = in_word.offset(255);
+                        limit = in_word.add(255);
                     }
                     while in_word < limit && *in_word == [0; 8] {
-                        in_word = in_word.offset(1);
+                        in_word = in_word.add(1);
                     }
 
                     *buf.get_unchecked_mut(buf_idx) = ptr_sub(in_word, in_ptr as *const [u8; 8])
@@ -403,7 +403,7 @@ where
                     let run_start = in_ptr;
                     let mut limit = in_end;
                     if ptr_sub(limit, in_ptr) > 255 * 8 {
-                        limit = in_ptr.offset(255 * 8);
+                        limit = in_ptr.add(255 * 8);
                     }
 
                     while in_ptr < limit {
@@ -411,13 +411,13 @@ where
 
                         for _ in 0..8 {
                             c += u8::from(*in_ptr == 0);
-                            in_ptr = in_ptr.offset(1);
+                            in_ptr = in_ptr.add(1);
                         }
 
                         if c >= 2 {
                             //# Un-read the word with multiple zeros, since
                             //# we'll want to compress that one.
-                            in_ptr = in_ptr.offset(-8);
+                            in_ptr = in_ptr.sub(8);
                             break;
                         }
                     }


### PR DESCRIPTION
Use `.add()` instead of `.offset()` where argument is unsigned so
- more clear what is happening there
- fewer casts in code