### PR TITLE
Capability pipelining with a motivating example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "capnp-rpc/examples/hello-world",
     "capnp-rpc/examples/calculator",
     "capnp-rpc/examples/pubsub",
+    "capnp-rpc/examples/shared-secret-capability",
     "capnp-rpc/examples/streaming",
     "capnp-rpc/examples/reconnect",
     "capnp-rpc/test",

--- a/capnp-rpc/examples/shared-secret-capability/Cargo.toml
+++ b/capnp-rpc/examples/shared-secret-capability/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+
+name = "shared-secret-capability"
+version = "0.0.0"
+authors = [ "Adam Schwab <aschwab@cloudflare.com>"  ]
+edition = "2021"
+
+build = "build.rs"
+
+[[bin]]
+name = "shared-secret-capability"
+path = "main.rs"
+
+[build-dependencies]
+capnpc = { path = "../../../capnpc" }
+
+[dependencies]
+capnp = { path = "../../../capnp" }
+futures = "0.3.0"
+tokio = { version = "1.0.0", features = ["net", "rt", "macros"]}
+tokio-util = { version = "0.7.4", features = ["compat"] }
+
+[dependencies.capnp-rpc]
+path = "../.."
+
+[lints]
+workspace = true

--- a/capnp-rpc/examples/shared-secret-capability/README.md
+++ b/capnp-rpc/examples/shared-secret-capability/README.md
@@ -1,0 +1,14 @@
+# Shared Secret Capability
+
+
+To run, in two separate terminals, do:
+
+```
+$ cargo run server 127.0.0.1:4000 "secret"
+```
+
+and
+
+```
+$ cargo run client 127.0.0.1:4000 "secret" "message"
+```

--- a/capnp-rpc/examples/shared-secret-capability/build.rs
+++ b/capnp-rpc/examples/shared-secret-capability/build.rs
@@ -1,0 +1,9 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    capnpc::CompilerCommand::new()
+        .file("echo.capnp")
+        .run()?;
+    capnpc::CompilerCommand::new()
+        .file("shared_secret.capnp")
+        .run()?;
+    Ok(())
+}

--- a/capnp-rpc/examples/shared-secret-capability/client.rs
+++ b/capnp-rpc/examples/shared-secret-capability/client.rs
@@ -63,8 +63,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             tokio::task::spawn_local(rpc_system);
             let mut request = shared_secret_client.authenticate_request();
             request.get().set_shared_secret(secret);
-            let resp = request.send().promise.await?;
-            let authed_echo = resp.get()?.get_authenticated()?;
+            let authed_echo = request.send().pipeline.get_authenticated();
             let mut echo_request = authed_echo.echo_request();
             echo_request.get().set_message(message);
             let resp = echo_request.send().promise.await?;

--- a/capnp-rpc/examples/shared-secret-capability/client.rs
+++ b/capnp-rpc/examples/shared-secret-capability/client.rs
@@ -1,0 +1,77 @@
+// Copyright (c) 2013-2016 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+use crate::{echo_capnp::echo, shared_secret_capnp::shared_secret_authenticated};
+use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
+
+use futures::AsyncReadExt;
+
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use std::net::ToSocketAddrs;
+    let args: Vec<String> = ::std::env::args().collect();
+    if args.len() != 5 {
+        println!(
+            "usage: {} client HOST:PORT SECRET MESSAGE",
+            args[0]
+        );
+        return Ok(());
+    }
+
+    let addr = &args[2]
+        .to_socket_addrs()?
+        .next()
+        .expect("could not parse address");
+
+    let secret = &args[3];
+    let message = &args[4];
+
+    tokio::task::LocalSet::new()
+        .run_until(async move {
+            let stream = tokio::net::TcpStream::connect(&addr).await?;
+            stream.set_nodelay(true)?;
+            let (reader, writer) =
+                tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
+            let rpc_network = Box::new(twoparty::VatNetwork::new(
+                futures::io::BufReader::new(reader),
+                futures::io::BufWriter::new(writer),
+                rpc_twoparty_capnp::Side::Client,
+                Default::default(),
+            ));
+
+            let mut rpc_system = RpcSystem::new(rpc_network, None);
+            let shared_secret_client: shared_secret_authenticated::Client<echo::Owned> =
+                rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
+            
+            tokio::task::spawn_local(rpc_system);
+            let mut request = shared_secret_client.authenticate_request();
+            request.get().set_shared_secret(secret);
+            let resp = request.send().promise.await?;
+            let authed_echo = resp.get()?.get_authenticated()?;
+            let mut echo_request = authed_echo.echo_request();
+            echo_request.get().set_message(message);
+            let resp = echo_request.send().promise.await?;
+            let msg = resp.get()?.get_response_message()?.to_str()?;
+            println!("Received message: {}", msg);
+           
+            Ok(())
+        })
+        .await
+}

--- a/capnp-rpc/examples/shared-secret-capability/echo.capnp
+++ b/capnp-rpc/examples/shared-secret-capability/echo.capnp
@@ -1,0 +1,6 @@
+@0xbce2b6edc3ea24c9;
+
+interface Echo {
+  # simple capnp interface for testing
+  echo @0 (message :Text) -> (responseMessage :Text);
+}

--- a/capnp-rpc/examples/shared-secret-capability/main.rs
+++ b/capnp-rpc/examples/shared-secret-capability/main.rs
@@ -1,0 +1,41 @@
+// Copyright (c) 2013-2016 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+capnp::generated_code!(pub mod echo_capnp);
+capnp::generated_code!(pub mod shared_secret_capnp);
+
+pub mod client;
+pub mod server;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = ::std::env::args().collect();
+    if args.len() >= 2 {
+        match &args[1][..] {
+            "client" => return client::main().await,
+            "server" => return server::main().await,
+            _ => (),
+        }
+    }
+
+    println!("usage: {} [client | server] ADDRESS", args[0]);
+    Ok(())
+}

--- a/capnp-rpc/examples/shared-secret-capability/server.rs
+++ b/capnp-rpc/examples/shared-secret-capability/server.rs
@@ -1,0 +1,115 @@
+// Copyright (c) 2013-2016 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+use std::{
+    net::ToSocketAddrs, rc::Rc,
+};
+
+use crate::{echo_capnp::echo::{EchoParams, EchoResults}, shared_secret_capnp::{shared_secret_authenticated::{self, AuthenticateParams, AuthenticateResults}}};
+use crate::echo_capnp::echo;
+use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
+
+use capnp::{Error, traits::{Owned, SetterInput}};
+
+use futures::AsyncReadExt;
+
+struct SharedSecretImpl<C> {
+    secret: String,
+    inner_cap: C
+}
+
+
+impl<T: Owned + 'static, C: SetterInput<T> + Clone + 'static> shared_secret_authenticated::Server<T> for SharedSecretImpl<C> {
+    async fn authenticate(self: Rc<Self>,
+        params: AuthenticateParams<T>,
+        mut results: AuthenticateResults<T>) -> Result<(), Error>
+    {
+        let secret = params.get()?
+            .get_shared_secret()?
+            .to_str()?;
+        if secret != self.secret {
+            return Err(Error::failed("Auth failed".to_owned()));
+        }
+
+        results
+            .get()
+            .set_authenticated(self.inner_cap.clone())?;
+        Ok(())
+    }
+}
+
+struct EchoImpl {}
+
+impl echo::Server for EchoImpl {
+    async fn echo(self: Rc<Self>, params: EchoParams, mut results: EchoResults<>) -> Result<(), Error> {
+        let msg = params.get()?.get_message()?;
+        let mut response = results.get();
+        response.set_response_message(msg);
+        Ok(())
+    }
+}
+
+
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = ::std::env::args().collect();
+    if args.len() != 4 {
+        println!("usage: {} server ADDRESS[:PORT] SECRET", args[0]);
+        return Ok(());
+    }
+
+    let addr = &args[2]
+        .to_socket_addrs()?
+        .next()
+        .expect("could not parse address");
+    let secret = &args[3];
+
+    tokio::task::LocalSet::new()
+        .run_until(async move {
+            let listener = tokio::net::TcpListener::bind(&addr).await?;
+
+            let echo_impl = EchoImpl{};
+            let echo: echo::Client = capnp_rpc::new_client(echo_impl);
+
+            let shared_secret_impl = SharedSecretImpl{
+                secret: secret.to_owned(),
+                inner_cap: echo
+            };
+            let client: shared_secret_authenticated::Client<echo::Owned> = capnp_rpc::new_client(shared_secret_impl);
+
+            loop {
+                let (stream, _) = listener.accept().await?;
+                stream.set_nodelay(true)?;
+                let (reader, writer) =
+                    tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
+                let network = twoparty::VatNetwork::new(
+                    futures::io::BufReader::new(reader),
+                    futures::io::BufWriter::new(writer),
+                    rpc_twoparty_capnp::Side::Server,
+                    Default::default(),
+                );
+
+                let rpc_system = RpcSystem::new(Box::new(network), Some(client.clone().client));
+
+                tokio::task::spawn_local(rpc_system);
+            }
+        })
+        .await
+}

--- a/capnp-rpc/examples/shared-secret-capability/shared_secret.capnp
+++ b/capnp-rpc/examples/shared-secret-capability/shared_secret.capnp
@@ -1,0 +1,11 @@
+@0x9ab4d9cc53638ac6;
+
+# This interface is for testing purposes. Do not use this interface
+# for security because it is vulnerable to replay attacks among other
+# things.
+interface SharedSecretAuthenticated(T) {
+# This interface is generic over an underlying protected interface T
+  authenticate @0 (sharedSecret :Text) -> (authenticated :T);
+  # The authenticate method, which returns a capability to the underlying
+  # protected interface when the passed secret is valid.
+}

--- a/capnp/src/capability.rs
+++ b/capnp/src/capability.rs
@@ -312,6 +312,7 @@ pub trait FromTypelessPipeline {
     fn new(typeless: any_pointer::Pipeline) -> Self;
 }
 
+#[cfg(feature = "alloc")]
 impl<T: FromClientHook> FromTypelessPipeline for T {
     fn new(typeless: any_pointer::Pipeline) -> Self {
         Self::new(typeless.as_cap())

--- a/capnp/src/capability.rs
+++ b/capnp/src/capability.rs
@@ -312,6 +312,12 @@ pub trait FromTypelessPipeline {
     fn new(typeless: any_pointer::Pipeline) -> Self;
 }
 
+impl<T: FromClientHook> FromTypelessPipeline for T {
+    fn new(typeless: any_pointer::Pipeline) -> Self {
+        Self::new(typeless.as_cap())
+    }
+}
+
 /// Trait implemented (via codegen) by all user-defined capability client types.
 #[cfg(feature = "alloc")]
 pub trait FromClientHook {


### PR DESCRIPTION
Say we write a generic wrapper interface that is intended to expose an inner capability:

```
interface SharedSecretAuthenticated(T) {
# This interface is generic over an underlying protected interface T
  authenticate @0 (sharedSecret :Text) -> (authenticated :T);
}
```

The server works great, the inner type must be `Owned`, but the inner capability can be wrapped by the server impl via the `Owned` client type.

The client also works well when using `send().promise`. First the client unwraps the internal Owned client, then it can use the internal capability.

The problem comes with pipelining the client. It would be great if the wrapper interface could be pipelined with use of the inner capability so that only one `send()` need be awaited. This just requires that `Client` implement `FromTypelessPipeline`.

I've included a motivating example that doesn't compile without the impls for `FromTypelessPipeline`.