### PR TITLE
add, checked_sub in set_list_pointer

### DIFF
--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -2182,8 +2182,9 @@ mod wire_helpers {
                     src = src.add(BYTES_PER_WORD);
                 }
 
-                src =
-                    src.offset((decl_pointer_count - ptr_count) as isize * BYTES_PER_WORD as isize);
+                src = src.add(
+                    decl_pointer_count.checked_sub(ptr_count).unwrap() as usize * BYTES_PER_WORD,
+                );
             }
             Ok(SegmentAnd {
                 segment_id,


### PR DESCRIPTION
Preparation to `deny(cast_possible_wrap)`.

I used `checked_sub` because
- it is often free when compiler can prove it does not underflow
- when it is not free, it is virtually free because of how branch prediction works on modern CPUs (default branch is executed speculatively, and the panicking branch does not occupy prediction table entry)