### PR TITLE
Reproduce and fix bug related with `-> stream` not being queued

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "capnp-rpc/examples/calculator",
     "capnp-rpc/examples/pubsub",
     "capnp-rpc/examples/streaming",
+    "capnp-rpc/examples/bytestream",
     "capnp-rpc/examples/reconnect",
     "capnp-rpc/test",
     "example/addressbook",

--- a/capnp-rpc/examples/bytestream/Cargo.toml
+++ b/capnp-rpc/examples/bytestream/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "bytestream"
+version = "0.1.0"
+edition = "2021"
+build = "build.rs"
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+capnpc = { path = "../../../capnpc" }
+
+[dependencies]
+capnp = { path = "../../../capnp" }
+capnp-rpc = { path = "../.." }
+futures = "0.3.0"
+rand = "0.9.0"
+sha2 = { version = "0.11.0" }
+tokio = { version = "1.0.0", features = ["net", "rt", "time"] }
+tokio-util = { version = "0.7.4", features = ["compat"] }
+
+[lints]
+workspace = true

--- a/capnp-rpc/examples/bytestream/build.rs
+++ b/capnp-rpc/examples/bytestream/build.rs
@@ -1,0 +1,7 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    capnpc::CompilerCommand::new()
+        .import_path(".")
+        .file("bytestream.capnp")
+        .run()?;
+    Ok(())
+}

--- a/capnp-rpc/examples/bytestream/bytestream.capnp
+++ b/capnp-rpc/examples/bytestream/bytestream.capnp
@@ -1,0 +1,14 @@
+@0xd8c625bf1f3f8cf4;
+
+interface ByteStream {
+  write @0 (bytes :Data) -> stream;
+  end @1 ();
+}
+
+interface Transfer {
+  wait @0 () -> (sha256 :Data);
+}
+
+interface Sender {
+  send @0 (stream :ByteStream, size :UInt64, chunkSize :UInt32) -> (transfer :Transfer);
+}

--- a/capnp-rpc/examples/bytestream/capnp/stream.capnp
+++ b/capnp-rpc/examples/bytestream/capnp/stream.capnp
@@ -1,0 +1,24 @@
+# Copyright (c) 2019 Cloudflare, Inc. and contributors
+# Licensed under the MIT License:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+@0x86c366a91393f3f8;
+
+struct StreamResult @0x995f9a3377c0b16e {}

--- a/capnp-rpc/examples/bytestream/lib.rs
+++ b/capnp-rpc/examples/bytestream/lib.rs
@@ -1,0 +1,285 @@
+use std::rc::Rc;
+use std::sync::mpsc;
+
+use capnp::Error;
+use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
+use futures::channel::oneshot;
+use futures::lock::Mutex;
+use futures::AsyncReadExt;
+use rand::Rng;
+use sha2::{Digest, Sha256};
+
+capnp::generated_code!(pub mod bytestream_capnp);
+
+use bytestream_capnp::{byte_stream, sender, transfer};
+
+// Small chunks let the default 64 KiB flow-control window hold many writes in
+// flight, so the race reproduces without increasing VatNetwork's window size.
+const STREAM_SIZE: u64 = 1024 * 1024;
+const CHUNK_SIZE: u32 = 256;
+const WINDOW_SIZE: usize = 1024 * 1024;
+// Without an async boundary in `write()`, writes complete synchronously and the
+// following `end()` has no pending work to overtake.
+const WRITE_YIELDS: usize = 8;
+
+struct ByteStreamImpl {
+    state: Rc<Mutex<ByteStreamState>>,
+}
+
+struct ByteStreamState {
+    hasher: Sha256,
+    bytes_received: u64,
+    done: Option<oneshot::Sender<(Vec<u8>, u64)>>,
+}
+
+impl ByteStreamImpl {
+    fn new(done: oneshot::Sender<(Vec<u8>, u64)>) -> Self {
+        Self {
+            state: Rc::new(Mutex::new(ByteStreamState {
+                hasher: Sha256::new(),
+                bytes_received: 0,
+                done: Some(done),
+            })),
+        }
+    }
+}
+
+impl byte_stream::Server for ByteStreamImpl {
+    async fn write(self: Rc<Self>, params: byte_stream::WriteParams) -> Result<(), Error> {
+        let mut state = self.state.lock().await;
+
+        let bytes = params.get()?.get_bytes()?.to_vec();
+
+        // Model an AsyncWrite sink that returns Pending before completing the write.
+        for _ in 0..WRITE_YIELDS {
+            tokio::task::yield_now().await;
+        }
+
+        state.bytes_received += bytes.len() as u64;
+        state.hasher.update(&bytes);
+        Ok(())
+    }
+
+    async fn end(
+        self: Rc<Self>,
+        _params: byte_stream::EndParams,
+        _results: byte_stream::EndResults,
+    ) -> Result<(), Error> {
+        let mut state = self.state.lock().await;
+        let hash = std::mem::take(&mut state.hasher).finalize()[..].to_vec();
+        let bytes_received = state.bytes_received;
+        if let Some(done) = state.done.take() {
+            let _ = done.send((hash, bytes_received));
+        }
+        Ok(())
+    }
+}
+
+struct SenderImpl;
+
+struct TransferImpl {
+    state: Rc<Mutex<TransferState>>,
+}
+
+struct TransferState {
+    result: Option<Result<Vec<u8>, Error>>,
+    waiters: Vec<oneshot::Sender<Result<Vec<u8>, Error>>>,
+}
+
+impl TransferImpl {
+    fn new() -> Self {
+        Self {
+            state: Rc::new(Mutex::new(TransferState {
+                result: None,
+                waiters: Vec::new(),
+            })),
+        }
+    }
+}
+
+async fn send_bytes(
+    stream: byte_stream::Client,
+    stream_size: u64,
+    chunk_size: u32,
+) -> Result<Vec<u8>, Error> {
+    let mut rng = rand::rng();
+    let mut hasher = Sha256::new();
+    let mut bytes_written = 0;
+    while bytes_written < stream_size {
+        let mut request = stream.write_request();
+        let this_chunk_size = u64::min(chunk_size as u64, stream_size - bytes_written);
+        let bytes = request.get().init_bytes(this_chunk_size as u32);
+        rng.fill(bytes);
+        hasher.update(bytes);
+        request.send().await?;
+        bytes_written += this_chunk_size;
+    }
+
+    stream.end_request().send().promise.await?;
+    Ok(hasher.finalize()[..].to_vec())
+}
+
+async fn finish_send(state: Rc<Mutex<TransferState>>, result: Result<Vec<u8>, Error>) {
+    let waiters = {
+        let mut state = state.lock().await;
+        state.result = Some(result.clone());
+        std::mem::take(&mut state.waiters)
+    };
+
+    for waiter in waiters {
+        let _ = waiter.send(result.clone());
+    }
+}
+
+impl transfer::Server for TransferImpl {
+    async fn wait(
+        self: Rc<Self>,
+        _params: transfer::WaitParams,
+        mut results: transfer::WaitResults,
+    ) -> Result<(), Error> {
+        let receiver = {
+            let mut state = self.state.lock().await;
+            if let Some(result) = state.result.clone() {
+                match result {
+                    Ok(sha256) => {
+                        results.get().set_sha256(&sha256[..]);
+                        return Ok(());
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+
+            let (sender, receiver) = oneshot::channel();
+            state.waiters.push(sender);
+            receiver
+        };
+
+        let sha256 = match receiver.await {
+            Ok(Ok(sha256)) => sha256,
+            Ok(Err(e)) => return Err(e),
+            Err(_) => return Err(Error::failed("send task was canceled".into())),
+        };
+        results.get().set_sha256(&sha256[..]);
+        Ok(())
+    }
+}
+
+impl sender::Server for SenderImpl {
+    async fn send(
+        self: Rc<Self>,
+        params: sender::SendParams,
+        mut results: sender::SendResults,
+    ) -> Result<(), Error> {
+        let params = params.get()?;
+        let stream = params.get_stream()?;
+        let stream_size = params.get_size();
+        let chunk_size = params.get_chunk_size();
+
+        let transfer_impl = TransferImpl::new();
+        let state = transfer_impl.state.clone();
+        results
+            .get()
+            .set_transfer(capnp_rpc::new_client(transfer_impl));
+
+        tokio::task::spawn_local(async move {
+            let result = send_bytes(stream, stream_size, chunk_size).await;
+            finish_send(state, result).await;
+        });
+        Ok(())
+    }
+}
+
+#[test]
+fn tcp_bytestream_end_waits_for_streaming_writes() {
+    let (addr_sender, addr_receiver) = mpsc::channel();
+    let server_thread = std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .enable_time()
+            .build()
+            .unwrap();
+
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&runtime, async move {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            addr_sender.send(listener.local_addr().unwrap()).unwrap();
+
+            let (stream, _) = listener.accept().await.unwrap();
+            stream.set_nodelay(true).unwrap();
+            let (reader, writer) =
+                tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
+            let mut network = twoparty::VatNetwork::new(
+                futures::io::BufReader::new(reader),
+                futures::io::BufWriter::new(writer),
+                rpc_twoparty_capnp::Side::Server,
+                Default::default(),
+            );
+            network.set_window_size(WINDOW_SIZE);
+
+            let sender: sender::Client = capnp_rpc::new_client(SenderImpl);
+            RpcSystem::new(Box::new(network), Some(sender.client))
+                .await
+                .unwrap();
+        });
+    });
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&runtime, async move {
+        let stream = tokio::net::TcpStream::connect(addr_receiver.recv().unwrap())
+            .await
+            .unwrap();
+        stream.set_nodelay(true).unwrap();
+        let (reader, writer) = tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
+        let mut network = twoparty::VatNetwork::new(
+            futures::io::BufReader::new(reader),
+            futures::io::BufWriter::new(writer),
+            rpc_twoparty_capnp::Side::Client,
+            Default::default(),
+        );
+        network.set_window_size(WINDOW_SIZE);
+
+        let mut rpc_system = RpcSystem::new(Box::new(network), None);
+        let sender: sender::Client = rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
+        let disconnector = rpc_system.get_disconnector();
+        tokio::task::spawn_local(rpc_system);
+
+        let (done_sender, done_receiver) = oneshot::channel();
+        let stream: byte_stream::Client = capnp_rpc::new_client(ByteStreamImpl::new(done_sender));
+        let mut request = sender.send_request();
+        request.get().set_stream(stream);
+        request.get().set_size(STREAM_SIZE);
+        request.get().set_chunk_size(CHUNK_SIZE);
+
+        let local_result = async move {
+            done_receiver
+                .await
+                .map_err(|_| Error::failed("ByteStream.end() was not called".into()))
+        };
+        let wait_promise = request
+            .send()
+            .pipeline
+            .get_transfer()
+            .wait_request()
+            .send()
+            .promise;
+        let (response, (local_sha256, bytes_received)) =
+            futures::future::try_join(wait_promise, local_result)
+                .await
+                .unwrap();
+
+        assert_eq!(bytes_received, STREAM_SIZE);
+        assert_eq!(
+            response.get().unwrap().get_sha256().unwrap(),
+            &local_sha256[..]
+        );
+
+        disconnector.await.unwrap();
+    });
+
+    server_thread.join().unwrap();
+}

--- a/capnp-rpc/src/local.rs
+++ b/capnp-rpc/src/local.rs
@@ -30,7 +30,11 @@ use futures::channel::oneshot;
 use futures::TryFutureExt;
 
 use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
 use std::rc::Rc;
+use std::task::{Context, Poll};
 
 pub trait ResultsDoneHook {
     fn add_ref(&self) -> Box<dyn ResultsDoneHook>;
@@ -339,11 +343,186 @@ pub(crate) struct Client<S>
 where
     S: capability::Server + Clone,
 {
+    state: Rc<RefCell<ClientState<S>>>,
+}
+
+struct ClientState<S>
+where
+    S: capability::Server + Clone,
+{
     inner: S,
 
     /// If a streaming call on this capability has returned an error,
     /// this contains a copy of that error.
-    broken_error: Rc<RefCell<Option<Error>>>,
+    broken_error: Option<Error>,
+
+    /// True while a streaming call is in flight. Later calls must wait here so
+    /// non-streaming calls, like EOF methods, cannot overtake streaming writes.
+    blocked: bool,
+    blocked_calls: VecDeque<BlockedCall>,
+}
+
+struct BlockedCall {
+    interface_id: u64,
+    method_id: u16,
+    params: Box<dyn ParamsHook>,
+    results: Box<dyn ResultsHook>,
+    fulfiller: oneshot::Sender<Promise<(), Error>>,
+}
+
+struct StreamingCall<S>
+where
+    S: capability::Server + Clone + 'static,
+{
+    state: Rc<RefCell<ClientState<S>>>,
+    promise: Promise<(), Error>,
+    completed: bool,
+}
+
+impl<S> Unpin for StreamingCall<S> where S: capability::Server + Clone + 'static {}
+
+impl<S> Future for StreamingCall<S>
+where
+    S: capability::Server + Clone + 'static,
+{
+    type Output = Result<(), Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        match Pin::new(&mut this.promise).poll(cx) {
+            Poll::Ready(result) => {
+                if let Err(e) = &result {
+                    this.state.borrow_mut().broken_error = Some(e.clone());
+                }
+                this.completed = true;
+                ClientState::unblock(this.state.clone());
+                Poll::Ready(result)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<S> Drop for StreamingCall<S>
+where
+    S: capability::Server + Clone + 'static,
+{
+    fn drop(&mut self) {
+        if !self.completed {
+            ClientState::unblock(self.state.clone());
+        }
+    }
+}
+
+impl<S> ClientState<S>
+where
+    S: capability::Server + Clone + 'static,
+{
+    fn dispatch_or_queue(
+        state: Rc<RefCell<Self>>,
+        interface_id: u64,
+        method_id: u16,
+        params: Box<dyn ParamsHook>,
+        results: Box<dyn ResultsHook>,
+    ) -> Promise<(), Error> {
+        {
+            let mut state_ref = state.borrow_mut();
+            if let Some(e) = &state_ref.broken_error {
+                return Promise::err(e.clone());
+            }
+
+            if state_ref.blocked {
+                let (fulfiller, promise) = oneshot::channel();
+                state_ref.blocked_calls.push_back(BlockedCall {
+                    interface_id,
+                    method_id,
+                    params,
+                    results,
+                    fulfiller,
+                });
+
+                // The queued call has not started yet. Resolve this promise
+                // with the call's real promise once it reaches the front.
+                return Promise::from_future(async move {
+                    match promise.await {
+                        Ok(p) => p.await,
+                        Err(e) => Err(crate::canceled_to_error(e)),
+                    }
+                });
+            }
+        }
+
+        Self::dispatch_call(state, interface_id, method_id, params, results)
+    }
+
+    fn dispatch_call(
+        state: Rc<RefCell<Self>>,
+        interface_id: u64,
+        method_id: u16,
+        params: Box<dyn ParamsHook>,
+        results: Box<dyn ResultsHook>,
+    ) -> Promise<(), Error> {
+        let inner = {
+            let state_ref = state.borrow();
+            if let Some(e) = &state_ref.broken_error {
+                return Promise::err(e.clone());
+            }
+            state_ref.inner.clone()
+        };
+
+        let f = inner.dispatch_call(
+            interface_id,
+            method_id,
+            ::capnp::capability::Params::new(params),
+            ::capnp::capability::Results::new(results),
+        );
+
+        if f.is_streaming {
+            // A streaming call serializes later calls on the same local
+            // capability until its server-side promise completes.
+            state.borrow_mut().blocked = true;
+            Promise::from_future(StreamingCall {
+                state,
+                promise: f.promise,
+                completed: false,
+            })
+        } else {
+            f.promise
+        }
+    }
+
+    fn unblock(state: Rc<RefCell<Self>>) {
+        loop {
+            let blocked_call = {
+                let mut state_ref = state.borrow_mut();
+                state_ref.blocked = false;
+                state_ref.blocked_calls.pop_front()
+            };
+
+            let Some(blocked_call) = blocked_call else {
+                return;
+            };
+
+            if blocked_call.fulfiller.is_canceled() {
+                continue;
+            }
+
+            let promise = Self::dispatch_call(
+                state.clone(),
+                blocked_call.interface_id,
+                blocked_call.method_id,
+                blocked_call.params,
+                blocked_call.results,
+            );
+            let _ = blocked_call.fulfiller.send(promise);
+
+            // If the unblocked call was itself streaming, dispatch_call() set
+            // blocked again; leave remaining calls queued behind it.
+            if state.borrow().blocked {
+                return;
+            }
+        }
+    }
 }
 
 impl<S> Client<S>
@@ -352,8 +531,12 @@ where
 {
     pub(crate) fn new(server: S) -> Self {
         Self {
-            inner: server,
-            broken_error: Rc::new(RefCell::new(None)),
+            state: Rc::new(RefCell::new(ClientState {
+                inner: server,
+                broken_error: None,
+                blocked: false,
+                blocked_calls: VecDeque::new(),
+            })),
         }
     }
 }
@@ -364,8 +547,7 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            inner: self.inner.clone(),
-            broken_error: self.broken_error.clone(),
+            state: self.state.clone(),
         }
     }
 }
@@ -398,36 +580,17 @@ where
         params: Box<dyn ParamsHook>,
         results: Box<dyn ResultsHook>,
     ) -> Promise<(), Error> {
-        let streaming_error = self.broken_error.clone();
-        if let Some(e) = &*streaming_error.borrow() {
-            // Previous streaming call threw, so everything fails from now on.
-            return Promise::err(e.clone());
-        }
-
         // We don't want to actually dispatch the call synchronously, because we don't want the callee
         // to have any side effects before the promise is returned to the caller.  This helps avoid
         // race conditions.
-        //
-        // TODO: actually use some kind of queue here to guarantee that call order is maintained.
-        // This currently relies on the task scheduler being first-in-first-out.
-        let inner = self.inner.clone();
+        let state = self.state.clone();
         Promise::from_future(async move {
-            let f = inner.dispatch_call(
-                interface_id,
-                method_id,
-                ::capnp::capability::Params::new(params),
-                ::capnp::capability::Results::new(results),
-            );
-            let result = f.promise.await;
-            if let (true, Err(e)) = (f.is_streaming, &result) {
-                *streaming_error.borrow_mut() = Some(e.clone());
-            }
-            result
+            ClientState::dispatch_or_queue(state, interface_id, method_id, params, results).await
         })
     }
 
     fn get_ptr(&self) -> usize {
-        self.inner.as_ptr()
+        self.state.borrow().inner.as_ptr()
     }
 
     fn get_brand(&self) -> usize {

--- a/capnp-rpc/test/build.rs
+++ b/capnp-rpc/test/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     ::capnpc::CompilerCommand::new()
+        .import_path(".")
         .file("test.capnp")
         .run()
         .unwrap();

--- a/capnp-rpc/test/capnp/stream.capnp
+++ b/capnp-rpc/test/capnp/stream.capnp
@@ -1,0 +1,26 @@
+# Copyright (c) 2019 Cloudflare, Inc. and contributors
+# Licensed under the MIT License:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+@0x86c366a91393f3f8;
+
+struct StreamResult @0x995f9a3377c0b16e {
+  # Empty struct that serves as the return type for streaming methods.
+}

--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -29,6 +29,12 @@ use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
 use futures::channel::oneshot;
 use futures::{Future, FutureExt, TryFutureExt};
 
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+use std::time::Duration;
+
 capnp::generated_code!(pub mod test_capnp);
 
 pub mod impls;
@@ -304,6 +310,137 @@ where
 {
     rpc_top_level(main.clone());
     local_top_level(main);
+}
+
+#[derive(Clone, Default)]
+struct SharedGate {
+    inner: Arc<SharedGateInner>,
+}
+
+#[derive(Default)]
+struct SharedGateInner {
+    open: AtomicBool,
+    wakers: Mutex<Vec<Waker>>,
+}
+
+impl SharedGate {
+    fn wait(&self) -> SharedGateWait {
+        SharedGateWait { gate: self.clone() }
+    }
+
+    fn open(&self) {
+        self.inner.open.store(true, Ordering::SeqCst);
+        for waker in std::mem::take(&mut *self.inner.wakers.lock().unwrap()) {
+            waker.wake();
+        }
+    }
+}
+
+struct SharedGateWait {
+    gate: SharedGate,
+}
+
+impl Future for SharedGateWait {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.gate.inner.open.load(Ordering::SeqCst) {
+            Poll::Ready(())
+        } else {
+            let mut wakers = self.gate.inner.wakers.lock().unwrap();
+            if self.gate.inner.open.load(Ordering::SeqCst) {
+                Poll::Ready(())
+            } else {
+                wakers.push(cx.waker().clone());
+                Poll::Pending
+            }
+        }
+    }
+}
+
+struct GatedTestStreamingImpl {
+    i_sum: std::cell::Cell<u32>,
+    gate: SharedGate,
+}
+
+impl GatedTestStreamingImpl {
+    fn new(gate: SharedGate) -> Self {
+        Self {
+            i_sum: std::cell::Cell::new(0),
+            gate,
+        }
+    }
+}
+
+impl test_capnp::test_streaming::Server for GatedTestStreamingImpl {
+    async fn do_stream_i(
+        self: std::rc::Rc<Self>,
+        params: test_capnp::test_streaming::DoStreamIParams,
+    ) -> Result<(), Error> {
+        let i = params.get()?.get_i();
+        self.gate.wait().await;
+        self.i_sum.set(self.i_sum.get() + i);
+        Ok(())
+    }
+
+    async fn finish_stream(
+        self: std::rc::Rc<Self>,
+        _params: test_capnp::test_streaming::FinishStreamParams,
+        mut results: test_capnp::test_streaming::FinishStreamResults,
+    ) -> Result<(), Error> {
+        let total_i = self.i_sum.get();
+        self.gate.open();
+        results.get().set_total_i(total_i);
+        Ok(())
+    }
+}
+
+fn rpc_streaming_top_level<F, G>(gate: SharedGate, main: F)
+where
+    F: FnOnce(futures::executor::LocalSpawner, test_capnp::test_streaming::Client, SharedGate) -> G,
+    F: Send + 'static,
+    G: Future<Output = Result<(), Error>> + 'static,
+{
+    let mut pool = futures::executor::LocalPool::new();
+    let mut spawner = pool.spawner();
+    let (client_writer, server_reader) = async_byte_channel::channel();
+    let (server_writer, client_reader) = async_byte_channel::channel();
+    let server_gate = gate.clone();
+
+    let join_handle = std::thread::spawn(move || {
+        let mut network = twoparty::VatNetwork::new(
+            server_reader,
+            server_writer,
+            rpc_twoparty_capnp::Side::Server,
+            Default::default(),
+        );
+        network.set_window_size(256 * 1024);
+
+        let bootstrap: test_capnp::test_streaming::Client =
+            capnp_rpc::new_client(GatedTestStreamingImpl::new(server_gate));
+        let rpc_system = RpcSystem::new(Box::new(network), Some(bootstrap.client));
+        futures::executor::block_on(rpc_system).unwrap();
+    });
+
+    let mut network = twoparty::VatNetwork::new(
+        client_reader,
+        client_writer,
+        rpc_twoparty_capnp::Side::Client,
+        Default::default(),
+    );
+    network.set_window_size(256 * 1024);
+
+    let mut rpc_system = RpcSystem::new(Box::new(network), None);
+    let client: test_capnp::test_streaming::Client =
+        rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
+
+    let disconnector = rpc_system.get_disconnector();
+    spawn(&mut spawner, rpc_system);
+    let result = pool.run_until(main(spawner, client, gate));
+
+    pool.run_until(disconnector).unwrap();
+    join_handle.join().unwrap();
+    result.unwrap();
 }
 
 #[test]
@@ -1178,6 +1315,39 @@ fn basic_streaming() {
         let r = client.finish_stream_request().send().promise.await?;
         let results = r.get()?;
         assert_eq!(results.get_total_i(), ITERS * EACH);
+        Ok(())
+    });
+}
+
+#[test]
+fn streaming_calls_complete_before_following_call() {
+    const EACH: u32 = 10;
+    const ITERS: u32 = 8;
+    const EXPECTED: u32 = EACH * ITERS;
+
+    let gate = SharedGate::default();
+    rpc_streaming_top_level(gate, |_spawner, client, gate| async move {
+        for _ in 0..ITERS {
+            let mut request = client.do_stream_i_request();
+            request.get().set_i(EACH);
+            request.send().await?;
+        }
+
+        let release_gate = gate.clone();
+        let release_thread = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            release_gate.open();
+        });
+
+        let r = client.finish_stream_request().send().promise.await?;
+        release_thread.join().unwrap();
+
+        let total_i = r.get()?.get_total_i();
+        if total_i != EXPECTED {
+            return Err(Error::failed(format!(
+                "finishStream observed {total_i} streamed items, expected {EXPECTED}"
+            )));
+        }
         Ok(())
     });
 }


### PR DESCRIPTION
Awaiting a -> stream call only means flow-control has room to send more data. It does not guarantee the receiver has finished processing that call. A following non-streaming call, like end() in the bytestream example, could run before earlier streaming write() calls completed.

In our real usage this sometimes surfaced as:
`Error { kind: MessageContainsOutOfBoundsPointer, extra: "" }`
In this repro, I was not able to reproduce that exact out-of-bounds error. The repro reliably shows the underlying ordering issue instead: end() completes before all bytes have arrived.

The changes have been driven by GPT 5.5, the main fixes are not depending on the runtime processing tasks in a FIFO way, and having our own queue of call dispatches in `local.rs`.