### PR TITLE
Add support for FD passing

### DIFF
--- a/async-byte-channel/Cargo.toml
+++ b/async-byte-channel/Cargo.toml
@@ -7,7 +7,12 @@ description = "Helper library for writing async tests"
 repository = "https://github.com/dwrensha/capnproto-rust"
 edition = "2021"
 
-[dependencies.futures]
+[dependencies.capnp-futures]
+version = "0.26.0"
+path = "../capnp-futures"
+default-features = false
+
+[dev-dependencies.futures]
 version = "0.3.0"
 default-features = false
 features = ["std", "executor"]

--- a/async-byte-channel/src/lib.rs
+++ b/async-byte-channel/src/lib.rs
@@ -1,10 +1,10 @@
 // Simple in-memory byte stream.
 
-use std::pin::Pin;
+use std::io;
 use std::sync::{Arc, Mutex};
 
-use futures::{AsyncRead, AsyncWrite};
-use std::task::{Poll, Waker};
+use capnp_futures::io::{AsyncFdRead, AsyncFdWrite, Count, FdReadBuf, FdWriteBuf};
+use std::task::{Context, Poll, Waker};
 
 #[derive(Debug)]
 struct Inner {
@@ -68,16 +68,17 @@ pub fn channel() -> (Sender, Receiver) {
     (sender, receiver)
 }
 
-impl AsyncRead for Receiver {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut futures::task::Context,
+impl AsyncFdRead for Receiver {
+    fn poll_read_with_fds(
+        &mut self,
+        cx: &mut Context<'_>,
         buf: &mut [u8],
-    ) -> futures::task::Poll<Result<usize, futures::io::Error>> {
+        _fd_buf: &mut FdReadBuf,
+    ) -> Poll<io::Result<Count>> {
         let mut inner = self.inner.lock().unwrap();
         if inner.read_cursor == inner.write_cursor {
             if inner.write_end_closed {
-                Poll::Ready(Ok(0))
+                Poll::Ready(Ok(Count { bytes: 0, fds: 0 }))
             } else {
                 inner.read_waker = Some(cx.waker().clone());
                 Poll::Pending
@@ -91,17 +92,21 @@ impl AsyncRead for Receiver {
             if let Some(write_waker) = inner.write_waker.take() {
                 write_waker.wake();
             }
-            Poll::Ready(Ok(copy_len))
+            Poll::Ready(Ok(Count {
+                bytes: copy_len,
+                fds: 0,
+            }))
         }
     }
 }
 
-impl AsyncWrite for Sender {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut futures::task::Context,
+impl AsyncFdWrite for Sender {
+    fn poll_write_with_fds(
+        &mut self,
+        cx: &mut Context<'_>,
         buf: &[u8],
-    ) -> futures::task::Poll<Result<usize, futures::io::Error>> {
+        _fd_buf: &FdWriteBuf<'_>,
+    ) -> Poll<io::Result<Count>> {
         let mut inner = self.inner.lock().unwrap();
         if inner.read_end_closed {
             return Poll::Ready(Err(std::io::Error::new(
@@ -128,33 +133,23 @@ impl AsyncWrite for Sender {
         if let Some(read_waker) = inner.read_waker.take() {
             read_waker.wake();
         }
-        Poll::Ready(Ok(copy_len))
+        Poll::Ready(Ok(Count {
+            bytes: copy_len,
+            fds: 0,
+        }))
     }
 
-    fn poll_flush(
-        self: Pin<&mut Self>,
-        _cx: &mut futures::task::Context,
-    ) -> Poll<Result<(), futures::io::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_close(
-        self: Pin<&mut Self>,
-        _cx: &mut futures::task::Context,
-    ) -> Poll<Result<(), futures::io::Error>> {
-        let mut inner = self.inner.lock().unwrap();
-        inner.write_end_closed = true;
-        if let Some(read_waker) = inner.read_waker.take() {
-            read_waker.wake();
-        }
+    fn poll_flush(&mut self, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Poll::Ready(Ok(()))
     }
 }
 
 #[cfg(test)]
 pub mod test {
+    use std::io;
+
+    use capnp_futures::io::{AsyncFdReadExt, AsyncFdWriteExt as _};
     use futures::task::LocalSpawnExt;
-    use futures::{AsyncReadExt, AsyncWriteExt};
 
     #[test]
     fn basic() {
@@ -173,10 +168,12 @@ pub mod test {
             })
             .unwrap();
 
-        let mut buf3 = vec![];
-        pool.run_until(receiver.read_to_end(&mut buf3)).unwrap();
-
-        assert_eq!(buf.len(), buf3.len());
+        pool.run_until(async {
+            receiver.read_exact(&mut vec![0; buf.len()]).await?;
+            assert_eq!(receiver.read(&mut [0]).await?, 0);
+            io::Result::Ok(())
+        })
+        .unwrap();
     }
 
     #[test]

--- a/capnp-futures/Cargo.toml
+++ b/capnp-futures/Cargo.toml
@@ -31,6 +31,12 @@ default-features = false
 features = ["std"]
 optional = true
 
+[dependencies.tokio]
+version = "1.52.3"
+default-features = false
+features = ["net"]
+optional = true
+
 [dev-dependencies.futures]
 version = "0.3.0"
 default-features = false
@@ -43,6 +49,7 @@ quickcheck = "1"
 [features]
 default = ["futures-io"]
 futures-io = ["dep:futures-io"]
+tokio = ["dep:tokio"]
 
 [lints]
 workspace = true

--- a/capnp-futures/Cargo.toml
+++ b/capnp-futures/Cargo.toml
@@ -31,6 +31,12 @@ default-features = false
 features = ["std"]
 optional = true
 
+[dependencies.rustix]
+version = "1.1.4"
+default-features = false
+features = ["std", "net"]
+optional = true
+
 [dependencies.tokio]
 version = "1.52.3"
 default-features = false
@@ -50,6 +56,7 @@ quickcheck = "1"
 default = ["futures-io"]
 futures-io = ["dep:futures-io"]
 tokio = ["dep:tokio"]
+tokio-unix-fd-stream = ["tokio", "dep:rustix"]
 
 [lints]
 workspace = true

--- a/capnp-futures/Cargo.toml
+++ b/capnp-futures/Cargo.toml
@@ -20,10 +20,16 @@ version = "0.3.0"
 default-features = false
 features = ["std"]
 
-[dependencies.futures-util]
+[dependencies.futures-core]
 version = "0.3.0"
 default-features = false
-features = ["io", "std"]
+features = ["std"]
+
+[dependencies.futures-io]
+version = "0.3.0"
+default-features = false
+features = ["std"]
+optional = true
 
 [dev-dependencies.futures]
 version = "0.3.0"
@@ -33,6 +39,10 @@ features = ["executor"]
 [dev-dependencies]
 capnp = { version = "0.26.0", path = "../capnp", features = ["quickcheck"] }
 quickcheck = "1"
+
+[features]
+default = ["futures-io"]
+futures-io = ["dep:futures-io"]
 
 [lints]
 workspace = true

--- a/capnp-futures/src/io/futures_io/mod.rs
+++ b/capnp-futures/src/io/futures_io/mod.rs
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures_io::{AsyncRead, AsyncWrite};
+
+pub use read_stream::ReadStream;
+pub use write_queue::{write_queue, Sender};
+
+use crate::io::{AsyncFdRead, AsyncFdWrite, Count, FdReadBuf, FdWriteBuf};
+
+mod read_stream;
+pub mod serialize;
+pub mod serialize_packed;
+mod write_queue;
+
+#[derive(Debug)]
+pub struct Compat<T> {
+    inner: T,
+}
+
+impl<T> Compat<T> {
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T> From<T> for Compat<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<T> AsRef<T> for Compat<T> {
+    fn as_ref(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T> AsMut<T> for Compat<T> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncFdRead for Compat<R> {
+    fn poll_read_with_fds(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+        _fd_buf: &mut FdReadBuf,
+    ) -> Poll<io::Result<Count>> {
+        Pin::new(&mut self.inner)
+            .poll_read(cx, buf)
+            .map_ok(|bytes| Count { bytes, fds: 0 })
+    }
+}
+
+impl<W: AsyncWrite + Unpin> AsyncFdWrite for Compat<W> {
+    fn poll_write_with_fds(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+        _fd_buf: &FdWriteBuf<'_>,
+    ) -> Poll<io::Result<Count>> {
+        Pin::new(&mut self.inner)
+            .poll_write(cx, buf)
+            .map_ok(|bytes| Count { bytes, fds: 0 })
+    }
+
+    fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+}

--- a/capnp-futures/src/io/futures_io/read_stream.rs
+++ b/capnp-futures/src/io/futures_io/read_stream.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use capnp::{message, Error};
+use futures_core::stream::Stream;
+use futures_io::AsyncRead;
+
+use crate::io::futures_io::Compat;
+
+/// An incoming sequence of messages.
+#[must_use = "streams do nothing unless polled"]
+pub struct ReadStream<'a, R>
+where
+    R: AsyncRead + Unpin,
+{
+    inner: crate::io::read_stream::ReadStream<'a, Compat<R>>,
+}
+
+impl<R> Unpin for ReadStream<'_, R> where R: AsyncRead + Unpin {}
+
+impl<'a, R> ReadStream<'a, R>
+where
+    R: AsyncRead + Unpin + 'a,
+{
+    pub fn new(reader: R, options: message::ReaderOptions) -> Self {
+        ReadStream {
+            inner: crate::io::read_stream::ReadStream::new(Compat::new(reader), options),
+        }
+    }
+}
+
+impl<'a, R> Stream for ReadStream<'a, R>
+where
+    R: AsyncRead + Unpin + 'a,
+{
+    type Item = Result<message::Reader<capnp::serialize::OwnedSegments>, Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}

--- a/capnp-futures/src/io/futures_io/serialize.rs
+++ b/capnp-futures/src/io/futures_io/serialize.rs
@@ -1,0 +1,66 @@
+// Copyright (c) 2013-2016 Sandstorm Development Group, Inc. and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//! Asynchronous reading and writing of messages using the
+//! [standard stream framing](https://capnproto.org/encoding.html#serialization-over-a-stream).
+//!
+//! Each message is preceded by a segment table indicating the size of its segments.
+
+use capnp::serialize::OwnedSegments;
+use capnp::{message, Result};
+use futures_io::{AsyncRead, AsyncWrite};
+
+use crate::io::futures_io::Compat;
+pub use crate::io::serialize::AsOutputSegments;
+
+/// Asynchronously reads a message from `reader`.
+pub async fn read_message<R>(
+    reader: R,
+    options: message::ReaderOptions,
+) -> Result<message::Reader<OwnedSegments>>
+where
+    R: AsyncRead + Unpin,
+{
+    crate::io::serialize::read_message(Compat::new(reader), options).await
+}
+
+/// Asynchronously reads a message from `reader`.
+///
+/// Returns `None` if `reader` has zero bytes left (i.e. is at end-of-file).
+/// To read a stream containing an unknown number of messages, you could call
+/// this function repeatedly until it returns `None`.
+pub async fn try_read_message<R>(
+    reader: R,
+    options: message::ReaderOptions,
+) -> Result<Option<message::Reader<OwnedSegments>>>
+where
+    R: AsyncRead + Unpin,
+{
+    crate::io::serialize::try_read_message(Compat::new(reader), options).await
+}
+
+/// Writes the provided message to `writer`. Does not call `flush()`.
+pub async fn write_message<W, M>(writer: W, message: M) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+    M: AsOutputSegments,
+{
+    crate::io::serialize::write_message(Compat::new(writer), message).await
+}

--- a/capnp-futures/src/io/futures_io/serialize_packed.rs
+++ b/capnp-futures/src/io/futures_io/serialize_packed.rs
@@ -1,0 +1,152 @@
+// Copyright (c) 2013-2015 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//! Asynchronous reading and writing of messages using the
+//! [packed stream encoding](https://capnproto.org/encoding.html#packing).
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use capnp::serialize::OwnedSegments;
+use capnp::{message, Result};
+use futures_io::{AsyncRead, AsyncWrite};
+
+use crate::io::futures_io::Compat;
+use crate::io::serialize::AsOutputSegments;
+use crate::io::{AsyncFdRead, AsyncFdWrite};
+
+/// An `AsyncRead` wrapper that unpacks packed data.
+pub struct PackedRead<R>
+where
+    R: AsyncRead + Unpin,
+{
+    inner: crate::io::serialize_packed::PackedRead<Compat<R>>,
+}
+
+impl<R> PackedRead<R>
+where
+    R: AsyncRead + Unpin,
+{
+    /// Creates a new `PackedRead` from a `AsyncRead`. For optimal performance,
+    /// `inner` should be a buffered `AsyncRead`.
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner: crate::io::serialize_packed::PackedRead::new(Compat::new(inner)),
+        }
+    }
+}
+
+impl<R> AsyncRead for PackedRead<R>
+where
+    R: AsyncRead + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        outbuf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        self.inner
+            .poll_read_with_fds(cx, outbuf, &mut [])
+            .map_ok(|count| count.bytes)
+    }
+}
+
+/// Asynchronously reads a packed message from `read`.
+///
+/// Returns `None` if `read` has zero bytes left (i.e. is at end-of-file).
+/// To read a stream containing an unknown number of messages, you could call
+/// this function repeatedly until it returns `None`.
+pub async fn try_read_message<R>(
+    read: R,
+    options: message::ReaderOptions,
+) -> Result<Option<message::Reader<OwnedSegments>>>
+where
+    R: AsyncRead + Unpin,
+{
+    crate::io::serialize_packed::try_read_message(Compat::new(read), options).await
+}
+
+/// Asynchronously reads a message from `reader`.
+pub async fn read_message<R>(
+    reader: R,
+    options: message::ReaderOptions,
+) -> Result<message::Reader<OwnedSegments>>
+where
+    R: AsyncRead + Unpin,
+{
+    crate::io::serialize_packed::read_message(Compat::new(reader), options).await
+}
+
+/// An `AsyncWrite` wrapper that packs any data passed into it.
+pub struct PackedWrite<W>
+where
+    W: AsyncWrite + Unpin,
+{
+    inner: crate::io::serialize_packed::PackedWrite<Compat<W>>,
+}
+
+/// Writes the provided message to `writer`. Does not call `writer.flush()`,
+/// so that multiple successive calls can amortize work when `writer` is
+/// buffered.
+pub async fn write_message<W, M>(writer: W, message: M) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+    M: AsOutputSegments,
+{
+    crate::io::serialize_packed::write_message(Compat::new(writer), message).await
+}
+
+impl<W> PackedWrite<W>
+where
+    W: AsyncWrite + Unpin,
+{
+    /// Creates a new `PackedWrite` from a `AsyncWrite`. For optimal performance,
+    /// `inner` should be a buffered `AsyncWrite`.
+    pub fn new(inner: W) -> Self {
+        Self {
+            inner: crate::io::serialize_packed::PackedWrite::new(Compat::new(inner)),
+        }
+    }
+}
+
+impl<W> AsyncWrite for PackedWrite<W>
+where
+    W: AsyncWrite + Unpin,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        inbuf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.inner
+            .poll_write_with_fds(cx, inbuf, &[])
+            .map_ok(|count| count.bytes)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.inner.poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(self.inner.inner.as_mut()).poll_close(cx)
+    }
+}

--- a/capnp-futures/src/io/futures_io/write_queue.rs
+++ b/capnp-futures/src/io/futures_io/write_queue.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Sandstorm Development Group, Inc. and contributors
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,13 +18,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#[cfg(feature = "futures-io")]
-pub use io::futures_io::serialize;
-#[cfg(feature = "futures-io")]
-pub use io::futures_io::serialize_packed;
-#[cfg(feature = "futures-io")]
-pub use io::futures_io::ReadStream;
-#[cfg(feature = "futures-io")]
-pub use io::futures_io::{write_queue, Sender};
+use std::future::Future;
 
-pub mod io;
+use capnp::Error;
+use futures_io::AsyncWrite;
+
+pub use crate::io::Sender;
+use crate::io::{futures_io::Compat, serialize::AsOutputSegments};
+
+/// Creates a new write queue that wraps the given `AsyncWrite`.
+///
+/// Returns `(sender, task)`, where `sender` can be used to push writes onto the
+/// queue, and `task` is a future that performs the work of the writes. The queue
+/// will run as long as `task` is polled, until either `sender.terminate()` is
+/// called or `sender` and all of its clones are dropped.
+pub fn write_queue<W, M>(writer: W) -> (Sender<M>, impl Future<Output = Result<(), Error>>)
+where
+    W: AsyncWrite + Unpin,
+    M: AsOutputSegments,
+{
+    crate::io::write_queue(Compat::new(writer))
+}

--- a/capnp-futures/src/io/mod.rs
+++ b/capnp-futures/src/io/mod.rs
@@ -35,6 +35,8 @@ pub mod futures_io;
 mod read_stream;
 pub mod serialize;
 pub mod serialize_packed;
+#[cfg(feature = "tokio")]
+pub mod tokio;
 mod write_queue;
 
 pub type FdReadBuf = [Option<OwnedFd>];

--- a/capnp-futures/src/io/mod.rs
+++ b/capnp-futures/src/io/mod.rs
@@ -1,0 +1,219 @@
+// Copyright (c) 2026 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+use std::{
+    future::{self, Future},
+    io, mem,
+    task::{Context, Poll},
+};
+
+use capnp::fd::{BorrowedFd, OwnedFd};
+
+pub use read_stream::ReadStream;
+pub use write_queue::{write_queue, Sender};
+
+#[cfg(feature = "futures-io")]
+pub mod futures_io;
+mod read_stream;
+pub mod serialize;
+pub mod serialize_packed;
+mod write_queue;
+
+pub type FdReadBuf = [Option<OwnedFd>];
+pub type FdWriteBuf<'a> = [BorrowedFd<'a>];
+
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Count {
+    pub bytes: usize,
+    pub fds: usize,
+}
+
+pub trait AsyncFdRead {
+    // TODO: Better buffer types here may be a good idea.
+    fn poll_read_with_fds(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+        fd_buf: &mut FdReadBuf,
+    ) -> Poll<io::Result<Count>>;
+}
+
+impl<T: ?Sized + AsyncFdRead> AsyncFdRead for Box<T> {
+    fn poll_read_with_fds(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+        fd_buf: &mut FdReadBuf,
+    ) -> Poll<io::Result<Count>> {
+        (**self).poll_read_with_fds(cx, buf, fd_buf)
+    }
+}
+
+impl<T: ?Sized + AsyncFdRead> AsyncFdRead for &mut T {
+    fn poll_read_with_fds(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+        fd_buf: &mut FdReadBuf,
+    ) -> Poll<io::Result<Count>> {
+        (**self).poll_read_with_fds(cx, buf, fd_buf)
+    }
+}
+
+impl AsyncFdRead for &[u8] {
+    fn poll_read_with_fds(
+        &mut self,
+        _cx: &mut Context<'_>,
+        buf: &mut [u8],
+        _fd_buf: &mut FdReadBuf,
+    ) -> Poll<io::Result<Count>> {
+        let (chunk, rest) = self.split_at(self.len().min(buf.len()));
+        buf[..chunk.len()].copy_from_slice(chunk);
+        *self = rest;
+        Poll::Ready(Ok(Count {
+            bytes: chunk.len(),
+            fds: 0,
+        }))
+    }
+}
+
+pub trait AsyncFdReadExt: AsyncFdRead {
+    fn read_with_fds(
+        &mut self,
+        buf: &mut [u8],
+        fd_buf: &mut FdReadBuf,
+    ) -> impl Future<Output = io::Result<Count>> {
+        future::poll_fn(|cx| self.poll_read_with_fds(cx, buf, fd_buf))
+    }
+
+    fn read(&mut self, buf: &mut [u8]) -> impl Future<Output = io::Result<usize>> {
+        future::poll_fn(|cx| {
+            self.poll_read_with_fds(cx, buf, &mut [])
+                .map_ok(|count| count.bytes)
+        })
+    }
+
+    fn read_exact(&mut self, mut buf: &mut [u8]) -> impl Future<Output = io::Result<()>> {
+        async move {
+            while !buf.is_empty() {
+                let bytes = self.read(buf).await?;
+                (_, buf) = mem::take(&mut buf).split_at_mut(bytes);
+                if bytes == 0 {
+                    return Err(io::Error::from(io::ErrorKind::UnexpectedEof));
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+impl<R: AsyncFdRead> AsyncFdReadExt for R {}
+
+pub trait AsyncFdWrite {
+    fn poll_write_with_fds(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+        fd_buf: &FdWriteBuf<'_>,
+    ) -> Poll<io::Result<Count>>;
+
+    fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>>;
+}
+
+impl<T: ?Sized + AsyncFdWrite> AsyncFdWrite for Box<T> {
+    fn poll_write_with_fds(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+        fd_buf: &FdWriteBuf<'_>,
+    ) -> Poll<io::Result<Count>> {
+        (**self).poll_write_with_fds(cx, buf, fd_buf)
+    }
+
+    fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        (**self).poll_flush(cx)
+    }
+}
+
+impl<T: ?Sized + AsyncFdWrite> AsyncFdWrite for &mut T {
+    fn poll_write_with_fds(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+        fd_buf: &FdWriteBuf<'_>,
+    ) -> Poll<io::Result<Count>> {
+        (**self).poll_write_with_fds(cx, buf, fd_buf)
+    }
+
+    fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        (**self).poll_flush(cx)
+    }
+}
+
+impl AsyncFdWrite for Vec<u8> {
+    fn poll_write_with_fds(
+        &mut self,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+        _fd_buf: &FdWriteBuf<'_>,
+    ) -> Poll<io::Result<Count>> {
+        self.extend(buf);
+        Poll::Ready(Ok(Count {
+            bytes: buf.len(),
+            fds: 0,
+        }))
+    }
+
+    fn poll_flush(&mut self, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+pub trait AsyncFdWriteExt: AsyncFdWrite {
+    fn write_all(&mut self, buf: &[u8]) -> impl Future<Output = io::Result<()>> {
+        self.write_all_with_fds(buf, &[])
+    }
+
+    fn write_all_with_fds(
+        &mut self,
+        mut buf: &[u8],
+        mut fd_buf: &FdWriteBuf<'_>,
+    ) -> impl Future<Output = io::Result<()>> {
+        async move {
+            while !buf.is_empty() {
+                let count = future::poll_fn(|cx| self.poll_write_with_fds(cx, buf, fd_buf)).await?;
+                (_, buf) = mem::take(&mut buf).split_at(count.bytes);
+                if count.bytes == 0 {
+                    return Err(io::Error::from(io::ErrorKind::WriteZero));
+                }
+                // FD passing is all‐or‐nothing.
+                fd_buf = &[];
+            }
+            Ok(())
+        }
+    }
+
+    fn flush(&mut self) -> impl Future<Output = io::Result<()>> {
+        future::poll_fn(|cx| self.poll_flush(cx))
+    }
+}
+
+impl<W: AsyncFdWrite> AsyncFdWriteExt for W {}

--- a/capnp-futures/src/io/read_stream.rs
+++ b/capnp-futures/src/io/read_stream.rs
@@ -23,17 +23,18 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use capnp::{message, Error};
-use futures_util::stream::Stream;
-use futures_util::AsyncRead;
+use futures_core::stream::Stream;
+
+use crate::io::AsyncFdRead;
 
 async fn read_next_message<R>(
     mut reader: R,
     options: message::ReaderOptions,
 ) -> Result<(R, Option<message::Reader<capnp::serialize::OwnedSegments>>), Error>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncFdRead,
 {
-    let m = crate::serialize::try_read_message(&mut reader, options).await?;
+    let m = crate::io::serialize::try_read_message(&mut reader, options).await?;
     Ok((reader, m))
 }
 
@@ -44,17 +45,17 @@ type ReadStreamResult<R> =
 #[must_use = "streams do nothing unless polled"]
 pub struct ReadStream<'a, R>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncFdRead,
 {
     options: message::ReaderOptions,
     read: Pin<Box<dyn Future<Output = ReadStreamResult<R>> + 'a>>,
 }
 
-impl<R> Unpin for ReadStream<'_, R> where R: AsyncRead + Unpin {}
+impl<R> Unpin for ReadStream<'_, R> where R: AsyncFdRead {}
 
 impl<'a, R> ReadStream<'a, R>
 where
-    R: AsyncRead + Unpin + 'a,
+    R: AsyncFdRead + 'a,
 {
     pub fn new(reader: R, options: message::ReaderOptions) -> Self {
         ReadStream {
@@ -66,7 +67,7 @@ where
 
 impl<'a, R> Stream for ReadStream<'a, R>
 where
-    R: AsyncRead + Unpin + 'a,
+    R: AsyncFdRead + 'a,
 {
     type Item = Result<message::Reader<capnp::serialize::OwnedSegments>, Error>;
 

--- a/capnp-futures/src/io/serialize.rs
+++ b/capnp-futures/src/io/serialize.rs
@@ -25,7 +25,15 @@
 
 use capnp::serialize::{OwnedSegments, SegmentLengthsBuilder};
 use capnp::{message, Error, OutputSegments, Result};
-use futures_util::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+use crate::io::{
+    AsyncFdRead, AsyncFdReadExt as _, AsyncFdWrite, AsyncFdWriteExt as _, FdReadBuf, FdWriteBuf,
+};
+
+pub struct MessageReaderAndFdCount {
+    pub reader: message::Reader<OwnedSegments>,
+    pub fds: usize,
+}
 
 /// Asynchronously reads a message from `reader`.
 pub async fn read_message<R>(
@@ -33,9 +41,23 @@ pub async fn read_message<R>(
     options: message::ReaderOptions,
 ) -> Result<message::Reader<OwnedSegments>>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncFdRead,
 {
     match try_read_message(reader, options).await? {
+        Some(s) => Ok(s),
+        None => Err(Error::from_kind(capnp::ErrorKind::PrematureEndOfFile)),
+    }
+}
+
+pub async fn read_message_with_fds<R>(
+    reader: R,
+    fd_buf: &mut FdReadBuf,
+    options: message::ReaderOptions,
+) -> Result<MessageReaderAndFdCount>
+where
+    R: AsyncFdRead,
+{
+    match try_read_message_with_fds(reader, fd_buf, options).await? {
         Some(s) => Ok(s),
         None => Err(Error::from_kind(capnp::ErrorKind::PrematureEndOfFile)),
     }
@@ -47,41 +69,59 @@ where
 /// To read a stream containing an unknown number of messages, you could call
 /// this function repeatedly until it returns `None`.
 pub async fn try_read_message<R>(
-    mut reader: R,
+    reader: R,
     options: message::ReaderOptions,
 ) -> Result<Option<message::Reader<OwnedSegments>>>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncFdRead,
 {
-    let Some(segment_lengths_builder) = read_segment_table(&mut reader, options).await? else {
+    Ok(try_read_message_with_fds(reader, &mut [], options)
+        .await?
+        .map(|message| message.reader))
+}
+
+pub async fn try_read_message_with_fds<R>(
+    mut reader: R,
+    fd_buf: &mut FdReadBuf,
+    options: message::ReaderOptions,
+) -> Result<Option<MessageReaderAndFdCount>>
+where
+    R: AsyncFdRead,
+{
+    let Some((segment_lengths_builder, fds)) =
+        read_segment_table(&mut reader, options, fd_buf).await?
+    else {
         return Ok(None);
     };
-    Ok(Some(
-        read_segments(
+    Ok(Some(MessageReaderAndFdCount {
+        reader: read_segments(
             reader,
             segment_lengths_builder.into_owned_segments(),
             options,
         )
         .await?,
-    ))
+        fds,
+    }))
 }
 
 async fn read_segment_table<R>(
     mut reader: R,
     options: message::ReaderOptions,
-) -> Result<Option<SegmentLengthsBuilder>>
+    fd_buf: &mut FdReadBuf,
+) -> Result<Option<(SegmentLengthsBuilder, usize)>>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncFdRead,
 {
     let mut buf: [u8; 8] = [0; 8];
-    {
-        let n = reader.read(&mut buf[..]).await?;
-        if n == 0 {
+    let fds = {
+        let n = reader.read_with_fds(&mut buf[..], fd_buf).await?;
+        if n.bytes == 0 {
             return Ok(None);
-        } else if n < 8 {
-            reader.read_exact(&mut buf[n..]).await?;
+        } else if n.bytes < 8 {
+            reader.read_exact(&mut buf[n.bytes..]).await?;
         }
-    }
+        n.fds
+    };
     let (segment_count, first_segment_length) = parse_segment_table_first(&buf[..])?;
 
     let mut segment_lengths_builder = SegmentLengthsBuilder::with_capacity(segment_count);
@@ -120,7 +160,7 @@ where
         }
     }
 
-    Ok(Some(segment_lengths_builder))
+    Ok(Some((segment_lengths_builder, fds)))
 }
 
 /// Reads segments from `read`.
@@ -130,7 +170,7 @@ async fn read_segments<R>(
     options: message::ReaderOptions,
 ) -> Result<message::Reader<OwnedSegments>>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncFdRead,
 {
     read.read_exact(&mut owned_segments[..]).await?;
     Ok(message::Reader::new(owned_segments, options))
@@ -158,6 +198,10 @@ fn parse_segment_table_first(buf: &[u8]) -> Result<(usize, usize)> {
 /// Something that contains segments ready to be written out.
 pub trait AsOutputSegments {
     fn as_output_segments(&self) -> OutputSegments<'_>;
+
+    fn as_fds(&self) -> &FdWriteBuf<'_> {
+        &[]
+    }
 }
 
 impl<M> AsOutputSegments for &M
@@ -166,6 +210,10 @@ where
 {
     fn as_output_segments(&self) -> OutputSegments<'_> {
         (*self).as_output_segments()
+    }
+
+    fn as_fds(&self) -> &FdWriteBuf<'_> {
+        (*self).as_fds()
     }
 }
 
@@ -199,18 +247,22 @@ where
 /// Writes the provided message to `writer`. Does not call `flush()`.
 pub async fn write_message<W, M>(mut writer: W, message: M) -> Result<()>
 where
-    W: AsyncWrite + Unpin,
+    W: AsyncFdWrite,
     M: AsOutputSegments,
 {
     let segments = message.as_output_segments();
-    write_segment_table(&mut writer, &segments[..]).await?;
+    write_segment_table(&mut writer, &segments[..], message.as_fds()).await?;
     write_segments(writer, &segments[..]).await?;
     Ok(())
 }
 
-async fn write_segment_table<W>(mut write: W, segments: &[&[u8]]) -> ::std::io::Result<()>
+async fn write_segment_table<W>(
+    mut write: W,
+    segments: &[&[u8]],
+    fd_buf: &FdWriteBuf<'_>,
+) -> ::std::io::Result<()>
 where
-    W: AsyncWrite + Unpin,
+    W: AsyncFdWrite,
 {
     let mut buf: [u8; 8] = [0; 8];
     let segment_count = segments.len();
@@ -218,7 +270,7 @@ where
     // write the first Word, which contains segment_count and the 1st segment length
     buf[0..4].copy_from_slice(&(segment_count as u32 - 1).to_le_bytes());
     buf[4..8].copy_from_slice(&((segments[0].len() / 8) as u32).to_le_bytes());
-    write.write_all(&buf).await?;
+    write.write_all_with_fds(&buf, fd_buf).await?;
 
     if segment_count > 1 {
         if segment_count < 4 {
@@ -255,7 +307,7 @@ where
 /// Writes segments to `write`.
 async fn write_segments<W>(mut write: W, segments: &[&[u8]]) -> Result<()>
 where
-    W: AsyncWrite + Unpin,
+    W: AsyncFdWrite,
 {
     for segment in segments {
         write.write_all(segment).await?;
@@ -267,16 +319,14 @@ where
 pub mod test {
     use std::cmp;
     use std::io::{self, Read, Write};
-    use std::pin::Pin;
     use std::task::{Context, Poll};
-
-    use futures::io::Cursor;
-    use futures::{AsyncRead, AsyncWrite};
 
     use quickcheck::{quickcheck, TestResult};
 
     use capnp::message::ReaderSegments;
     use capnp::{message, OutputSegments};
+
+    use crate::io::{AsyncFdRead, AsyncFdWrite, Count, FdReadBuf, FdWriteBuf};
 
     use super::{read_segment_table, try_read_message, write_message, AsOutputSegments};
 
@@ -293,11 +343,13 @@ pub mod test {
         );
         let segment_lengths = exec
             .run_until(read_segment_table(
-                Cursor::new(&buf[..]),
+                &buf[..],
                 message::ReaderOptions::new(),
+                &mut [],
             ))
             .unwrap()
-            .unwrap();
+            .unwrap()
+            .0;
         assert_eq!(0, segment_lengths.total_words());
         assert_eq!(vec![(0, 0)], segment_lengths.to_segment_indices());
         buf.clear();
@@ -311,11 +363,13 @@ pub mod test {
 
         let segment_lengths = exec
             .run_until(read_segment_table(
-                &mut Cursor::new(&buf[..]),
+                &buf[..],
                 message::ReaderOptions::new(),
+                &mut [],
             ))
             .unwrap()
-            .unwrap();
+            .unwrap()
+            .0;
         assert_eq!(1, segment_lengths.total_words());
         assert_eq!(vec![(0, 1)], segment_lengths.to_segment_indices());
         buf.clear();
@@ -330,11 +384,13 @@ pub mod test {
         );
         let segment_lengths = exec
             .run_until(read_segment_table(
-                &mut Cursor::new(&buf[..]),
+                &buf[..],
                 message::ReaderOptions::new(),
+                &mut [],
             ))
             .unwrap()
-            .unwrap();
+            .unwrap()
+            .0;
         assert_eq!(2, segment_lengths.total_words());
         assert_eq!(vec![(0, 1), (1, 2)], segment_lengths.to_segment_indices());
         buf.clear();
@@ -349,11 +405,13 @@ pub mod test {
         );
         let segment_lengths = exec
             .run_until(read_segment_table(
-                &mut Cursor::new(&buf[..]),
+                &buf[..],
                 message::ReaderOptions::new(),
+                &mut [],
             ))
             .unwrap()
-            .unwrap();
+            .unwrap()
+            .0;
         assert_eq!(258, segment_lengths.total_words());
         assert_eq!(
             vec![(0, 1), (1, 2), (2, 258)],
@@ -373,11 +431,13 @@ pub mod test {
         );
         let segment_lengths = exec
             .run_until(read_segment_table(
-                &mut Cursor::new(&buf[..]),
+                &buf[..],
                 message::ReaderOptions::new(),
+                &mut [],
             ))
             .unwrap()
-            .unwrap();
+            .unwrap()
+            .0;
         assert_eq!(200, segment_lengths.total_words());
         assert_eq!(
             vec![(0, 77), (77, 100), (100, 101), (101, 200)],
@@ -395,8 +455,9 @@ pub mod test {
         buf.extend([0; 513 * 4]);
         assert!(exec
             .run_until(read_segment_table(
-                Cursor::new(&buf[..]),
-                message::ReaderOptions::new()
+                &buf[..],
+                message::ReaderOptions::new(),
+                &mut [],
             ))
             .is_err());
         buf.clear();
@@ -404,8 +465,9 @@ pub mod test {
         buf.extend([0, 0, 0, 0]); // 1 segments
         assert!(exec
             .run_until(read_segment_table(
-                Cursor::new(&buf[..]),
-                message::ReaderOptions::new()
+                &buf[..],
+                message::ReaderOptions::new(),
+                &mut [],
             ))
             .is_err());
 
@@ -415,8 +477,9 @@ pub mod test {
         buf.extend([0; 3]);
         assert!(exec
             .run_until(read_segment_table(
-                Cursor::new(&buf[..]),
-                message::ReaderOptions::new()
+                &buf[..],
+                message::ReaderOptions::new(),
+                &mut [],
             ))
             .is_err());
         buf.clear();
@@ -424,8 +487,9 @@ pub mod test {
         buf.extend([255, 255, 255, 255]); // 0 segments
         assert!(exec
             .run_until(read_segment_table(
-                Cursor::new(&buf[..]),
-                message::ReaderOptions::new()
+                &buf[..],
+                message::ReaderOptions::new(),
+                &mut [],
             ))
             .is_err());
         buf.clear();
@@ -434,7 +498,7 @@ pub mod test {
     fn construct_segment_table(segments: &[&[u8]]) -> Vec<u8> {
         let mut exec = futures::executor::LocalPool::new();
         let mut buf = vec![];
-        exec.run_until(super::write_segment_table(&mut buf, segments))
+        exec.run_until(super::write_segment_table(&mut buf, segments, &[]))
             .unwrap();
         buf
     }
@@ -560,15 +624,16 @@ pub mod test {
         }
     }
 
-    impl<R> AsyncRead for BlockingRead<R>
+    impl<R> AsyncFdRead for BlockingRead<R>
     where
-        R: Read + Unpin,
+        R: Read,
     {
-        fn poll_read(
-            mut self: Pin<&mut Self>,
+        fn poll_read_with_fds(
+            &mut self,
             cx: &mut Context,
             buf: &mut [u8],
-        ) -> Poll<io::Result<usize>> {
+            _fd_buf: &mut FdReadBuf,
+        ) -> Poll<io::Result<Count>> {
             if self.idx == 0 {
                 self.idx = self.blocking_period;
                 cx.waker().wake_by_ref();
@@ -580,7 +645,10 @@ pub mod test {
                     Ok(n) => n,
                 };
                 self.idx -= bytes_read;
-                Poll::Ready(Ok(bytes_read))
+                Poll::Ready(Ok(Count {
+                    bytes: bytes_read,
+                    fds: 0,
+                }))
             }
         }
     }
@@ -616,15 +684,16 @@ pub mod test {
         }
     }
 
-    impl<W> AsyncWrite for BlockingWrite<W>
+    impl<W> AsyncFdWrite for BlockingWrite<W>
     where
-        W: Write + Unpin,
+        W: Write,
     {
-        fn poll_write(
-            mut self: Pin<&mut Self>,
+        fn poll_write_with_fds(
+            &mut self,
             cx: &mut Context,
             buf: &[u8],
-        ) -> Poll<io::Result<usize>> {
+            _fd_buf: &FdWriteBuf<'_>,
+        ) -> Poll<io::Result<Count>> {
             if self.idx == 0 {
                 self.idx = self.blocking_period;
                 cx.waker().wake_by_ref();
@@ -636,15 +705,14 @@ pub mod test {
                     Ok(n) => n,
                 };
                 self.idx -= bytes_written;
-                Poll::Ready(Ok(bytes_written))
+                Poll::Ready(Ok(Count {
+                    bytes: bytes_written,
+                    fds: 0,
+                }))
             }
         }
-        fn poll_flush(mut self: Pin<&mut Self>, _cx: &mut Context) -> Poll<io::Result<()>> {
+        fn poll_flush(&mut self, _cx: &mut Context) -> Poll<io::Result<()>> {
             Poll::Ready(self.writer.flush())
-        }
-
-        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<io::Result<()>> {
-            Poll::Ready(Ok(()))
         }
     }
 

--- a/capnp-futures/src/io/serialize_packed.rs
+++ b/capnp-futures/src/io/serialize_packed.rs
@@ -22,14 +22,15 @@
 //! Asynchronous reading and writing of messages using the
 //! [packed stream encoding](https://capnproto.org/encoding.html#packing).
 
+use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use capnp::serialize::OwnedSegments;
 use capnp::{message, Result};
-use futures_util::{AsyncRead, AsyncWrite};
 
-use crate::serialize::AsOutputSegments;
+use crate::io::serialize::AsOutputSegments;
+use crate::io::{AsyncFdRead, AsyncFdWrite, Count, FdReadBuf, FdWriteBuf};
 
 enum PackedReadStage {
     Start,
@@ -39,10 +40,10 @@ enum PackedReadStage {
     WritingPassthrough,
 }
 
-/// An `AsyncRead` wrapper that unpacks packed data.
+/// An `AsyncFdRead` wrapper that unpacks packed data.
 pub struct PackedRead<R>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncFdRead,
 {
     inner: R,
     stage: PackedReadStage,
@@ -63,10 +64,10 @@ where
 
 impl<R> PackedRead<R>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncFdRead,
 {
-    /// Creates a new `PackedRead` from a `AsyncRead`. For optimal performance,
-    /// `inner` should be a buffered `AsyncRead`.
+    /// Creates a new `PackedRead` from a `AsyncFdRead`. For optimal performance,
+    /// `inner` should be a buffered `AsyncFdRead`.
     pub fn new(inner: R) -> Self {
         Self {
             inner,
@@ -80,15 +81,17 @@ where
     }
 }
 
-impl<R> AsyncRead for PackedRead<R>
+impl<R> AsyncFdRead for PackedRead<R>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncFdRead,
 {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
+    fn poll_read_with_fds(
+        &mut self,
         cx: &mut std::task::Context<'_>,
         outbuf: &mut [u8],
-    ) -> Poll<std::result::Result<usize, std::io::Error>> {
+        // TODO: Perhaps this should work with FDs.
+        _fd_buf: &mut FdReadBuf,
+    ) -> Poll<io::Result<Count>> {
         let Self {
             stage,
             inner,
@@ -102,19 +105,19 @@ where
         loop {
             match *stage {
                 PackedReadStage::Start => {
-                    match Pin::new(&mut *inner).poll_read(cx, &mut buf[*buf_pos..2])? {
+                    match inner.poll_read_with_fds(cx, &mut buf[*buf_pos..2], &mut [])? {
                         Poll::Pending => return Poll::Pending,
                         Poll::Ready(n) => {
-                            if n == 0 {
+                            if n.bytes == 0 {
                                 if *buf_pos > 0 {
                                     // We are mid-way through reading the tag word.
                                     return Poll::Ready(Err(std::io::Error::from(
                                         std::io::ErrorKind::UnexpectedEof,
                                     )));
                                 }
-                                return Poll::Ready(Ok(0));
+                                return Poll::Ready(Ok(n));
                             }
-                            *buf_pos += n;
+                            *buf_pos += n.bytes;
                             if *buf_pos >= 2 {
                                 let tag = buf[0];
                                 let count = buf[1];
@@ -152,18 +155,21 @@ where
                     } else {
                         *num_run_bytes_remaining -= num_zeroes;
                     }
-                    return Poll::Ready(Ok(num_zeroes));
+                    return Poll::Ready(Ok(Count {
+                        bytes: num_zeroes,
+                        fds: 0,
+                    }));
                 }
                 PackedReadStage::BufferingWord => {
-                    match Pin::new(&mut *inner).poll_read(cx, &mut buf[*buf_pos..*buf_size])? {
+                    match inner.poll_read_with_fds(cx, &mut buf[*buf_pos..*buf_size], &mut [])? {
                         Poll::Pending => return Poll::Pending,
-                        Poll::Ready(0) => {
+                        Poll::Ready(Count { bytes: 0, .. }) => {
                             return Poll::Ready(Err(std::io::Error::from(
                                 std::io::ErrorKind::UnexpectedEof,
                             )))
                         }
                         Poll::Ready(n) => {
-                            *buf_pos += n;
+                            *buf_pos += n.bytes;
                             if *buf_pos >= *buf_size {
                                 *stage = PackedReadStage::DrainingBuffer;
                                 *buf_pos = 1;
@@ -195,26 +201,26 @@ where
                     } else {
                         // We did not finish the word.
                     }
-                    return Poll::Ready(Ok(ii));
+                    return Poll::Ready(Ok(Count { bytes: ii, fds: 0 }));
                 }
                 PackedReadStage::WritingPassthrough => {
                     let upper_bound = std::cmp::min(*num_run_bytes_remaining, outbuf.len());
                     if upper_bound == 0 {
                         *stage = PackedReadStage::Start;
                     } else {
-                        match Pin::new(&mut *inner).poll_read(cx, &mut outbuf[0..upper_bound])? {
+                        match inner.poll_read_with_fds(cx, &mut outbuf[0..upper_bound], &mut [])? {
                             Poll::Pending => return Poll::Pending,
                             Poll::Ready(n) => {
-                                if n == 0 {
+                                if n.bytes == 0 {
                                     // We are mid-way through a pass-through run.
                                     return Poll::Ready(Err(std::io::Error::from(
                                         std::io::ErrorKind::UnexpectedEof,
                                     )));
                                 }
-                                if n >= *num_run_bytes_remaining {
+                                if n.bytes >= *num_run_bytes_remaining {
                                     *stage = PackedReadStage::Start;
                                 }
-                                *num_run_bytes_remaining -= n;
+                                *num_run_bytes_remaining -= n.bytes;
                                 return Poll::Ready(Ok(n));
                             }
                         }
@@ -235,10 +241,10 @@ pub async fn try_read_message<R>(
     options: message::ReaderOptions,
 ) -> Result<Option<message::Reader<OwnedSegments>>>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncFdRead,
 {
     let packed_read = PackedRead::new(read);
-    crate::serialize::try_read_message(packed_read, options).await
+    crate::io::serialize::try_read_message(packed_read, options).await
 }
 
 /// Asynchronously reads a message from `reader`.
@@ -247,7 +253,7 @@ pub async fn read_message<R>(
     options: message::ReaderOptions,
 ) -> Result<message::Reader<OwnedSegments>>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncFdRead,
 {
     match try_read_message(reader, options).await? {
         Some(s) => Ok(s),
@@ -268,9 +274,9 @@ enum PackedWriteStage {
 /// An `AsyncWrite` wrapper that packs any data passed into it.
 pub struct PackedWrite<W>
 where
-    W: AsyncWrite + Unpin,
+    W: AsyncFdWrite,
 {
-    inner: W,
+    pub(crate) inner: W,
     stage: PackedWriteStage,
     buf: [u8; 8],
     buf_pos: usize,
@@ -282,16 +288,18 @@ where
     run_bytes_remaining: usize,
 }
 
+impl<W> Unpin for PackedWrite<W> where W: AsyncFdWrite {}
+
 struct FinishPendingWrites<W>
 where
-    W: AsyncWrite + Unpin,
+    W: AsyncFdWrite,
 {
     inner: PackedWrite<W>,
 }
 
 impl<W> FinishPendingWrites<W>
 where
-    W: AsyncWrite + Unpin,
+    W: AsyncFdWrite,
 {
     fn new(inner: PackedWrite<W>) -> Self {
         Self { inner }
@@ -300,7 +308,7 @@ where
 
 impl<W> std::future::Future for FinishPendingWrites<W>
 where
-    W: AsyncWrite + Unpin,
+    W: AsyncFdWrite,
 {
     type Output = std::result::Result<(), capnp::Error>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
@@ -316,11 +324,11 @@ where
 /// buffered.
 pub async fn write_message<W, M>(writer: W, message: M) -> Result<()>
 where
-    W: AsyncWrite + Unpin,
+    W: AsyncFdWrite,
     M: AsOutputSegments,
 {
     let mut packed_write = PackedWrite::new(writer);
-    crate::serialize::write_message(&mut packed_write, message).await?;
+    crate::io::serialize::write_message(&mut packed_write, message).await?;
 
     // Finish any pending work, so that nothing gets lost when we drop
     // the `PackedWrite`.
@@ -329,7 +337,7 @@ where
 
 impl<W> PackedWrite<W>
 where
-    W: AsyncWrite + Unpin,
+    W: AsyncFdWrite,
 {
     /// Creates a new `PackedWrite` from a `AsyncWrite`. For optimal performance,
     /// `inner` should be a buffered `AsyncWrite`.
@@ -393,9 +401,11 @@ where
                     }
                 }
                 PackedWriteStage::WriteWord => {
-                    match Pin::new(&mut *inner)
-                        .poll_write(cx, &packed_buf[*buf_pos..*packed_buf_size])?
-                    {
+                    match inner.poll_write_with_fds(
+                        cx,
+                        &packed_buf[*buf_pos..*packed_buf_size],
+                        &[],
+                    )? {
                         Poll::Pending => {
                             if inbuf_bytes_consumed == 0 {
                                 return Poll::Pending;
@@ -404,7 +414,7 @@ where
                             }
                         }
                         Poll::Ready(n) => {
-                            *buf_pos += n;
+                            *buf_pos += n.bytes;
                         }
                     }
                     if *buf_pos == *packed_buf_size {
@@ -446,11 +456,12 @@ where
                     }
                 }
                 PackedWriteStage::WriteRunWordCount => {
-                    match Pin::new(&mut *inner).poll_write(
+                    match inner.poll_write_with_fds(
                         cx,
                         &[(*run_bytes_remaining / 8)
                             .try_into()
                             .expect("overflow writing run word count")],
+                        &[],
                     )? {
                         Poll::Pending => {
                             if inbuf_bytes_consumed == 0 {
@@ -459,7 +470,7 @@ where
                                 return Poll::Ready(Ok(inbuf_bytes_consumed));
                             }
                         }
-                        Poll::Ready(1) => {
+                        Poll::Ready(Count { bytes: 1, .. }) => {
                             if packed_buf[0] == 0 {
                                 // we're done here
                                 inbuf = &inbuf[(*run_bytes_remaining)..];
@@ -471,7 +482,7 @@ where
                                 *stage = PackedWriteStage::WriteUncompressedRun;
                             }
                         }
-                        Poll::Ready(0) => {
+                        Poll::Ready(Count { bytes: 0, .. }) => {
                             // just loop around and try again
                         }
                         Poll::Ready(_) => panic!("should not be possible"),
@@ -479,7 +490,7 @@ where
                 }
 
                 PackedWriteStage::WriteUncompressedRun => {
-                    match Pin::new(&mut *inner).poll_write(cx, &inbuf[..*run_bytes_remaining])? {
+                    match inner.poll_write_with_fds(cx, &inbuf[..*run_bytes_remaining], &[])? {
                         Poll::Pending => {
                             if inbuf_bytes_consumed == 0 {
                                 return Poll::Pending;
@@ -488,10 +499,10 @@ where
                             }
                         }
                         Poll::Ready(n) => {
-                            inbuf_bytes_consumed += n;
-                            inbuf = &inbuf[n..];
-                            if n < *run_bytes_remaining {
-                                *run_bytes_remaining -= n;
+                            inbuf_bytes_consumed += n.bytes;
+                            inbuf = &inbuf[n.bytes..];
+                            if n.bytes < *run_bytes_remaining {
+                                *run_bytes_remaining -= n.bytes;
                             } else {
                                 *buf_pos = 0;
                                 *stage = PackedWriteStage::Start;
@@ -520,48 +531,42 @@ where
     }
 }
 
-impl<W> AsyncWrite for PackedWrite<W>
+impl<W> AsyncFdWrite for PackedWrite<W>
 where
-    W: AsyncWrite + Unpin,
+    W: AsyncFdWrite,
 {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
+    fn poll_write_with_fds(
+        &mut self,
         cx: &mut Context<'_>,
         inbuf: &[u8],
-    ) -> Poll<std::result::Result<usize, std::io::Error>> {
-        (*self).poll_write_aux(cx, inbuf)
+        // TODO: Perhaps this should work with FDs.
+        _fd_buf: &FdWriteBuf<'_>,
+    ) -> Poll<io::Result<Count>> {
+        (*self)
+            .poll_write_aux(cx, inbuf)
+            .map_ok(|bytes| Count { bytes, fds: 0 })
     }
 
-    fn poll_flush(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<std::result::Result<(), std::io::Error>> {
+    fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match (*self).finish_pending_writes(cx)? {
             Poll::Pending => return Poll::Pending,
             Poll::Ready(_) => (),
         }
 
-        Pin::new(&mut self.inner).poll_flush(cx)
-    }
-
-    fn poll_close(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<std::result::Result<(), std::io::Error>> {
-        Pin::new(&mut self.inner).poll_close(cx)
+        self.inner.poll_flush(cx)
     }
 }
 
 #[cfg(test)]
 pub mod test {
-    use crate::serialize::test::{BlockingRead, BlockingWrite};
-    use crate::serialize_packed::{try_read_message, PackedRead, PackedWrite};
+    use crate::io::serialize::test::{BlockingRead, BlockingWrite};
+    use crate::io::serialize_packed::{try_read_message, PackedRead, PackedWrite};
+    use crate::io::{AsyncFdReadExt as _, AsyncFdWriteExt as _};
     use capnp::message::ReaderSegments;
-    use futures::{AsyncReadExt, AsyncWriteExt};
     use quickcheck::{quickcheck, TestResult};
 
     pub fn check_unpacks_to(blocking_period: usize, packed: &[u8], unpacked: &[u8]) {
-        let mut packed_read = PackedRead::new(crate::serialize::test::BlockingRead::new(
+        let mut packed_read = PackedRead::new(crate::io::serialize::test::BlockingRead::new(
             packed,
             blocking_period,
         ));
@@ -584,10 +589,11 @@ pub mod test {
 
         let mut bytes: Vec<u8> = vec![0; packed.len()];
         {
-            let mut packed_write = PackedWrite::new(crate::serialize::test::BlockingWrite::new(
-                &mut bytes[..],
-                write_blocking_period,
-            ));
+            let mut packed_write =
+                PackedWrite::new(crate::io::serialize::test::BlockingWrite::new(
+                    &mut bytes[..],
+                    write_blocking_period,
+                ));
             futures::executor::block_on(Box::pin(packed_write.write_all(unpacked)))
                 .expect("writing");
             futures::executor::block_on(Box::pin(packed_write.flush())).expect("flushing");
@@ -681,7 +687,7 @@ pub mod test {
         let (mut read, segments) = {
             let cursor = std::io::Cursor::new(Vec::new());
             let mut writer = BlockingWrite::new(cursor, write_blocking_period);
-            futures::executor::block_on(Box::pin(crate::serialize_packed::write_message(
+            futures::executor::block_on(Box::pin(crate::io::serialize_packed::write_message(
                 &mut writer,
                 &segments,
             )))
@@ -694,7 +700,7 @@ pub mod test {
         };
 
         let message = futures::executor::block_on(Box::pin(
-            crate::serialize_packed::try_read_message(&mut read, Default::default()),
+            crate::io::serialize_packed::try_read_message(&mut read, Default::default()),
         ))
         .expect("reading")
         .unwrap();

--- a/capnp-futures/src/io/tokio/mod.rs
+++ b/capnp-futures/src/io/tokio/mod.rs
@@ -25,8 +25,22 @@ use std::{
     task::{Context, Poll},
 };
 
+#[cfg(all(
+    feature = "tokio-unix-fd-stream",
+    unix,
+    // Per <https://github.com/bytecodealliance/rustix/blob/v1.1.4/src/net/send_recv/mod.rs>.
+    not(any(target_os = "espidf", target_os = "horizon", target_os = "vita"))
+))]
+mod unix_fd_stream;
+
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
+#[cfg(all(
+    feature = "tokio-unix-fd-stream",
+    unix,
+    not(any(target_os = "espidf", target_os = "horizon", target_os = "vita"))
+))]
+pub use crate::io::tokio::unix_fd_stream::UnixFdStream;
 use crate::io::{AsyncFdRead, AsyncFdWrite, Count, FdReadBuf, FdWriteBuf};
 
 #[derive(Debug)]

--- a/capnp-futures/src/io/tokio/mod.rs
+++ b/capnp-futures/src/io/tokio/mod.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use crate::io::{AsyncFdRead, AsyncFdWrite, Count, FdReadBuf, FdWriteBuf};
+
+#[derive(Debug)]
+pub struct Compat<T> {
+    inner: T,
+}
+
+impl<T> Compat<T> {
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T> From<T> for Compat<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<T> AsRef<T> for Compat<T> {
+    fn as_ref(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T> AsMut<T> for Compat<T> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncFdRead for Compat<R> {
+    fn poll_read_with_fds(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+        _fd_buf: &mut FdReadBuf,
+    ) -> Poll<io::Result<Count>> {
+        let mut buf = ReadBuf::new(buf);
+        Pin::new(&mut self.inner)
+            .poll_read(cx, &mut buf)
+            .map_ok(|()| Count {
+                bytes: buf.filled().len(),
+                fds: 0,
+            })
+    }
+}
+
+impl<W: AsyncWrite + Unpin> AsyncFdWrite for Compat<W> {
+    fn poll_write_with_fds(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+        _fd_buf: &FdWriteBuf<'_>,
+    ) -> Poll<io::Result<Count>> {
+        Pin::new(&mut self.inner)
+            .poll_write(cx, buf)
+            .map_ok(|bytes| Count { bytes, fds: 0 })
+    }
+
+    fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+}

--- a/capnp-futures/src/io/tokio/unix_fd_stream.rs
+++ b/capnp-futures/src/io/tokio/unix_fd_stream.rs
@@ -1,0 +1,247 @@
+// Copyright (c) 2026 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+use std::{
+    io::{self, IoSlice, IoSliceMut},
+    mem::MaybeUninit,
+    os::fd::OwnedFd,
+    task::{ready, Context, Poll},
+};
+
+use rustix::net::{
+    recvmsg, sendmsg, RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags, SendAncillaryBuffer,
+    SendAncillaryMessage, SendFlags,
+};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    net::UnixStream,
+};
+
+use crate::io::{tokio::Compat, AsyncFdRead, AsyncFdWrite, Count, FdReadBuf, FdWriteBuf};
+
+#[derive(Debug)]
+pub struct UnixFdStream<T> {
+    inner: T,
+    cmsg_space: [MaybeUninit<u8>; CMSG_SPACE_LEN],
+}
+
+// We set this to 1024 to give ample room for both `SCM_RIGHTS`
+// messages and any other ancillary data that might come along for
+// the ride.
+const MAX_FDS_PER_MESSAGE: usize = 1024;
+const CMSG_SPACE_LEN: usize = rustix::cmsg_space!(ScmRights(MAX_FDS_PER_MESSAGE));
+
+impl<T> UnixFdStream<T> {
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            cmsg_space: [MaybeUninit::uninit(); CMSG_SPACE_LEN],
+        }
+    }
+
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T> From<T> for UnixFdStream<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<T> AsRef<T> for UnixFdStream<T> {
+    fn as_ref(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T> AsMut<T> for UnixFdStream<T> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<T> AsyncFdRead for UnixFdStream<T>
+where
+    T: AsyncRead + AsRef<UnixStream> + Unpin,
+{
+    fn poll_read_with_fds(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+        fd_buf: &mut FdReadBuf,
+    ) -> Poll<io::Result<Count>> {
+        if fd_buf.is_empty() {
+            return Compat::new(&mut self.inner).poll_read_with_fds(cx, buf, fd_buf);
+        }
+
+        let stream = self.inner.as_ref();
+        let mut iov = [IoSliceMut::new(buf)];
+        // Darwin has a nasty bug that leaks file descriptor table entries if
+        // `SCM_RIGHTS` messages get truncated; see
+        // <https://gist.github.com/kentonv/bc7592af98c68ba2738f4436920868dc>
+        // for details. We work around it by always using a buffer big enough
+        // to store the maximum number of FDs.
+        //
+        // On other platforms, we’d prefer to avoid accepting excess FDs into
+        // our table to begin with, so we can avoid closing them.
+        //
+        // TODO: This defeats the attempt to reserve additional buffer space
+        // for `SCM_CREDENTIALS`, etc.; compensating for that would be easy,
+        // but compensating for `SCM_SECURITY` would require 255+ bytes if
+        // someone decided to enable `SO_PASSSEC`. It’s unclear if there’s an
+        // actually good solution here.
+        let cmsg_space = if let Some(space) = cfg!(not(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "visionos",
+            target_os = "watchos"
+        )))
+        .then_some(())
+        .and_then(|()| {
+            self.cmsg_space
+                .get_mut(..rustix::cmsg_space!(ScmRights(fd_buf.len())))
+        }) {
+            space
+        } else {
+            &mut self.cmsg_space
+        };
+        let mut cmsg_buf = RecvAncillaryBuffer::new(cmsg_space);
+        #[allow(unused_mut)]
+        let mut flags = RecvFlags::DONTWAIT;
+        #[allow(unused_mut)]
+        let mut set_cloexec: fn(&OwnedFd) -> rustix::io::Result<()> =
+            |fd| rustix::io::fcntl_setfd(fd, rustix::io::FdFlags::CLOEXEC);
+
+        // Per <https://github.com/bytecodealliance/rustix/blob/v1.1.4/src/backend/libc/net/send_recv.rs#L71-L84>.
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "visionos",
+            target_os = "watchos",
+            target_os = "solaris",
+            target_os = "illumos",
+            target_os = "aix",
+            target_os = "haiku",
+            target_os = "nto",
+            target_os = "redox",
+        )))]
+        {
+            flags |= RecvFlags::CMSG_CLOEXEC;
+            set_cloexec = |_fd| Ok(());
+        }
+
+        let bytes = loop {
+            ready!(stream.poll_read_ready(cx))?;
+            let result = stream.try_io(tokio::io::Interest::READABLE, || {
+                Ok(recvmsg(stream, &mut iov, &mut cmsg_buf, flags)?)
+            });
+            match result {
+                Ok(received) => break received.bytes,
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(err) => return Poll::Ready(Err(err)),
+            }
+        };
+
+        let mut fds = 0;
+        let mut errs = Ok(());
+        let mut fd_iter = cmsg_buf
+            .drain()
+            .filter_map(|cmsg| match cmsg {
+                RecvAncillaryMessage::ScmRights(fds) => Some(fds),
+                _ => None,
+            })
+            .flatten();
+        for (slot, fd) in fd_buf.iter_mut().zip(&mut fd_iter) {
+            errs = errs.and(set_cloexec(&fd));
+            *slot = Some(fd);
+            fds += 1;
+        }
+
+        // Drop excess file descriptors.
+        //
+        // TODO: It feels like it might be a bug in rustix that these seemingly
+        // get leaked by default.
+        //
+        // TODO: `close(2)` can block (e.g. FUSE, NFS), and we’re in an async
+        // context. I’m not sure if Tokio is very careful around this in
+        // general, but it might be worth considering doing this with
+        // `task::spawn_blocking` or similar. (But then, the exact same
+        // consideration will apply to any consuming code downstream of this.)
+        for _excess_fd in fd_iter {}
+
+        Poll::Ready(errs.map_err(io::Error::from).and(Ok(Count { bytes, fds })))
+    }
+}
+
+impl<T> AsyncFdWrite for UnixFdStream<T>
+where
+    T: AsyncWrite + AsRef<UnixStream> + Unpin,
+{
+    fn poll_write_with_fds(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+        fd_buf: &FdWriteBuf<'_>,
+    ) -> Poll<io::Result<Count>> {
+        if fd_buf.is_empty() {
+            return Compat::new(&mut self.inner).poll_write_with_fds(cx, buf, fd_buf);
+        }
+
+        let stream = self.inner.as_ref();
+        let iov = [IoSlice::new(buf)];
+        let mut cmsg_buf = SendAncillaryBuffer::new(&mut self.cmsg_space);
+        // No operating system that I’m aware of supports sending 1024 FDs at
+        // a time anyway, and limits vary between operating systems, so let’s
+        // accept silent truncation if someone is trying to send an
+        // unreasonable number.
+        assert!(
+            cmsg_buf.push(SendAncillaryMessage::ScmRights(
+                fd_buf.get(..MAX_FDS_PER_MESSAGE).unwrap_or(fd_buf),
+            )),
+            "ancillary message should fit in buffer"
+        );
+
+        loop {
+            ready!(stream.poll_write_ready(cx))?;
+            let result = stream.try_io(tokio::io::Interest::WRITABLE, || {
+                Ok(sendmsg(stream, &iov, &mut cmsg_buf, SendFlags::DONTWAIT)?)
+            });
+            match result {
+                Ok(bytes) => {
+                    return Poll::Ready(Ok(Count {
+                        bytes,
+                        fds: fd_buf.len(),
+                    }))
+                }
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(err) => return Poll::Ready(Err(err)),
+            }
+        }
+    }
+
+    fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Compat::new(&mut self.inner).poll_flush(cx)
+    }
+}

--- a/capnp-futures/src/io/write_queue.rs
+++ b/capnp-futures/src/io/write_queue.rs
@@ -37,6 +37,7 @@ where
     M: AsOutputSegments,
 {
     Message(M, oneshot::Sender<M>),
+    MessageMove(M, oneshot::Sender<()>),
     Done(Result<(), Error>, oneshot::Sender<()>),
 }
 
@@ -91,6 +92,13 @@ where
                     writer.flush().await?;
                     let _ = returner.send(m);
                 }
+                Item::MessageMove(m, finisher) => {
+                    let result = crate::io::serialize::write_message(&mut writer, m).await;
+                    in_flight.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+                    result?;
+                    writer.flush().await?;
+                    let _ = finisher.send(());
+                }
                 Item::Done(r, finisher) => {
                     let _ = finisher.send(());
                     return r;
@@ -130,6 +138,21 @@ where
         let (complete, oneshot) = oneshot::channel();
 
         let _ = self.sender.unbounded_send(Item::Message(message, complete));
+
+        MapErr(oneshot)
+    }
+
+    pub fn send_move(
+        &mut self,
+        message: M,
+    ) -> impl Future<Output = Result<(), Error>> + Unpin + 'static {
+        self.in_flight
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let (complete, oneshot) = oneshot::channel();
+
+        let _ = self
+            .sender
+            .unbounded_send(Item::MessageMove(message, complete));
 
         MapErr(oneshot)
     }

--- a/capnp-futures/src/io/write_queue.rs
+++ b/capnp-futures/src/io/write_queue.rs
@@ -18,14 +18,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use std::future::Future;
-
-use futures_channel::oneshot;
-use futures_util::{AsyncWrite, AsyncWriteExt, StreamExt, TryFutureExt};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use capnp::Error;
+use futures_channel::oneshot;
 
-use crate::serialize::AsOutputSegments;
+use crate::{
+    io::serialize::AsOutputSegments,
+    io::{AsyncFdWrite, AsyncFdWriteExt as _},
+};
 
 enum Item<M>
 where
@@ -64,7 +69,7 @@ where
 /// called or `sender` and all of its clones are dropped.
 pub fn write_queue<W, M>(mut writer: W) -> (Sender<M>, impl Future<Output = Result<(), Error>>)
 where
-    W: AsyncWrite + Unpin,
+    W: AsyncFdWrite,
     M: AsOutputSegments,
 {
     let (tx, mut rx) = futures_channel::mpsc::unbounded::<Item<M>>();
@@ -77,10 +82,10 @@ where
     };
 
     let queue = async move {
-        while let Some(item) = rx.next().await {
+        while let Ok(item) = rx.recv().await {
             match item {
                 Item::Message(m, returner) => {
-                    let result = crate::serialize::write_message(&mut writer, &m).await;
+                    let result = crate::io::serialize::write_message(&mut writer, &m).await;
                     in_flight.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
                     result?;
                     writer.flush().await?;
@@ -101,14 +106,12 @@ where
 fn _assert_kinds() {
     fn _assert_send<T: Send>(_x: T) {}
     fn _assert_sync<T: Sync>() {}
-    fn _assert_write_queue_send<W: AsyncWrite + Unpin + Send, M: AsOutputSegments + Sync + Send>(
-        w: W,
-    ) {
+    fn _assert_write_queue_send<W: AsyncFdWrite + Send, M: AsOutputSegments + Sync + Send>(w: W) {
         let (s, f) = write_queue::<W, M>(w);
         _assert_send(s);
         _assert_send(f);
     }
-    fn _assert_write_queue_send_2<W: AsyncWrite + Unpin + Send>(w: W) {
+    fn _assert_write_queue_send_2<W: AsyncFdWrite + Send>(w: W) {
         let (s, f) = write_queue::<W, capnp::message::Builder<capnp::message::HeapAllocator>>(w);
         _assert_send(s);
         _assert_send(f);
@@ -128,7 +131,7 @@ where
 
         let _ = self.sender.unbounded_send(Item::Message(message, complete));
 
-        oneshot.map_err(|oneshot::Canceled| Error::disconnected("WriteQueue has terminated".into()))
+        MapErr(oneshot)
     }
 
     /// Returns the number of messages queued to be written.
@@ -153,7 +156,18 @@ where
 
         let _ = self.sender.unbounded_send(Item::Done(result, complete));
 
-        receiver
+        MapErr(receiver)
+    }
+}
+
+struct MapErr<T>(oneshot::Receiver<T>);
+
+impl<T> Future for MapErr<T> {
+    type Output = Result<T, Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.0)
+            .poll(cx)
             .map_err(|oneshot::Canceled| Error::disconnected("WriteQueue has terminated".into()))
     }
 }

--- a/capnp-futures/test/overflow_test.rs
+++ b/capnp-futures/test/overflow_test.rs
@@ -43,7 +43,7 @@ mod tests {
     fn write_async(builder: &message::Builder<HeapAllocator>) -> Vec<u8> {
         futures::executor::block_on(async {
             let mut buf: Vec<u8> = Vec::new();
-            capnp_futures::serialize_packed::write_message(&mut buf, builder)
+            capnp_futures::io::serialize_packed::write_message(&mut buf, builder)
                 .await
                 .unwrap();
             buf
@@ -56,7 +56,7 @@ mod tests {
 
     fn read_async(buf: &[u8]) -> message::Reader<OwnedSegments> {
         futures::executor::block_on(async {
-            capnp_futures::serialize_packed::read_message(buf, message::DEFAULT_READER_OPTIONS)
+            capnp_futures::io::serialize_packed::read_message(buf, message::DEFAULT_READER_OPTIONS)
                 .await
                 .unwrap()
         })

--- a/capnp-futures/test/test.rs
+++ b/capnp-futures/test/test.rs
@@ -25,7 +25,7 @@ capnp::generated_code!(pub mod addressbook_capnp);
 mod tests {
     use crate::addressbook_capnp::{address_book, person};
     use capnp::message;
-    use capnp_futures::serialize;
+    use capnp_futures::io::serialize;
     use futures::task::LocalSpawnExt;
 
     fn populate_address_book(address_book: address_book::Builder) {
@@ -95,9 +95,9 @@ mod tests {
         let spawner = pool.spawner();
 
         let (writer, reader) = async_byte_channel::channel();
-        let (mut sender, write_queue) = capnp_futures::write_queue(writer);
+        let (mut sender, write_queue) = capnp_futures::io::write_queue(writer);
 
-        let read_stream = capnp_futures::ReadStream::new(reader, Default::default());
+        let read_stream = capnp_futures::io::ReadStream::new(reader, Default::default());
         let messages_read = Rc::new(Cell::new(0u32));
         let messages_read1 = messages_read.clone();
 
@@ -184,8 +184,9 @@ mod tests {
     #[test]
     fn static_lifetime_not_required_on_highlevel() {
         let (mut write, mut read) = async_byte_channel::channel();
-        let _ = capnp_futures::ReadStream::new(&mut read, message::ReaderOptions::default());
-        let _ =
-            capnp_futures::write_queue::<_, message::Builder<message::HeapAllocator>>(&mut write);
+        let _ = capnp_futures::io::ReadStream::new(&mut read, message::ReaderOptions::default());
+        let _ = capnp_futures::io::write_queue::<_, message::Builder<message::HeapAllocator>>(
+            &mut write,
+        );
     }
 }

--- a/capnp-rpc/Cargo.toml
+++ b/capnp-rpc/Cargo.toml
@@ -14,11 +14,15 @@ edition = "2021"
 readme = "README.md"
 
 [dependencies]
-capnp-futures = { version = "0.26.0", path = "../capnp-futures" }
+capnp-futures = { version = "0.26.0", path = "../capnp-futures", default-features = false }
 capnp = {version = "0.26.0", path = "../capnp"}
 futures-channel = { version = "0.3.0", default-features = false, features = ["std"] }
-futures-io = { version = "0.3.0", default-features = false, features = ["std"] }
+futures-io = { version = "0.3.0", default-features = false, features = ["std"], optional = true }
 futures-util = { version = "0.3.0", default-features = false, features = ["std"] }
+
+[features]
+default = ["futures-io"]
+futures-io = ["dep:futures-io", "capnp-futures/futures-io"]
 
 [lints]
 workspace = true

--- a/capnp-rpc/Cargo.toml
+++ b/capnp-rpc/Cargo.toml
@@ -13,14 +13,12 @@ edition = "2021"
 
 readme = "README.md"
 
-[dependencies.futures]
-version = "0.3.0"
-default-features = false
-features = ["std"]
-
 [dependencies]
 capnp-futures = { version = "0.26.0", path = "../capnp-futures" }
 capnp = {version = "0.26.0", path = "../capnp"}
+futures-channel = { version = "0.3.0", default-features = false, features = ["std"] }
+futures-io = { version = "0.3.0", default-features = false, features = ["std"] }
+futures-util = { version = "0.3.0", default-features = false, features = ["std"] }
 
 [lints]
 workspace = true

--- a/capnp-rpc/src/attach.rs
+++ b/capnp-rpc/src/attach.rs
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use futures::Future;
+use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 

--- a/capnp-rpc/src/broken.rs
+++ b/capnp-rpc/src/broken.rs
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 use capnp::any_pointer;
+use capnp::fd::BorrowedFd;
 use capnp::private::capability::{
     ClientHook, ParamsHook, PipelineHook, PipelineOp, RequestHook, ResultsHook,
 };
@@ -157,6 +158,10 @@ impl ClientHook for Client {
 
     fn when_resolved(&self) -> Promise<(), Error> {
         crate::rpc::default_when_resolved_impl(self)
+    }
+
+    fn get_fd(&self) -> Option<BorrowedFd<'_>> {
+        None
     }
 }
 

--- a/capnp-rpc/src/flow_control.rs
+++ b/capnp-rpc/src/flow_control.rs
@@ -1,8 +1,8 @@
 use capnp::capability::Promise;
 use capnp::Error;
 
-use futures::channel::oneshot;
-use futures::TryFutureExt;
+use futures_channel::oneshot;
+use futures_util::TryFutureExt as _;
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/capnp-rpc/src/lib.rs
+++ b/capnp-rpc/src/lib.rs
@@ -61,9 +61,10 @@
 use capnp::capability::Promise;
 use capnp::private::capability::ClientHook;
 use capnp::Error;
-use futures::channel::oneshot;
-use futures::{Future, FutureExt, TryFutureExt};
+use futures_channel::oneshot;
+use futures_util::{FutureExt as _, TryFutureExt as _};
 use std::cell::RefCell;
+use std::future::Future;
 use std::pin::Pin;
 use std::rc::{Rc, Weak};
 use std::task::{Context, Poll};
@@ -479,9 +480,7 @@ where
 /// Creates a `Client` from a future that resolves to a `Client`.
 ///
 /// Any calls that arrive before the resolution are accumulated in a queue.
-pub fn new_future_client<T>(
-    client_future: impl ::futures::Future<Output = Result<T, Error>> + 'static,
-) -> T
+pub fn new_future_client<T>(client_future: impl Future<Output = Result<T, Error>> + 'static) -> T
 where
     T: ::capnp::capability::FromClientHook,
 {
@@ -545,6 +544,6 @@ where
     }
 }
 
-fn canceled_to_error(_e: futures::channel::oneshot::Canceled) -> Error {
+fn canceled_to_error(_e: oneshot::Canceled) -> Error {
     Error::failed("oneshot was canceled".to_string())
 }

--- a/capnp-rpc/src/lib.rs
+++ b/capnp-rpc/src/lib.rs
@@ -59,8 +59,10 @@
 //! For a more complete example, see <https://github.com/capnproto/capnproto-rust/tree/master/capnp-rpc/examples/calculator>
 
 use capnp::capability::Promise;
+use capnp::fd::FdHooks;
 use capnp::private::capability::ClientHook;
 use capnp::Error;
+use capnp_futures::io::FdReadBuf;
 use futures_channel::oneshot;
 use futures_util::{FutureExt as _, TryFutureExt as _};
 use std::cell::RefCell;
@@ -123,6 +125,10 @@ pub trait OutgoingMessage {
     /// Same as `get_body()`, but returns the corresponding reader type.
     fn get_body_as_reader(&self) -> ::capnp::Result<::capnp::any_pointer::Reader<'_>>;
 
+    fn set_fds(&mut self, fds: FdHooks) {
+        let _ = fds;
+    }
+
     /// Sends the message. Returns a promise that resolves once the send has completed.
     /// Dropping the returned promise does *not* cancel the send.
     fn send(
@@ -149,6 +155,15 @@ pub trait IncomingMessage {
     /// The standard RPC implementation interprets it as a Message as defined
     /// in `schema/rpc.capnp`.
     fn get_body(&self) -> ::capnp::Result<::capnp::any_pointer::Reader<'_>>;
+
+    fn get_body_and_attached_fds(
+        &mut self,
+    ) -> (
+        ::capnp::Result<::capnp::any_pointer::Reader<'_>>,
+        &mut FdReadBuf,
+    ) {
+        (self.get_body(), &mut [])
+    }
 }
 
 /// A two-way RPC connection.

--- a/capnp-rpc/src/local.rs
+++ b/capnp-rpc/src/local.rs
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 use capnp::capability::{self, Promise};
+use capnp::fd::BorrowedFd;
 use capnp::private::capability::{
     ClientHook, ParamsHook, PipelineHook, PipelineOp, RequestHook, ResponseHook, ResultsHook,
 };
@@ -611,5 +612,9 @@ where
 
     fn when_resolved(&self) -> Promise<(), Error> {
         crate::rpc::default_when_resolved_impl(self)
+    }
+
+    fn get_fd(&self) -> Option<BorrowedFd<'_>> {
+        self.inner.server.get_fd()
     }
 }

--- a/capnp-rpc/src/local.rs
+++ b/capnp-rpc/src/local.rs
@@ -343,15 +343,18 @@ pub(crate) struct Client<S>
 where
     S: capability::Server + Clone,
 {
-    state: Rc<RefCell<ClientState<S>>>,
+    inner: Rc<ClientInner<S>>,
 }
 
-struct ClientState<S>
+pub(crate) struct ClientInner<S>
 where
     S: capability::Server + Clone,
 {
-    inner: S,
+    server: S,
+    state: RefCell<ClientState>,
+}
 
+struct ClientState {
     /// If a streaming call on this capability has returned an error,
     /// this contains a copy of that error.
     broken_error: Option<Error>,
@@ -374,7 +377,7 @@ struct StreamingCall<S>
 where
     S: capability::Server + Clone + 'static,
 {
-    state: Rc<RefCell<ClientState<S>>>,
+    inner: Rc<ClientInner<S>>,
     promise: Promise<(), Error>,
     completed: bool,
 }
@@ -392,10 +395,10 @@ where
         match Pin::new(&mut this.promise).poll(cx) {
             Poll::Ready(result) => {
                 if let Err(e) = &result {
-                    this.state.borrow_mut().broken_error = Some(e.clone());
+                    this.inner.state.borrow_mut().broken_error = Some(e.clone());
                 }
                 this.completed = true;
-                ClientState::unblock(this.state.clone());
+                ClientInner::unblock(this.inner.clone());
                 Poll::Ready(result)
             }
             Poll::Pending => Poll::Pending,
@@ -409,24 +412,24 @@ where
 {
     fn drop(&mut self) {
         if !self.completed {
-            ClientState::unblock(self.state.clone());
+            ClientInner::unblock(self.inner.clone());
         }
     }
 }
 
-impl<S> ClientState<S>
+impl<S> ClientInner<S>
 where
     S: capability::Server + Clone + 'static,
 {
     fn dispatch_or_queue(
-        state: Rc<RefCell<Self>>,
+        inner: Rc<Self>,
         interface_id: u64,
         method_id: u16,
         params: Box<dyn ParamsHook>,
         results: Box<dyn ResultsHook>,
     ) -> Promise<(), Error> {
         {
-            let mut state_ref = state.borrow_mut();
+            let mut state_ref = inner.state.borrow_mut();
             if let Some(e) = &state_ref.broken_error {
                 return Promise::err(e.clone());
             }
@@ -452,25 +455,24 @@ where
             }
         }
 
-        Self::dispatch_call(state, interface_id, method_id, params, results)
+        Self::dispatch_call(inner, interface_id, method_id, params, results)
     }
 
     fn dispatch_call(
-        state: Rc<RefCell<Self>>,
+        inner: Rc<Self>,
         interface_id: u64,
         method_id: u16,
         params: Box<dyn ParamsHook>,
         results: Box<dyn ResultsHook>,
     ) -> Promise<(), Error> {
-        let inner = {
-            let state_ref = state.borrow();
-            if let Some(e) = &state_ref.broken_error {
+        let server = {
+            if let Some(e) = &inner.state.borrow().broken_error {
                 return Promise::err(e.clone());
             }
-            state_ref.inner.clone()
+            inner.server.clone()
         };
 
-        let f = inner.dispatch_call(
+        let f = server.dispatch_call(
             interface_id,
             method_id,
             ::capnp::capability::Params::new(params),
@@ -480,9 +482,9 @@ where
         if f.is_streaming {
             // A streaming call serializes later calls on the same local
             // capability until its server-side promise completes.
-            state.borrow_mut().blocked = true;
+            inner.state.borrow_mut().blocked = true;
             Promise::from_future(StreamingCall {
-                state,
+                inner: inner.clone(),
                 promise: f.promise,
                 completed: false,
             })
@@ -491,10 +493,10 @@ where
         }
     }
 
-    fn unblock(state: Rc<RefCell<Self>>) {
+    fn unblock(inner: Rc<Self>) {
         loop {
             let blocked_call = {
-                let mut state_ref = state.borrow_mut();
+                let mut state_ref = inner.state.borrow_mut();
                 state_ref.blocked = false;
                 state_ref.blocked_calls.pop_front()
             };
@@ -508,7 +510,7 @@ where
             }
 
             let promise = Self::dispatch_call(
-                state.clone(),
+                inner.clone(),
                 blocked_call.interface_id,
                 blocked_call.method_id,
                 blocked_call.params,
@@ -518,7 +520,7 @@ where
 
             // If the unblocked call was itself streaming, dispatch_call() set
             // blocked again; leave remaining calls queued behind it.
-            if state.borrow().blocked {
+            if inner.state.borrow().blocked {
                 return;
             }
         }
@@ -531,12 +533,14 @@ where
 {
     pub(crate) fn new(server: S) -> Self {
         Self {
-            state: Rc::new(RefCell::new(ClientState {
-                inner: server,
-                broken_error: None,
-                blocked: false,
-                blocked_calls: VecDeque::new(),
-            })),
+            inner: Rc::new(ClientInner {
+                server,
+                state: RefCell::new(ClientState {
+                    broken_error: None,
+                    blocked: false,
+                    blocked_calls: VecDeque::new(),
+                }),
+            }),
         }
     }
 }
@@ -547,7 +551,7 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            state: self.state.clone(),
+            inner: self.inner.clone(),
         }
     }
 }
@@ -583,14 +587,14 @@ where
         // We don't want to actually dispatch the call synchronously, because we don't want the callee
         // to have any side effects before the promise is returned to the caller.  This helps avoid
         // race conditions.
-        let state = self.state.clone();
+        let inner = self.inner.clone();
         Promise::from_future(async move {
-            ClientState::dispatch_or_queue(state, interface_id, method_id, params, results).await
+            ClientInner::dispatch_or_queue(inner, interface_id, method_id, params, results).await
         })
     }
 
     fn get_ptr(&self) -> usize {
-        self.state.borrow().inner.as_ptr()
+        self.inner.server.as_ptr()
     }
 
     fn get_brand(&self) -> usize {

--- a/capnp-rpc/src/local.rs
+++ b/capnp-rpc/src/local.rs
@@ -26,8 +26,8 @@ use capnp::traits::{Imbue, ImbueMut};
 use capnp::Error;
 use capnp::{any_pointer, message};
 
-use futures::channel::oneshot;
-use futures::TryFutureExt;
+use futures_channel::oneshot;
+use futures_util::TryFutureExt as _;
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -261,7 +261,7 @@ impl RequestHook for Request {
         let results = Results::new(results_done_fulfiller, pipeline_sender.weak_clone());
         let promise = client.call(interface_id, method_id, Box::new(params), Box::new(results));
 
-        let p = futures::future::try_join(promise, results_done_promise).and_then(
+        let p = futures_util::future::try_join(promise, results_done_promise).and_then(
             move |((), results_done_hook)| {
                 pipeline_sender
                     .complete(Box::new(Pipeline::new(results_done_hook.add_ref()))

--- a/capnp-rpc/src/queued.rs
+++ b/capnp-rpc/src/queued.rs
@@ -23,10 +23,10 @@ use capnp::any_pointer;
 use capnp::capability::Promise;
 use capnp::private::capability::{ClientHook, ParamsHook, PipelineHook, PipelineOp, ResultsHook};
 use capnp::Error;
-
-use futures::{Future, FutureExt, TryFutureExt};
+use futures_util::{FutureExt as _, TryFutureExt as _};
 
 use std::cell::RefCell;
+use std::future::Future;
 use std::rc::{Rc, Weak};
 
 use crate::attach::Attach;
@@ -37,7 +37,7 @@ pub(crate) struct PipelineInner {
     // Once the promise resolves, this will become non-null and point to the underlying object.
     redirect: Option<Box<dyn PipelineHook>>,
 
-    promise_to_drive: futures::future::Shared<Promise<(), Error>>,
+    promise_to_drive: futures_util::future::Shared<Promise<(), Error>>,
 
     clients_to_resolve: SenderQueue<(Weak<RefCell<ClientInner>>, Vec<PipelineOp>), ()>,
 }
@@ -135,8 +135,11 @@ impl Pipeline {
         F: Future<Output = Result<(), Error>> + 'static + Unpin,
     {
         let new = Promise::from_future(
-            futures::future::try_join(self.inner.borrow_mut().promise_to_drive.clone(), promise)
-                .map_ok(|_| ()),
+            futures_util::future::try_join(
+                self.inner.borrow_mut().promise_to_drive.clone(),
+                promise,
+            )
+            .map_ok(|_| ()),
         )
         .shared();
         self.inner.borrow_mut().promise_to_drive = new;
@@ -184,7 +187,7 @@ pub(crate) struct ClientInner {
     // to a reference to it so that it doesn't get canceled before the client is resolved.
     pipeline_inner: Option<Rc<RefCell<PipelineInner>>>,
 
-    promise_to_drive: Option<futures::future::Shared<Promise<(), Error>>>,
+    promise_to_drive: Option<futures_util::future::Shared<Promise<(), Error>>>,
 
     // When this promise resolves, each queued call will be forwarded to the real client.  This needs
     // to occur *before* any 'whenMoreResolved()' promises resolve, because we want to make sure
@@ -293,10 +296,10 @@ impl ClientHook for Client {
             Some(ref p) => {
                 let p1 = p.clone();
                 Promise::from_future(async move {
-                    match futures::future::select(p1, promise).await {
-                        futures::future::Either::Left((Ok(()), promise)) => promise.await,
-                        futures::future::Either::Left((Err(e), _)) => Err(e),
-                        futures::future::Either::Right((r, _)) => {
+                    match futures_util::future::select(p1, promise).await {
+                        futures_util::future::Either::Left((Ok(()), promise)) => promise.await,
+                        futures_util::future::Either::Left((Err(e), _)) => Err(e),
+                        futures_util::future::Either::Right((r, _)) => {
                             // Don't bother waiting for `promise_to_drive` to resolve.
                             // If we're here because set_pipeline() was called, then
                             // `promise_to_drive` might in fact never resolve.
@@ -332,7 +335,7 @@ impl ClientHook for Client {
         let promise = self.inner.borrow_mut().client_resolution_queue.push(());
         match &self.inner.borrow().promise_to_drive {
             Some(p) => Some(Promise::from_future(
-                futures::future::try_join(p.clone(), promise).map_ok(|v| v.1),
+                futures_util::future::try_join(p.clone(), promise).map_ok(|v| v.1),
             )),
             None => Some(Promise::from_future(promise)),
         }

--- a/capnp-rpc/src/queued.rs
+++ b/capnp-rpc/src/queued.rs
@@ -21,6 +21,7 @@
 
 use capnp::any_pointer;
 use capnp::capability::Promise;
+use capnp::fd::BorrowedFd;
 use capnp::private::capability::{ClientHook, ParamsHook, PipelineHook, PipelineOp, ResultsHook};
 use capnp::Error;
 use futures_util::{FutureExt as _, TryFutureExt as _};
@@ -351,5 +352,9 @@ impl ClientHook for Client {
 
     fn when_resolved(&self) -> Promise<(), Error> {
         crate::rpc::default_when_resolved_impl(self)
+    }
+
+    fn get_fd(&self) -> Option<BorrowedFd<'_>> {
+        self.inner.redirect.get().and_then(|p| p.get_fd())
     }
 }

--- a/capnp-rpc/src/queued.rs
+++ b/capnp-rpc/src/queued.rs
@@ -25,7 +25,7 @@ use capnp::private::capability::{ClientHook, ParamsHook, PipelineHook, PipelineO
 use capnp::Error;
 use futures_util::{FutureExt as _, TryFutureExt as _};
 
-use std::cell::RefCell;
+use std::cell::{OnceCell, RefCell};
 use std::future::Future;
 use std::rc::{Rc, Weak};
 
@@ -39,7 +39,7 @@ pub(crate) struct PipelineInner {
 
     promise_to_drive: futures_util::future::Shared<Promise<(), Error>>,
 
-    clients_to_resolve: SenderQueue<(Weak<RefCell<ClientInner>>, Vec<PipelineOp>), ()>,
+    clients_to_resolve: SenderQueue<(Weak<ClientInner>, Vec<PipelineOp>), ()>,
 }
 
 impl PipelineInner {
@@ -181,8 +181,11 @@ impl PipelineHook for Pipeline {
 
 pub(crate) struct ClientInner {
     // Once the promise resolves, this will become non-null and point to the underlying object.
-    redirect: Option<Box<dyn ClientHook>>,
+    redirect: OnceCell<Box<dyn ClientHook>>,
+    state: RefCell<ClientState>,
+}
 
+struct ClientState {
     // The queued::PipelineInner that this client is derived from, if any. We need to hold on
     // to a reference to it so that it doesn't get canceled before the client is resolved.
     pipeline_inner: Option<Rc<RefCell<PipelineInner>>>,
@@ -205,40 +208,41 @@ pub(crate) struct ClientInner {
 }
 
 impl ClientInner {
-    pub(crate) fn resolve(state: &Rc<RefCell<Self>>, result: Result<Box<dyn ClientHook>, Error>) {
-        assert!(state.borrow().redirect.is_none());
+    pub(crate) fn resolve(inner: &Rc<Self>, result: Result<Box<dyn ClientHook>, Error>) {
         let client = match result {
             Ok(clienthook) => clienthook,
             Err(e) => broken::new_cap(e),
         };
-        state.borrow_mut().redirect = Some(client.add_ref());
-        for (args, waiter) in state.borrow_mut().call_forwarding_queue.drain() {
+        assert!(inner.redirect.set(client.add_ref()).is_ok());
+        for (args, waiter) in inner.state.borrow_mut().call_forwarding_queue.drain() {
             let (interface_id, method_id, params, results) = args;
             let result_promise = client.call(interface_id, method_id, params, results);
             let _ = waiter.send(result_promise);
         }
 
-        for ((), waiter) in state.borrow_mut().client_resolution_queue.drain() {
+        for ((), waiter) in inner.state.borrow_mut().client_resolution_queue.drain() {
             let _ = waiter.send(client.add_ref());
         }
-        state.borrow_mut().promise_to_drive.take();
-        state.borrow_mut().pipeline_inner.take();
+        inner.state.borrow_mut().promise_to_drive.take();
+        inner.state.borrow_mut().pipeline_inner.take();
     }
 }
 
 pub(crate) struct Client {
-    pub(crate) inner: Rc<RefCell<ClientInner>>,
+    pub(crate) inner: Rc<ClientInner>,
 }
 
 impl Client {
     pub(crate) fn new(pipeline_inner: Option<Rc<RefCell<PipelineInner>>>) -> Self {
-        let inner = Rc::new(RefCell::new(ClientInner {
-            promise_to_drive: None,
-            pipeline_inner,
-            redirect: None,
-            call_forwarding_queue: SenderQueue::new(),
-            client_resolution_queue: SenderQueue::new(),
-        }));
+        let inner = Rc::new(ClientInner {
+            redirect: OnceCell::new(),
+            state: RefCell::new(ClientState {
+                promise_to_drive: None,
+                pipeline_inner,
+                call_forwarding_queue: SenderQueue::new(),
+                client_resolution_queue: SenderQueue::new(),
+            }),
+        });
         Self { inner }
     }
 
@@ -246,8 +250,9 @@ impl Client {
     where
         F: Future<Output = Result<(), Error>> + 'static,
     {
-        assert!(self.inner.borrow().promise_to_drive.is_none());
-        self.inner.borrow_mut().promise_to_drive = Some(Promise::from_future(promise).shared());
+        assert!(self.inner.state.borrow().promise_to_drive.is_none());
+        self.inner.state.borrow_mut().promise_to_drive =
+            Some(Promise::from_future(promise).shared());
     }
 }
 
@@ -278,13 +283,14 @@ impl ClientHook for Client {
         params: Box<dyn ParamsHook>,
         results: Box<dyn ResultsHook>,
     ) -> Promise<(), Error> {
-        if let Some(client) = &self.inner.borrow().redirect {
+        if let Some(client) = self.inner.redirect.get() {
             return client.call(interface_id, method_id, params, results);
         }
 
         let inner_clone = self.inner.clone();
         let promise = self
             .inner
+            .state
             .borrow_mut()
             .call_forwarding_queue
             .push((interface_id, method_id, params, results))
@@ -292,7 +298,7 @@ impl ClientHook for Client {
             .and_then(|x| x);
 
         // We need to drive `promise_to_drive` until we have a result.
-        match self.inner.borrow().promise_to_drive {
+        match self.inner.state.borrow().promise_to_drive {
             Some(ref p) => {
                 let p1 = p.clone();
                 Promise::from_future(async move {
@@ -313,7 +319,7 @@ impl ClientHook for Client {
     }
 
     fn get_ptr(&self) -> usize {
-        (&*self.inner.borrow()) as *const _ as usize
+        (&*self.inner.state.borrow()) as *const _ as usize
     }
 
     fn get_brand(&self) -> usize {
@@ -321,19 +327,21 @@ impl ClientHook for Client {
     }
 
     fn get_resolved(&self) -> Option<Box<dyn ClientHook>> {
-        match &self.inner.borrow().redirect {
-            Some(inner) => Some(inner.clone()),
-            None => None,
-        }
+        self.inner.redirect.get().cloned()
     }
 
     fn when_more_resolved(&self) -> Option<Promise<Box<dyn ClientHook>, Error>> {
-        if let Some(client) = &self.inner.borrow().redirect {
+        if let Some(client) = self.inner.redirect.get() {
             return Some(Promise::ok(client.add_ref()));
         }
 
-        let promise = self.inner.borrow_mut().client_resolution_queue.push(());
-        match &self.inner.borrow().promise_to_drive {
+        let promise = self
+            .inner
+            .state
+            .borrow_mut()
+            .client_resolution_queue
+            .push(());
+        match &self.inner.state.borrow().promise_to_drive {
             Some(p) => Some(Promise::from_future(
                 futures_util::future::try_join(p.clone(), promise).map_ok(|v| v.1),
             )),

--- a/capnp-rpc/src/reconnect.rs
+++ b/capnp-rpc/src/reconnect.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 
 use capnp::capability::{FromClientHook, Promise};
+use capnp::fd::BorrowedFd;
 use capnp::private::capability::{ClientHook, RequestHook};
 use futures_util::TryFutureExt as _;
 
@@ -205,6 +206,13 @@ where
 
     fn when_resolved(&self) -> Promise<(), capnp::Error> {
         Promise::ok(())
+    }
+
+    fn get_fd(&self) -> Option<BorrowedFd<'_>> {
+        // We can’t return `self.get_current().get_fd()` because it might not
+        // live long enough. This matches the C++ behaviour; see
+        // <https://github.com/capnproto/capnproto/blob/291d8ee870ab394d32fbdd5d2160add84b65e229/c%2B%2B/src/capnp/reconnect.c%2B%2B#L72-L77>.
+        None
     }
 }
 

--- a/capnp-rpc/src/reconnect.rs
+++ b/capnp-rpc/src/reconnect.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use capnp::capability::{FromClientHook, Promise};
 use capnp::private::capability::{ClientHook, RequestHook};
-use futures::TryFutureExt;
+use futures_util::TryFutureExt as _;
 
 /// Trait implemented by the reconnecting client to set new connection out-of-band.
 ///

--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -2666,7 +2666,7 @@ where
     VatId: 'static,
 {
     Import(Rc<RefCell<ImportClient<VatId>>>),
-    Pipeline(Rc<RefCell<PipelineClient<VatId>>>),
+    Pipeline(Rc<PipelineClient<VatId>>),
     Promise(Rc<RefCell<PromiseClient<VatId>>>),
 }
 
@@ -2684,7 +2684,7 @@ where
     VatId: 'static,
 {
     Import(Weak<RefCell<ImportClient<VatId>>>),
-    Pipeline(Weak<RefCell<PipelineClient<VatId>>>),
+    Pipeline(Weak<PipelineClient<VatId>>),
     Promise(Weak<RefCell<PromiseClient<VatId>>>),
 }
 
@@ -2808,18 +2808,18 @@ where
         connection_state: &Rc<ConnectionState<VatId>>,
         question_ref: Rc<RefCell<QuestionRef<VatId>>>,
         ops: Vec<PipelineOp>,
-    ) -> Rc<RefCell<Self>> {
-        Rc::new(RefCell::new(Self {
+    ) -> Rc<Self> {
+        Rc::new(Self {
             connection_state: connection_state.clone(),
             question_ref,
             ops,
-        }))
+        })
     }
 }
 
-impl<VatId> From<Rc<RefCell<PipelineClient<VatId>>>> for Client<VatId> {
-    fn from(client: Rc<RefCell<PipelineClient<VatId>>>) -> Self {
-        let connection_state = client.borrow().connection_state.clone();
+impl<VatId> From<Rc<PipelineClient<VatId>>> for Client<VatId> {
+    fn from(client: Rc<PipelineClient<VatId>>) -> Self {
+        let connection_state = client.connection_state.clone();
         Self::new(&connection_state, ClientVariant::Pipeline(client))
     }
 }
@@ -3031,13 +3031,12 @@ impl<VatId> Client<VatId> {
             }
             ClientVariant::Pipeline(pipeline_client) => {
                 let mut builder = target.init_promised_answer();
-                let question_ref = &pipeline_client.borrow().question_ref;
+                let question_ref = &pipeline_client.question_ref;
                 builder.set_question_id(question_ref.borrow().id);
-                let mut transform =
-                    builder.init_transform(pipeline_client.borrow().ops.len() as u32);
-                for idx in 0..pipeline_client.borrow().ops.len() {
+                let mut transform = builder.init_transform(pipeline_client.ops.len() as u32);
+                for idx in 0..pipeline_client.ops.len() {
                     if let ::capnp::private::capability::PipelineOp::GetPointerField(ordinal) =
-                        pipeline_client.borrow().ops[idx]
+                        pipeline_client.ops[idx]
                     {
                         transform
                             .reborrow()
@@ -3063,13 +3062,13 @@ impl<VatId> Client<VatId> {
             }
             ClientVariant::Pipeline(pipeline_client) => {
                 let mut promised_answer = descriptor.init_receiver_answer();
-                let question_ref = &pipeline_client.borrow().question_ref;
+                let question_ref = &pipeline_client.question_ref;
                 promised_answer.set_question_id(question_ref.borrow().id);
                 let mut transform =
-                    promised_answer.init_transform(pipeline_client.borrow().ops.len() as u32);
-                for idx in 0..pipeline_client.borrow().ops.len() {
+                    promised_answer.init_transform(pipeline_client.ops.len() as u32);
+                for idx in 0..pipeline_client.ops.len() {
                     if let ::capnp::private::capability::PipelineOp::GetPointerField(ordinal) =
-                        pipeline_client.borrow().ops[idx]
+                        pipeline_client.ops[idx]
                     {
                         transform
                             .reborrow()
@@ -3179,9 +3178,7 @@ impl<VatId> ClientHook for Client<VatId> {
     fn get_ptr(&self) -> usize {
         match &self.variant {
             ClientVariant::Import(import_client) => (&*import_client.borrow()) as *const _ as usize,
-            ClientVariant::Pipeline(pipeline_client) => {
-                (&*pipeline_client.borrow()) as *const _ as usize
-            }
+            ClientVariant::Pipeline(pipeline_client) => &**pipeline_client as *const _ as usize,
             ClientVariant::Promise(promise_client) => {
                 (&*promise_client.borrow()) as *const _ as usize
             }

--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -32,7 +32,7 @@ use capnp::Error;
 use futures_channel::oneshot;
 use futures_util::{future, Future, FutureExt, TryFutureExt};
 
-use std::cell::{Cell, RefCell};
+use std::cell::{Cell, OnceCell, RefCell};
 use std::cmp::Reverse;
 use std::collections::binary_heap::BinaryHeap;
 use std::collections::hash_map::{self, HashMap};
@@ -313,7 +313,7 @@ where
     app_client: Option<WeakClient<VatId>>,
 
     // If non-null, the import is a promise.
-    promise_client_to_resolve: Option<Weak<RefCell<PromiseClient<VatId>>>>,
+    promise_client_to_resolve: Option<Weak<PromiseClient<VatId>>>,
 }
 
 impl<VatId> Import<VatId> {
@@ -532,7 +532,7 @@ impl<VatId> ConnectionState<VatId> {
             for (_, ref mut import) in import_slots.iter_mut() {
                 if let Some(f) = import.promise_client_to_resolve.take() {
                     if let Some(promise_client) = f.upgrade() {
-                        promise_client.borrow_mut().resolve(Err(error.clone()));
+                        promise_client.resolve(Err(error.clone()));
                     }
                 }
             }
@@ -849,7 +849,7 @@ impl<VatId> ConnectionState<VatId> {
             match import.promise_client_to_resolve.take() {
                 Some(weak_promise_client) => {
                     if let Some(promise_client) = weak_promise_client.upgrade() {
-                        promise_client.borrow_mut().resolve(replacement_or_error);
+                        promise_client.resolve(replacement_or_error);
                     }
                 }
                 None => {
@@ -2093,10 +2093,7 @@ where
     resolve_self_promise: Promise<(), Error>,
 
     promise_clients_to_resolve: RefCell<
-        crate::sender_queue::SenderQueue<
-            (Weak<RefCell<PromiseClient<VatId>>>, Vec<PipelineOp>),
-            (),
-        >,
+        crate::sender_queue::SenderQueue<(Weak<PromiseClient<VatId>>, Vec<PipelineOp>), ()>,
     >,
     resolution_waiters: crate::sender_queue::SenderQueue<(), ()>,
 }
@@ -2120,7 +2117,7 @@ where
                 Err(e) => Err(e),
             };
             if let Some(c) = c.upgrade() {
-                c.borrow_mut().resolve(resolved);
+                c.resolve(resolved);
             }
         }
 
@@ -2667,7 +2664,7 @@ where
 {
     Import(Rc<ImportClient<VatId>>),
     Pipeline(Rc<PipelineClient<VatId>>),
-    Promise(Rc<RefCell<PromiseClient<VatId>>>),
+    Promise(Rc<PromiseClient<VatId>>),
 }
 
 struct Client<VatId>
@@ -2685,7 +2682,7 @@ where
 {
     Import(Weak<ImportClient<VatId>>),
     Pipeline(Weak<PipelineClient<VatId>>),
-    Promise(Weak<RefCell<PromiseClient<VatId>>>),
+    Promise(Weak<PromiseClient<VatId>>),
 }
 
 struct WeakClient<VatId>
@@ -2839,9 +2836,13 @@ where
     VatId: 'static,
 {
     connection_state: Rc<ConnectionState<VatId>>,
-    is_resolved: bool,
-    cap: Box<dyn ClientHook>,
+    unresolved: RefCell<Option<PromiseClientUnresolved>>,
+    resolved: OnceCell<Box<dyn ClientHook>>,
     import_id: Option<ImportId>,
+}
+
+struct PromiseClientUnresolved {
+    initial: Box<dyn ClientHook>,
     received_call: bool,
     resolution_waiters: crate::sender_queue::SenderQueue<(), Box<dyn ClientHook>>,
 }
@@ -2851,18 +2852,24 @@ impl<VatId> PromiseClient<VatId> {
         connection_state: &Rc<ConnectionState<VatId>>,
         initial: Box<dyn ClientHook>,
         import_id: Option<ImportId>,
-    ) -> Rc<RefCell<Self>> {
-        Rc::new(RefCell::new(Self {
+    ) -> Rc<Self> {
+        Rc::new(Self {
             connection_state: connection_state.clone(),
-            is_resolved: false,
-            cap: initial,
+            unresolved: RefCell::new(Some(PromiseClientUnresolved {
+                initial,
+                received_call: false,
+                resolution_waiters: crate::sender_queue::SenderQueue::new(),
+            })),
+            resolved: OnceCell::new(),
             import_id,
-            received_call: false,
-            resolution_waiters: crate::sender_queue::SenderQueue::new(),
-        }))
+        })
     }
 
-    fn resolve(&mut self, replacement: Result<Box<dyn ClientHook>, Error>) {
+    fn resolve(&self, replacement: Result<Box<dyn ClientHook>, Error>) {
+        let Some(mut unresolved) = self.unresolved.borrow_mut().take() else {
+            // TODO: I *believe* this should never happen – should this panic?
+            return;
+        };
         let (mut replacement, is_error) = match replacement {
             Ok(v) => (v, false),
             Err(e) => (broken::new_cap(e), true),
@@ -2871,7 +2878,7 @@ impl<VatId> PromiseClient<VatId> {
         let is_connected = connection_state.connection.borrow().is_ok();
         let replacement_brand = replacement.get_brand();
         if replacement_brand != connection_state.get_brand()
-            && self.received_call
+            && unresolved.received_call
             && !is_error
             && is_connected
         {
@@ -2898,7 +2905,7 @@ impl<VatId> PromiseClient<VatId> {
                     .set_sender_loopback(embargo_id);
                 let target = disembargo.init_target();
 
-                let redirect = connection_state.write_target(&*self.cap, target);
+                let redirect = connection_state.write_target(&*unresolved.initial, target);
                 if redirect.is_some() {
                     panic!("Original promise target should always be from this RPC connection.")
                 }
@@ -2924,17 +2931,15 @@ impl<VatId> PromiseClient<VatId> {
             let _ = message.send();
         }
 
-        for ((), waiter) in self.resolution_waiters.drain() {
+        for ((), waiter) in unresolved.resolution_waiters.drain() {
             let _ = waiter.send(replacement.clone());
         }
 
-        let old_cap = mem::replace(&mut self.cap, replacement);
+        assert!(self.resolved.set(replacement).is_ok());
         connection_state.add_task(async move {
-            drop(old_cap);
+            drop(unresolved.initial);
             Ok(())
         });
-
-        self.is_resolved = true;
     }
 }
 
@@ -2968,9 +2973,9 @@ impl<VatId> Drop for PromiseClient<VatId> {
     }
 }
 
-impl<VatId> From<Rc<RefCell<PromiseClient<VatId>>>> for Client<VatId> {
-    fn from(client: Rc<RefCell<PromiseClient<VatId>>>) -> Self {
-        let connection_state = client.borrow().connection_state.clone();
+impl<VatId> From<Rc<PromiseClient<VatId>>> for Client<VatId> {
+    fn from(client: Rc<PromiseClient<VatId>>) -> Self {
+        let connection_state = client.connection_state.clone();
         Self::new(&connection_state, ClientVariant::Promise(client))
     }
 }
@@ -3044,9 +3049,16 @@ impl<VatId> Client<VatId> {
                 None
             }
             ClientVariant::Promise(promise_client) => {
-                promise_client.borrow_mut().received_call = true;
-                self.connection_state
-                    .write_target(&*promise_client.borrow().cap, target)
+                // TODO: Is this ever `Some`?
+                if let Some(resolved) = promise_client.resolved.get() {
+                    self.connection_state.write_target(&**resolved, target)
+                } else if let Some(unresolved) = promise_client.unresolved.borrow_mut().as_mut() {
+                    unresolved.received_call = true;
+                    self.connection_state
+                        .write_target(&*unresolved.initial, target)
+                } else {
+                    panic!("promise was neither resolved nor unresolved");
+                }
             }
         }
     }
@@ -3077,14 +3089,17 @@ impl<VatId> Client<VatId> {
                 None
             }
             ClientVariant::Promise(promise_client) => {
-                promise_client.borrow_mut().received_call = true;
-
-                ConnectionState::write_descriptor(
-                    &self.connection_state.clone(),
-                    promise_client.borrow().cap.clone(),
-                    descriptor,
-                )
-                .unwrap()
+                // TODO: Is this ever `Some`?
+                let cap = if let Some(resolved) = promise_client.resolved.get() {
+                    resolved.clone()
+                } else if let Some(unresolved) = promise_client.unresolved.borrow_mut().as_mut() {
+                    unresolved.received_call = true;
+                    unresolved.initial.clone()
+                } else {
+                    panic!("promise was neither resolved nor unresolved");
+                };
+                ConnectionState::write_descriptor(&self.connection_state.clone(), cap, descriptor)
+                    .unwrap()
             }
         }
     }
@@ -3176,9 +3191,7 @@ impl<VatId> ClientHook for Client<VatId> {
         match &self.variant {
             ClientVariant::Import(import_client) => &**import_client as *const _ as usize,
             ClientVariant::Pipeline(pipeline_client) => &**pipeline_client as *const _ as usize,
-            ClientVariant::Promise(promise_client) => {
-                (&*promise_client.borrow()) as *const _ as usize
-            }
+            ClientVariant::Promise(promise_client) => &**promise_client as *const _ as usize,
         }
     }
 
@@ -3190,13 +3203,7 @@ impl<VatId> ClientHook for Client<VatId> {
         match &self.variant {
             ClientVariant::Import(_import_client) => None,
             ClientVariant::Pipeline(_pipeline_client) => None,
-            ClientVariant::Promise(promise_client) => {
-                if promise_client.borrow().is_resolved {
-                    Some(promise_client.borrow().cap.clone())
-                } else {
-                    None
-                }
-            }
+            ClientVariant::Promise(promise_client) => promise_client.resolved.get().cloned(),
         }
     }
 
@@ -3205,7 +3212,14 @@ impl<VatId> ClientHook for Client<VatId> {
             ClientVariant::Import(_import_client) => None,
             ClientVariant::Pipeline(_pipeline_client) => None,
             ClientVariant::Promise(promise_client) => {
-                Some(promise_client.borrow_mut().resolution_waiters.push(()))
+                // TODO: Is this ever `Some`?
+                if let Some(resolved) = promise_client.resolved.get() {
+                    Some(Promise::ok(resolved.add_ref()))
+                } else if let Some(unresolved) = promise_client.unresolved.borrow_mut().as_mut() {
+                    Some(unresolved.resolution_waiters.push(()))
+                } else {
+                    panic!("promise was neither resolved nor unresolved");
+                }
             }
         }
     }

--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -305,7 +305,7 @@ pub(crate) struct Import<VatId>
 where
     VatId: 'static,
 {
-    import_client: Weak<RefCell<ImportClient<VatId>>>,
+    import_client: Weak<ImportClient<VatId>>,
 
     // Either a copy of importClient, or, in the case of promises, the wrapping PromiseClient.
     // Becomes null when it is discarded *or* when the import is destroyed (e.g. the promise is
@@ -317,7 +317,7 @@ where
 }
 
 impl<VatId> Import<VatId> {
-    fn new(import_client: &Rc<RefCell<ImportClient<VatId>>>) -> Self {
+    fn new(import_client: &Rc<ImportClient<VatId>>) -> Self {
         Self {
             import_client: Rc::downgrade(import_client),
             app_client: None,
@@ -1512,7 +1512,7 @@ impl<VatId> ConnectionState<VatId> {
         };
 
         // We just received a copy of this import ID, so the remote refcount has gone up.
-        import_client.borrow_mut().add_remote_ref();
+        import_client.add_remote_ref();
 
         let mut tmp = state.imports.borrow_mut();
         let Some(import) = tmp.slots.get_mut(&import_id) else {
@@ -2665,7 +2665,7 @@ enum ClientVariant<VatId>
 where
     VatId: 'static,
 {
-    Import(Rc<RefCell<ImportClient<VatId>>>),
+    Import(Rc<ImportClient<VatId>>),
     Pipeline(Rc<PipelineClient<VatId>>),
     Promise(Rc<RefCell<PromiseClient<VatId>>>),
 }
@@ -2683,7 +2683,7 @@ enum WeakClientVariant<VatId>
 where
     VatId: 'static,
 {
-    Import(Weak<RefCell<ImportClient<VatId>>>),
+    Import(Weak<ImportClient<VatId>>),
     Pipeline(Weak<PipelineClient<VatId>>),
     Promise(Weak<RefCell<PromiseClient<VatId>>>),
 }
@@ -2725,7 +2725,7 @@ where
     import_id: ImportId,
 
     /// Number of times we've received this import from the peer.
-    remote_ref_count: u32,
+    remote_ref_count: Cell<u32>,
 }
 
 impl<VatId> Drop for ImportClient<VatId> {
@@ -2750,13 +2750,13 @@ impl<VatId> Drop for ImportClient<VatId> {
 
         // Send a message releasing our remote references.
         let mut tmp = connection_state.connection.borrow_mut();
-        if let (true, Ok(c)) = (self.remote_ref_count > 0, tmp.as_mut()) {
+        if let (true, Ok(c)) = (self.remote_ref_count.get() > 0, tmp.as_mut()) {
             let mut message = c.new_outgoing_message(10);
             {
                 let root: message::Builder = message.get_body().unwrap().init_as();
                 let mut release = root.init_release();
                 release.set_id(self.import_id);
-                release.set_reference_count(self.remote_ref_count);
+                release.set_reference_count(self.remote_ref_count.get());
             }
             let _ = message.send();
         }
@@ -2767,25 +2767,22 @@ impl<VatId> ImportClient<VatId>
 where
     VatId: 'static,
 {
-    fn new(
-        connection_state: &Rc<ConnectionState<VatId>>,
-        import_id: ImportId,
-    ) -> Rc<RefCell<Self>> {
-        Rc::new(RefCell::new(Self {
+    fn new(connection_state: &Rc<ConnectionState<VatId>>, import_id: ImportId) -> Rc<Self> {
+        Rc::new(Self {
             connection_state: connection_state.clone(),
             import_id,
-            remote_ref_count: 0,
-        }))
+            remote_ref_count: Cell::new(0),
+        })
     }
 
-    fn add_remote_ref(&mut self) {
-        self.remote_ref_count += 1;
+    fn add_remote_ref(&self) {
+        self.remote_ref_count.update(|count| count + 1);
     }
 }
 
-impl<VatId> From<Rc<RefCell<ImportClient<VatId>>>> for Client<VatId> {
-    fn from(client: Rc<RefCell<ImportClient<VatId>>>) -> Self {
-        let connection_state = client.borrow().connection_state.clone();
+impl<VatId> From<Rc<ImportClient<VatId>>> for Client<VatId> {
+    fn from(client: Rc<ImportClient<VatId>>) -> Self {
+        let connection_state = client.connection_state.clone();
         Self::new(&connection_state, ClientVariant::Import(client))
     }
 }
@@ -3026,7 +3023,7 @@ impl<VatId> Client<VatId> {
     ) -> Option<Box<dyn ClientHook>> {
         match &self.variant {
             ClientVariant::Import(import_client) => {
-                target.set_imported_cap(import_client.borrow().import_id);
+                target.set_imported_cap(import_client.import_id);
                 None
             }
             ClientVariant::Pipeline(pipeline_client) => {
@@ -3057,7 +3054,7 @@ impl<VatId> Client<VatId> {
     fn write_descriptor(&self, mut descriptor: cap_descriptor::Builder) -> Option<u32> {
         match &self.variant {
             ClientVariant::Import(import_client) => {
-                descriptor.set_receiver_hosted(import_client.borrow().import_id);
+                descriptor.set_receiver_hosted(import_client.import_id);
                 None
             }
             ClientVariant::Pipeline(pipeline_client) => {
@@ -3177,7 +3174,7 @@ impl<VatId> ClientHook for Client<VatId> {
 
     fn get_ptr(&self) -> usize {
         match &self.variant {
-            ClientVariant::Import(import_client) => (&*import_client.borrow()) as *const _ as usize,
+            ClientVariant::Import(import_client) => &**import_client as *const _ as usize,
             ClientVariant::Pipeline(pipeline_client) => &**pipeline_client as *const _ as usize,
             ClientVariant::Promise(promise_client) => {
                 (&*promise_client.borrow()) as *const _ as usize

--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -24,11 +24,13 @@ use std::task::{Context, Poll};
 
 use capnp::any_pointer;
 use capnp::capability::Promise;
+use capnp::fd::{AsFd as _, BorrowedFd, FdHooks, OwnedFd};
 use capnp::private::capability::{
     ClientHook, ParamsHook, PipelineHook, PipelineOp, RequestHook, ResponseHook, ResultsHook,
 };
 use capnp::Error;
 
+use capnp_futures::io::FdReadBuf;
 use futures_channel::oneshot;
 use futures_util::{future, Future, FutureExt, TryFutureExt};
 
@@ -763,6 +765,7 @@ impl<VatId> ConnectionState<VatId> {
             let cap = connection_state.bootstrap_cap.clone();
             let mut cap_table = Vec::new();
             let mut payload = ret.init_results();
+            let mut fds = FdHooks::new();
             {
                 let mut content = payload.reborrow().get_content();
                 content.imbue_mut(&mut cap_table);
@@ -770,7 +773,9 @@ impl<VatId> ConnectionState<VatId> {
             }
             assert_eq!(cap_table.len(), 1);
 
-            Self::write_descriptors(connection_state, &cap_table, payload)
+            let exports = Self::write_descriptors(connection_state, &cap_table, payload, &mut fds);
+            response.set_fds(fds);
+            exports
         };
 
         let slots = &mut connection_state.answers.borrow_mut().slots;
@@ -824,9 +829,13 @@ impl<VatId> ConnectionState<VatId> {
         Ok(())
     }
 
-    fn handle_resolve(connection_state: &Rc<Self>, resolve: resolve::Reader) -> capnp::Result<()> {
+    fn handle_resolve(
+        connection_state: &Rc<Self>,
+        resolve: resolve::Reader,
+        fds: &mut FdReadBuf,
+    ) -> capnp::Result<()> {
         let replacement_or_error = match resolve.which()? {
-            resolve::Cap(c) => match Self::receive_cap(connection_state, c?)? {
+            resolve::Cap(c) => match Self::receive_cap(connection_state, c?, fds)? {
                 Some(cap) => Ok(cap),
                 None => {
                     return Err(Error::failed(
@@ -935,7 +944,7 @@ impl<VatId> ConnectionState<VatId> {
 
     fn handle_message(
         weak_state: &Weak<Self>,
-        message: Box<dyn crate::IncomingMessage>,
+        mut message: Box<dyn crate::IncomingMessage>,
     ) -> ::capnp::Result<()> {
         let Some(connection_state) = weak_state.upgrade() else {
             return Err(Error::disconnected(
@@ -943,7 +952,8 @@ impl<VatId> ConnectionState<VatId> {
             ));
         };
 
-        let reader = message.get_body()?.get_as::<message::Reader>()?;
+        let (body, fds) = message.get_body_and_attached_fds();
+        let reader = body?.get_as::<message::Reader>()?;
         match reader.which() {
             Ok(message::Unimplemented(message)) => {
                 Self::handle_unimplemented(&connection_state, message?)?
@@ -971,7 +981,7 @@ impl<VatId> ConnectionState<VatId> {
                         call.get_interface_id(),
                         call.get_method_id(),
                         call.get_question_id(),
-                        Self::receive_caps(&connection_state, payload.get_cap_table()?)?,
+                        Self::receive_caps(&connection_state, payload.get_cap_table()?, fds)?,
                         redirect_results,
                     )
                 };
@@ -1079,6 +1089,7 @@ impl<VatId> ConnectionState<VatId> {
                                     let cap_table = Self::receive_caps(
                                         &connection_state,
                                         results?.get_cap_table()?,
+                                        fds,
                                     )?;
 
                                     let question_ref =
@@ -1150,7 +1161,9 @@ impl<VatId> ConnectionState<VatId> {
                 }
             }
             Ok(message::Finish(finish)) => Self::handle_finish(&connection_state, finish?)?,
-            Ok(message::Resolve(resolve)) => Self::handle_resolve(&connection_state, resolve?)?,
+            Ok(message::Resolve(resolve)) => {
+                Self::handle_resolve(&connection_state, resolve?, fds)?
+            }
             Ok(message::Release(release)) => {
                 let release = release?;
                 connection_state.release_export(release.get_id(), release.get_reference_count())?;
@@ -1389,6 +1402,7 @@ impl<VatId> ConnectionState<VatId> {
 
                     // OK, we have to send a `Resolve` message.
                     let mut message = connection_state.new_outgoing_message(15)?;
+                    let mut fds = FdHooks::new();
                     {
                         let root: message::Builder = message.get_body()?.get_as()?;
                         let mut resolve = root.init_resolve();
@@ -1397,8 +1411,10 @@ impl<VatId> ConnectionState<VatId> {
                             &connection_state,
                             resolution,
                             resolve.init_cap(),
+                            &mut fds,
                         )?;
                     }
+                    message.set_fds(fds);
                     let _ = message.send();
                     Ok(())
                 }
@@ -1422,16 +1438,29 @@ impl<VatId> ConnectionState<VatId> {
         state: &Rc<Self>,
         mut inner: Box<dyn ClientHook>,
         mut descriptor: cap_descriptor::Builder,
+        fd_hooks: &mut FdHooks,
     ) -> ::capnp::Result<Option<ExportId>> {
         // Find the innermost wrapped capability.
         while let Some(resolved) = inner.get_resolved() {
             inner = resolved;
         }
+
+        // We don’t report an error if too many FDs have already been
+        // attached, as this can also happen due to per‐connection limits.
+        let result = fd_hooks.try_push(inner);
+        let inner = match &result {
+            Ok((attached_fd, inner)) => {
+                descriptor.set_attached_fd(*attached_fd);
+                *inner
+            }
+            Err(inner) => &**inner,
+        };
+
         if inner.get_brand() == state.get_brand() {
             let Some(c) = Client::from_ptr(inner.get_ptr(), state) else {
                 unreachable!()
             };
-            Ok(c.write_descriptor(descriptor))
+            Ok(c.write_descriptor(descriptor, fd_hooks))
         } else {
             let ptr = inner.get_ptr();
             let contains_key = state.exports_by_cap.borrow().contains_key(&ptr);
@@ -1445,7 +1474,7 @@ impl<VatId> ConnectionState<VatId> {
             } else {
                 // This is the first time we've seen this capability.
 
-                let mut exp = Export::new(inner.clone());
+                let mut exp = Export::new(inner.add_ref());
                 exp.canonical = true;
                 let export_id = state.exports.borrow_mut().push(exp);
                 state.exports_by_cap.borrow_mut().insert(ptr, export_id);
@@ -1471,6 +1500,7 @@ impl<VatId> ConnectionState<VatId> {
         state: &Rc<Self>,
         cap_table: &[Option<Box<dyn ClientHook>>],
         payload: payload::Builder,
+        fds: &mut FdHooks,
     ) -> Vec<ExportId> {
         let mut cap_table_builder = payload.init_cap_table(cap_table.len() as u32);
         let mut exports = Vec::new();
@@ -1481,6 +1511,7 @@ impl<VatId> ConnectionState<VatId> {
                         state,
                         cap.clone(),
                         cap_table_builder.reborrow().get(idx as u32),
+                        fds,
                     )
                     .unwrap()
                     {
@@ -1495,14 +1526,22 @@ impl<VatId> ConnectionState<VatId> {
         exports
     }
 
-    fn import(state: &Rc<Self>, import_id: ImportId, is_promise: bool) -> Box<dyn ClientHook> {
+    fn import(
+        state: &Rc<Self>,
+        import_id: ImportId,
+        is_promise: bool,
+        fd: Option<OwnedFd>,
+    ) -> Box<dyn ClientHook> {
         let import_client = {
             match state.imports.borrow_mut().slots.entry(import_id) {
-                hash_map::Entry::Occupied(occ) => occ
-                    .get()
-                    .import_client
-                    .upgrade()
-                    .expect("dangling ref to import client?"),
+                hash_map::Entry::Occupied(occ) => {
+                    let import_client = occ
+                        .get()
+                        .import_client
+                        .upgrade()
+                        .expect("dangling ref to import client?");
+                    import_client
+                }
                 hash_map::Entry::Vacant(v) => {
                     let import_client = ImportClient::new(state, import_id);
                     v.insert(Import::new(&import_client));
@@ -1510,6 +1549,8 @@ impl<VatId> ConnectionState<VatId> {
                 }
             }
         };
+
+        import_client.set_fd_if_missing(fd);
 
         // We just received a copy of this import ID, so the remote refcount has gone up.
         import_client.add_remote_ref();
@@ -1559,14 +1600,17 @@ impl<VatId> ConnectionState<VatId> {
     fn receive_cap(
         state: &Rc<Self>,
         descriptor: cap_descriptor::Reader,
+        fds: &mut FdReadBuf,
     ) -> ::capnp::Result<Option<Box<dyn ClientHook>>> {
+        let fd_index = descriptor.get_attached_fd();
+        let fd = fds.get_mut(usize::from(fd_index)).and_then(Option::take);
         match descriptor.which()? {
             cap_descriptor::None(()) => Ok(None),
             cap_descriptor::SenderHosted(sender_hosted) => {
-                Ok(Some(Self::import(state, sender_hosted, false)))
+                Ok(Some(Self::import(state, sender_hosted, false, fd)))
             }
             cap_descriptor::SenderPromise(sender_promise) => {
-                Ok(Some(Self::import(state, sender_promise, true)))
+                Ok(Some(Self::import(state, sender_promise, true, fd)))
             }
             cap_descriptor::ReceiverHosted(receiver_hosted) => {
                 if let Some(exp) = state.exports.borrow_mut().find(receiver_hosted) {
@@ -1599,10 +1643,11 @@ impl<VatId> ConnectionState<VatId> {
     fn receive_caps(
         state: &Rc<Self>,
         cap_table: ::capnp::struct_list::Reader<cap_descriptor::Owned>,
+        fds: &mut FdReadBuf,
     ) -> ::capnp::Result<Vec<Option<Box<dyn ClientHook>>>> {
         let mut result = Vec::new();
         for idx in 0..cap_table.len() {
-            result.push(Self::receive_cap(state, cap_table.get(idx))?);
+            result.push(Self::receive_cap(state, cap_table.get(idx), fds)?);
         }
         Ok(result)
     }
@@ -1806,11 +1851,14 @@ where
         Promise<Response<VatId>, Error>,
     ) {
         // Build the cap table.
+        let mut fds = FdHooks::new();
         let exports = ConnectionState::write_descriptors(
             connection_state,
             cap_table,
             get_call(&mut message).unwrap().get_params().unwrap(),
+            &mut fds,
         );
+        message.set_fds(fds);
 
         // Init the question table.  Do this after writing descriptors to avoid interference.
         let mut question = Question::<VatId>::new();
@@ -1857,11 +1905,14 @@ where
         flow: Rc<RefCell<Option<Box<dyn crate::FlowController>>>>,
     ) -> Promise<(), Error> {
         // Build the cap table.
+        let mut fds = FdHooks::new();
         let exports = ConnectionState::write_descriptors(
             connection_state,
             cap_table,
             get_call(&mut message).unwrap().get_params().unwrap(),
+            &mut fds,
         );
+        message.set_fds(fds);
 
         // Init the question table.  Do this after writing descriptors to avoid interference.
         let mut question = Question::<VatId>::new();
@@ -2542,6 +2593,7 @@ impl ResultsDone {
                                 Ok(hook)
                             }
                             (false, Ok(())) => {
+                                let mut fds = FdHooks::new();
                                 let exports = {
                                     let root: message::Builder = message.get_body()?.get_as()?;
                                     let message::Return(Ok(mut ret)) = root.which()? else {
@@ -2560,8 +2612,10 @@ impl ResultsDone {
                                         &connection_state,
                                         &cap_table,
                                         payload,
+                                        &mut fds,
                                     )
                                 };
+                                message.set_fds(fds);
 
                                 let (_promise, m) = message.send();
                                 connection_state.answer_has_sent_return(answer_id, exports);
@@ -2720,6 +2774,7 @@ where
 {
     connection_state: Rc<ConnectionState<VatId>>,
     import_id: ImportId,
+    fd: OnceCell<OwnedFd>,
 
     /// Number of times we've received this import from the peer.
     remote_ref_count: Cell<u32>,
@@ -2768,8 +2823,15 @@ where
         Rc::new(Self {
             connection_state: connection_state.clone(),
             import_id,
+            fd: OnceCell::new(),
             remote_ref_count: Cell::new(0),
         })
+    }
+
+    fn set_fd_if_missing(&self, fd: Option<OwnedFd>) {
+        if let Some(fd) = fd {
+            let _ = self.fd.set(fd);
+        }
     }
 
     fn add_remote_ref(&self) {
@@ -3063,7 +3125,11 @@ impl<VatId> Client<VatId> {
         }
     }
 
-    fn write_descriptor(&self, mut descriptor: cap_descriptor::Builder) -> Option<u32> {
+    fn write_descriptor(
+        &self,
+        mut descriptor: cap_descriptor::Builder,
+        fds: &mut FdHooks,
+    ) -> Option<u32> {
         match &self.variant {
             ClientVariant::Import(import_client) => {
                 descriptor.set_receiver_hosted(import_client.import_id);
@@ -3098,8 +3164,13 @@ impl<VatId> Client<VatId> {
                 } else {
                     panic!("promise was neither resolved nor unresolved");
                 };
-                ConnectionState::write_descriptor(&self.connection_state.clone(), cap, descriptor)
-                    .unwrap()
+                ConnectionState::write_descriptor(
+                    &self.connection_state.clone(),
+                    cap,
+                    descriptor,
+                    fds,
+                )
+                .unwrap()
             }
         }
     }
@@ -3226,6 +3297,16 @@ impl<VatId> ClientHook for Client<VatId> {
 
     fn when_resolved(&self) -> Promise<(), Error> {
         default_when_resolved_impl(self)
+    }
+
+    fn get_fd(&self) -> Option<BorrowedFd<'_>> {
+        match &self.variant {
+            ClientVariant::Import(import_client) => import_client.fd.get().map(|fd| fd.as_fd()),
+            ClientVariant::Pipeline(_pipeline_client) => None,
+            ClientVariant::Promise(promise_client) => {
+                promise_client.resolved.get().and_then(|cap| cap.get_fd())
+            }
+        }
     }
 }
 

--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -29,8 +29,8 @@ use capnp::private::capability::{
 };
 use capnp::Error;
 
-use futures::channel::oneshot;
-use futures::{future, Future, FutureExt, TryFutureExt};
+use futures_channel::oneshot;
+use futures_util::{future, Future, FutureExt, TryFutureExt};
 
 use std::cell::{Cell, RefCell};
 use std::cmp::Reverse;
@@ -2086,7 +2086,7 @@ where
     VatId: 'static,
 {
     variant: PipelineVariant<VatId>,
-    redirect_later: Option<RefCell<futures::future::Shared<Promise<Response<VatId>, Error>>>>,
+    redirect_later: Option<RefCell<futures_util::future::Shared<Promise<Response<VatId>, Error>>>>,
     connection_state: Rc<ConnectionState<VatId>>,
 
     #[allow(dead_code)]

--- a/capnp-rpc/src/sender_queue.rs
+++ b/capnp-rpc/src/sender_queue.rs
@@ -19,8 +19,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use futures::channel::oneshot;
-use futures::{FutureExt, TryFutureExt};
+use futures_channel::oneshot;
+use futures_util::{FutureExt as _, TryFutureExt as _};
 
 use std::cell::RefCell;
 use std::rc::{Rc, Weak};

--- a/capnp-rpc/src/split.rs
+++ b/capnp-rpc/src/split.rs
@@ -19,10 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use futures::{Future, FutureExt};
-
 use std::cell::RefCell;
+use std::future::Future;
 use std::rc::Rc;
+
+use futures_util::FutureExt as _;
 
 pub(crate) fn split<F, T1, T2, E>(
     f: F,

--- a/capnp-rpc/src/task_set.rs
+++ b/capnp-rpc/src/task_set.rs
@@ -18,9 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use futures::channel::{mpsc, oneshot};
-use futures::stream::FuturesUnordered;
-use futures::{Future, FutureExt, Stream};
+use futures_channel::{mpsc, oneshot};
+use futures_util::stream::FuturesUnordered;
+use futures_util::{FutureExt as _, Stream};
+use std::future::{self, Future};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -88,7 +89,7 @@ where
         // If the FuturesUnordered ever gets empty, its stream will terminate, which
         // is not what we want. So we make sure there is always at least one future in it.
         set.in_progress
-            .push(TaskInProgress::Task(Box::pin(::futures::future::pending())));
+            .push(TaskInProgress::Task(Box::pin(future::pending())));
 
         let handle = TaskSetHandle { sender };
 

--- a/capnp-rpc/src/twoparty.rs
+++ b/capnp-rpc/src/twoparty.rs
@@ -24,10 +24,12 @@
 
 use capnp::capability::Promise;
 use capnp::message::ReaderOptions;
-use futures::channel::oneshot;
-use futures::{AsyncRead, AsyncWrite, FutureExt, TryFutureExt};
+use futures_channel::oneshot;
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::{FutureExt as _, TryFutureExt as _};
 
 use std::cell::RefCell;
+use std::future;
 use std::rc::{Rc, Weak};
 
 pub type VatId = crate::rpc_twoparty_capnp::Side;
@@ -221,7 +223,7 @@ where
     // connection handle that we will return on connect()
     weak_connection_inner: Weak<RefCell<ConnectionInner<T>>>,
 
-    execution_driver: futures::future::Shared<Promise<(), ::capnp::Error>>,
+    execution_driver: futures_util::future::Shared<Promise<(), ::capnp::Error>>,
     side: crate::rpc_twoparty_capnp::Side,
 }
 
@@ -261,7 +263,7 @@ where
             (
                 Promise::from_future(write_queue.then(move |r| {
                     disconnect_promise
-                        .then(move |_| futures::future::ready(r))
+                        .then(move |_| future::ready(r))
                         .map_ok(|_| ())
                 }))
                 .shared(),
@@ -310,7 +312,7 @@ where
     fn accept(&mut self) -> Promise<Box<dyn crate::Connection<VatId>>, ::capnp::Error> {
         match self.connection.take() {
             Some(c) => Promise::ok(Box::new(c) as Box<dyn crate::Connection<VatId>>),
-            None => Promise::from_future(::futures::future::pending()),
+            None => Promise::from_future(future::pending()),
         }
     }
 

--- a/capnp-rpc/src/twoparty.rs
+++ b/capnp-rpc/src/twoparty.rs
@@ -23,10 +23,11 @@
 //! of a client-server connection.
 
 use capnp::capability::Promise;
+use capnp::fd::{FdHooks, OwnedFd};
 use capnp::message::ReaderOptions;
-use capnp_futures::io::AsyncFdRead;
+use capnp_futures::io::serialize::AsOutputSegments;
+use capnp_futures::io::{AsyncFdRead, FdReadBuf, FdWriteBuf};
 use futures_channel::oneshot;
-use futures_util::TryFutureExt as _;
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -35,11 +36,15 @@ pub type VatId = crate::rpc_twoparty_capnp::Side;
 
 struct IncomingMessage {
     message: ::capnp::message::Reader<capnp::serialize::OwnedSegments>,
+    fds: Vec<Option<OwnedFd>>,
 }
 
 impl IncomingMessage {
-    pub(crate) fn new(message: ::capnp::message::Reader<capnp::serialize::OwnedSegments>) -> Self {
-        Self { message }
+    pub(crate) fn new(
+        message: ::capnp::message::Reader<capnp::serialize::OwnedSegments>,
+        fds: Vec<Option<OwnedFd>>,
+    ) -> Self {
+        Self { message, fds }
     }
 }
 
@@ -47,12 +52,38 @@ impl crate::IncomingMessage for IncomingMessage {
     fn get_body(&self) -> ::capnp::Result<::capnp::any_pointer::Reader<'_>> {
         self.message.get_root()
     }
+
+    fn get_body_and_attached_fds(
+        &mut self,
+    ) -> (
+        capnp::Result<capnp::any_pointer::Reader<'_>>,
+        &mut FdReadBuf,
+    ) {
+        (self.message.get_root(), &mut self.fds)
+    }
+}
+
+struct MessageAndFds {
+    // TODO: This `Rc` is unnecessarily wasteful due to the return value of
+    // `OutgoingMessage::send()`, which nothing seems to use.
+    message: Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>,
+    fds: FdHooks,
+}
+
+impl AsOutputSegments for MessageAndFds {
+    fn as_output_segments(&self) -> capnp::OutputSegments<'_> {
+        self.message.as_output_segments()
+    }
+
+    fn as_fds(&self) -> &FdWriteBuf<'_> {
+        self.fds.as_fds()
+    }
 }
 
 struct OutgoingMessage {
     message: ::capnp::message::Builder<::capnp::message::HeapAllocator>,
-    sender:
-        ::capnp_futures::io::Sender<Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>>,
+    sender: ::capnp_futures::io::Sender<MessageAndFds>,
+    fds: FdHooks,
 }
 
 impl crate::OutgoingMessage for OutgoingMessage {
@@ -62,6 +93,10 @@ impl crate::OutgoingMessage for OutgoingMessage {
 
     fn get_body_as_reader(&self) -> ::capnp::Result<::capnp::any_pointer::Reader<'_>> {
         self.message.get_root_as_reader()
+    }
+
+    fn set_fds(&mut self, fds: FdHooks) {
+        self.fds = fds;
     }
 
     fn send(
@@ -74,12 +109,14 @@ impl crate::OutgoingMessage for OutgoingMessage {
         let Self {
             message,
             mut sender,
+            fds,
         } = tmp;
         let m = Rc::new(message);
-        (
-            Promise::from_future(sender.send(m.clone()).map_ok(|_| ())),
-            m,
-        )
+        let to_send = MessageAndFds {
+            message: m.clone(),
+            fds,
+        };
+        (Promise::from_future(sender.send_move(to_send)), m)
     }
 
     fn take(self: Box<Self>) -> ::capnp::message::Builder<::capnp::message::HeapAllocator> {
@@ -96,8 +133,8 @@ where
     T: AsyncFdRead + 'static,
 {
     input_stream: Rc<RefCell<Option<T>>>,
-    sender:
-        ::capnp_futures::io::Sender<Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>>,
+    sender: ::capnp_futures::io::Sender<MessageAndFds>,
+    max_fds_per_message: u8,
     side: crate::rpc_twoparty_capnp::Side,
     receive_options: ReaderOptions,
     on_disconnect_fulfiller: Option<oneshot::Sender<()>>,
@@ -131,9 +168,8 @@ where
 {
     fn new(
         input_stream: T,
-        sender: ::capnp_futures::io::Sender<
-            Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>,
-        >,
+        sender: ::capnp_futures::io::Sender<MessageAndFds>,
+        max_fds_per_message: u8,
         side: crate::rpc_twoparty_capnp::Side,
         receive_options: ReaderOptions,
         on_disconnect_fulfiller: oneshot::Sender<()>,
@@ -142,6 +178,7 @@ where
             inner: Rc::new(RefCell::new(ConnectionInner {
                 input_stream: Rc::new(RefCell::new(Some(input_stream))),
                 sender,
+                max_fds_per_message,
                 side,
                 receive_options,
                 on_disconnect_fulfiller: Some(on_disconnect_fulfiller),
@@ -169,6 +206,7 @@ where
         Box::new(OutgoingMessage {
             message,
             sender: self.inner.borrow().sender.clone(),
+            fds: FdHooks::new(),
         })
     }
 
@@ -182,13 +220,22 @@ where
         match maybe_input_stream {
             Some(mut s) => {
                 let receive_options = inner.receive_options;
+                let max_fds_per_message = inner.max_fds_per_message;
                 Promise::from_future(async move {
-                    let maybe_message =
-                        ::capnp_futures::io::serialize::try_read_message(&mut s, receive_options)
-                            .await?;
+                    let mut fd_buf = Vec::new();
+                    fd_buf.resize_with(max_fds_per_message.into(), Option::default);
+                    let maybe_message = ::capnp_futures::io::serialize::try_read_message_with_fds(
+                        &mut s,
+                        &mut fd_buf,
+                        receive_options,
+                    )
+                    .await?;
                     *return_it_here.borrow_mut() = Some(s);
-                    Ok(maybe_message.map(|message| {
-                        Box::new(IncomingMessage::new(message)) as Box<dyn crate::IncomingMessage>
+                    Ok(maybe_message.map(move |message| {
+                        fd_buf.truncate(message.fds);
+                        fd_buf.shrink_to_fit();
+                        Box::new(IncomingMessage::new(message.reader, fd_buf))
+                            as Box<dyn crate::IncomingMessage>
                     }))
                 })
             }
@@ -266,6 +313,19 @@ pub mod io {
         where
             U: AsyncFdWrite + 'static,
         {
+            Self::new_with_fds(input_stream, output_stream, 0, side, receive_options)
+        }
+
+        pub fn new_with_fds<U>(
+            input_stream: T,
+            output_stream: U,
+            max_fds_per_message: u8,
+            side: crate::rpc_twoparty_capnp::Side,
+            receive_options: ReaderOptions,
+        ) -> Self
+        where
+            U: AsyncFdWrite + 'static,
+        {
             let (fulfiller, disconnect_promise) = oneshot::channel();
             let disconnect_promise =
                 disconnect_promise.map_err(|_| ::capnp::Error::disconnected("disconnected".into()));
@@ -286,8 +346,14 @@ pub mod io {
                 )
             };
 
-            let connection =
-                Connection::new(input_stream, sender, side, receive_options, fulfiller);
+            let connection = Connection::new(
+                input_stream,
+                sender,
+                max_fds_per_message,
+                side,
+                receive_options,
+                fulfiller,
+            );
             let weak_inner = Rc::downgrade(&connection.inner);
             Self {
                 connection: Some(connection),

--- a/capnp-rpc/src/twoparty.rs
+++ b/capnp-rpc/src/twoparty.rs
@@ -24,13 +24,12 @@
 
 use capnp::capability::Promise;
 use capnp::message::ReaderOptions;
+use capnp_futures::io::AsyncFdRead;
 use futures_channel::oneshot;
-use futures_io::{AsyncRead, AsyncWrite};
-use futures_util::{FutureExt as _, TryFutureExt as _};
+use futures_util::TryFutureExt as _;
 
 use std::cell::RefCell;
-use std::future;
-use std::rc::{Rc, Weak};
+use std::rc::Rc;
 
 pub type VatId = crate::rpc_twoparty_capnp::Side;
 
@@ -52,7 +51,8 @@ impl crate::IncomingMessage for IncomingMessage {
 
 struct OutgoingMessage {
     message: ::capnp::message::Builder<::capnp::message::HeapAllocator>,
-    sender: ::capnp_futures::Sender<Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>>,
+    sender:
+        ::capnp_futures::io::Sender<Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>>,
 }
 
 impl crate::OutgoingMessage for OutgoingMessage {
@@ -93,10 +93,11 @@ impl crate::OutgoingMessage for OutgoingMessage {
 
 struct ConnectionInner<T>
 where
-    T: AsyncRead + 'static,
+    T: AsyncFdRead + 'static,
 {
     input_stream: Rc<RefCell<Option<T>>>,
-    sender: ::capnp_futures::Sender<Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>>,
+    sender:
+        ::capnp_futures::io::Sender<Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>>,
     side: crate::rpc_twoparty_capnp::Side,
     receive_options: ReaderOptions,
     on_disconnect_fulfiller: Option<oneshot::Sender<()>>,
@@ -105,14 +106,14 @@ where
 
 struct Connection<T>
 where
-    T: AsyncRead + 'static,
+    T: AsyncFdRead + 'static,
 {
     inner: Rc<RefCell<ConnectionInner<T>>>,
 }
 
 impl<T> Drop for ConnectionInner<T>
 where
-    T: AsyncRead,
+    T: AsyncFdRead,
 {
     fn drop(&mut self) {
         match self.on_disconnect_fulfiller.take() {
@@ -126,11 +127,11 @@ where
 
 impl<T> Connection<T>
 where
-    T: AsyncRead,
+    T: AsyncFdRead,
 {
     fn new(
         input_stream: T,
-        sender: ::capnp_futures::Sender<
+        sender: ::capnp_futures::io::Sender<
             Rc<::capnp::message::Builder<::capnp::message::HeapAllocator>>,
         >,
         side: crate::rpc_twoparty_capnp::Side,
@@ -152,7 +153,7 @@ where
 
 impl<T> crate::Connection<crate::rpc_twoparty_capnp::Side> for Connection<T>
 where
-    T: AsyncRead + Unpin,
+    T: AsyncFdRead,
 {
     fn get_peer_vat_id(&self) -> crate::rpc_twoparty_capnp::Side {
         self.inner.borrow().side
@@ -183,7 +184,7 @@ where
                 let receive_options = inner.receive_options;
                 Promise::from_future(async move {
                     let maybe_message =
-                        ::capnp_futures::serialize::try_read_message(&mut s, receive_options)
+                        ::capnp_futures::io::serialize::try_read_message(&mut s, receive_options)
                             .await?;
                     *return_it_here.borrow_mut() = Some(s);
                     Ok(maybe_message.map(|message| {
@@ -212,111 +213,204 @@ where
     }
 }
 
-/// A vat network with two parties, the client and the server.
-pub struct VatNetwork<T>
-where
-    T: AsyncRead + 'static + Unpin,
-{
-    // connection handle that we will return on accept()
-    connection: Option<Connection<T>>,
+pub mod io {
+    use std::{
+        cell::RefCell,
+        future,
+        rc::{Rc, Weak},
+    };
 
-    // connection handle that we will return on connect()
-    weak_connection_inner: Weak<RefCell<ConnectionInner<T>>>,
+    use capnp::{capability::Promise, message::ReaderOptions};
+    use capnp_futures::io::{AsyncFdRead, AsyncFdWrite};
+    use futures_channel::oneshot;
+    use futures_util::{FutureExt as _, TryFutureExt as _};
 
-    execution_driver: futures_util::future::Shared<Promise<(), ::capnp::Error>>,
-    side: crate::rpc_twoparty_capnp::Side,
-}
+    use crate::twoparty::{Connection, ConnectionInner, VatId};
 
-/// A two-party vat `VatNetwork` implementation.
-impl<T> VatNetwork<T>
-where
-    T: AsyncRead + Unpin,
-{
-    /// Creates a new two-party vat network that will receive data on `input_stream` and send data on
-    /// `output_stream`. (Typically, performance is best if these streams are buffered, possibly via
-    /// `futures::io::BufReader` and `futures::io::BufWriter`.)
-    ///
-    /// `side` indicates whether this is the client or the server side of the connection. This has no
-    /// effect on the data sent over the connection; it merely exists so that `RpcNetwork::bootstrap` knows
-    /// whether to return the local or the remote bootstrap capability. `VatId` parameters like this one
-    /// will make more sense once we have vat networks with more than two parties.
-    ///
-    /// The options in `receive_options` will be used when reading the messages that come in on `input_stream`.
-    pub fn new<U>(
-        input_stream: T,
-        output_stream: U,
-        side: crate::rpc_twoparty_capnp::Side,
-        receive_options: ReaderOptions,
-    ) -> Self
+    /// A two-party vat `VatNetwork` implementation.
+    pub struct VatNetwork<T>
     where
-        U: AsyncWrite + 'static + Unpin,
+        T: AsyncFdRead + 'static,
     {
-        let (fulfiller, disconnect_promise) = oneshot::channel();
-        let disconnect_promise =
-            disconnect_promise.map_err(|_| ::capnp::Error::disconnected("disconnected".into()));
+        // connection handle that we will return on accept()
+        connection: Option<Connection<T>>,
 
-        let (execution_driver, sender) = {
-            let (tx, write_queue) = ::capnp_futures::write_queue(output_stream);
+        // connection handle that we will return on connect()
+        weak_connection_inner: Weak<RefCell<ConnectionInner<T>>>,
 
-            // Don't use `.join()` here because we need to make sure to wait for `disconnect_promise` to
-            // resolve even if `write_queue` resolves to an error.
-            (
-                Promise::from_future(write_queue.then(move |r| {
-                    disconnect_promise
-                        .then(move |_| future::ready(r))
-                        .map_ok(|_| ())
-                }))
-                .shared(),
-                tx,
-            )
-        };
-
-        let connection = Connection::new(input_stream, sender, side, receive_options, fulfiller);
-        let weak_inner = Rc::downgrade(&connection.inner);
-        Self {
-            connection: Some(connection),
-            weak_connection_inner: weak_inner,
-            execution_driver,
-            side,
-        }
+        execution_driver: futures_util::future::Shared<Promise<(), ::capnp::Error>>,
+        side: crate::rpc_twoparty_capnp::Side,
     }
 
-    /// Set the number of bytes in the flow control window for each stream created
-    /// on this connection.
-    pub fn set_window_size(&mut self, window_size: usize) {
-        if let Some(ref mut conn) = self.connection {
-            conn.inner.borrow_mut().window_size_in_bytes = window_size;
-        }
-    }
-}
+    /// A two-party vat `VatNetwork` implementation.
+    impl<T> VatNetwork<T>
+    where
+        T: AsyncFdRead,
+    {
+        /// Creates a new two-party vat network that will receive data on `input_stream` and send data on
+        /// `output_stream`. (Typically, performance is best if these streams are buffered, possibly via
+        /// `futures::io::BufReader` and `futures::io::BufWriter`.)
+        ///
+        /// `side` indicates whether this is the client or the server side of the connection. This has no
+        /// effect on the data sent over the connection; it merely exists so that `RpcNetwork::bootstrap` knows
+        /// whether to return the local or the remote bootstrap capability. `VatId` parameters like this one
+        /// will make more sense once we have vat networks with more than two parties.
+        ///
+        /// The options in `receive_options` will be used when reading the messages that come in on `input_stream`.
+        pub fn new<U>(
+            input_stream: T,
+            output_stream: U,
+            side: crate::rpc_twoparty_capnp::Side,
+            receive_options: ReaderOptions,
+        ) -> Self
+        where
+            U: AsyncFdWrite + 'static,
+        {
+            let (fulfiller, disconnect_promise) = oneshot::channel();
+            let disconnect_promise =
+                disconnect_promise.map_err(|_| ::capnp::Error::disconnected("disconnected".into()));
 
-impl<T> crate::VatNetwork<VatId> for VatNetwork<T>
-where
-    T: AsyncRead + Unpin,
-{
-    fn connect(&mut self, host_id: VatId) -> Option<Box<dyn crate::Connection<VatId>>> {
-        if host_id == self.side {
-            None
-        } else {
-            match self.weak_connection_inner.upgrade() {
-                Some(connection_inner) => Some(Box::new(Connection {
-                    inner: connection_inner,
-                })),
-                None => {
-                    panic!("tried to reconnect a disconnected twoparty vat network.")
-                }
+            let (execution_driver, sender) = {
+                let (tx, write_queue) = ::capnp_futures::io::write_queue(output_stream);
+
+                // Don't use `.join()` here because we need to make sure to wait for `disconnect_promise` to
+                // resolve even if `write_queue` resolves to an error.
+                (
+                    Promise::from_future(write_queue.then(move |r| {
+                        disconnect_promise
+                            .then(move |_| future::ready(r))
+                            .map_ok(|_| ())
+                    }))
+                    .shared(),
+                    tx,
+                )
+            };
+
+            let connection =
+                Connection::new(input_stream, sender, side, receive_options, fulfiller);
+            let weak_inner = Rc::downgrade(&connection.inner);
+            Self {
+                connection: Some(connection),
+                weak_connection_inner: weak_inner,
+                execution_driver,
+                side,
+            }
+        }
+
+        /// Set the number of bytes in the flow control window for each stream created
+        /// on this connection.
+        pub fn set_window_size(&mut self, window_size: usize) {
+            if let Some(ref mut conn) = self.connection {
+                conn.inner.borrow_mut().window_size_in_bytes = window_size;
             }
         }
     }
 
-    fn accept(&mut self) -> Promise<Box<dyn crate::Connection<VatId>>, ::capnp::Error> {
-        match self.connection.take() {
-            Some(c) => Promise::ok(Box::new(c) as Box<dyn crate::Connection<VatId>>),
-            None => Promise::from_future(future::pending()),
+    impl<T> crate::VatNetwork<VatId> for VatNetwork<T>
+    where
+        T: AsyncFdRead,
+    {
+        fn connect(&mut self, host_id: VatId) -> Option<Box<dyn crate::Connection<VatId>>> {
+            if host_id == self.side {
+                None
+            } else {
+                match self.weak_connection_inner.upgrade() {
+                    Some(connection_inner) => Some(Box::new(Connection {
+                        inner: connection_inner,
+                    })),
+                    None => {
+                        panic!("tried to reconnect a disconnected twoparty vat network.")
+                    }
+                }
+            }
+        }
+
+        fn accept(&mut self) -> Promise<Box<dyn crate::Connection<VatId>>, ::capnp::Error> {
+            match self.connection.take() {
+                Some(c) => Promise::ok(Box::new(c) as Box<dyn crate::Connection<VatId>>),
+                None => Promise::from_future(future::pending()),
+            }
+        }
+
+        fn drive_until_shutdown(&mut self) -> Promise<(), ::capnp::Error> {
+            Promise::from_future(self.execution_driver.clone())
+        }
+    }
+}
+
+#[cfg(feature = "futures-io")]
+mod futures_io {
+    use capnp::{capability::Promise, message::ReaderOptions};
+    use capnp_futures::io::futures_io::Compat;
+    use futures_io::{AsyncRead, AsyncWrite};
+
+    use crate::twoparty::VatId;
+
+    /// A two-party vat `VatNetwork` implementation.
+    pub struct VatNetwork<T>
+    where
+        T: AsyncRead + Unpin + 'static,
+    {
+        inner: crate::twoparty::io::VatNetwork<Compat<T>>,
+    }
+
+    impl<T> VatNetwork<T>
+    where
+        T: AsyncRead + Unpin,
+    {
+        /// Creates a new two-party vat network that will receive data on `input_stream` and send data on
+        /// `output_stream`. (Typically, performance is best if these streams are buffered, possibly via
+        /// `futures::io::BufReader` and `futures::io::BufWriter`.)
+        ///
+        /// `side` indicates whether this is the client or the server side of the connection. This has no
+        /// effect on the data sent over the connection; it merely exists so that `RpcNetwork::bootstrap` knows
+        /// whether to return the local or the remote bootstrap capability. `VatId` parameters like this one
+        /// will make more sense once we have vat networks with more than two parties.
+        ///
+        /// The options in `receive_options` will be used when reading the messages that come in on `input_stream`.
+        pub fn new<U>(
+            input_stream: T,
+            output_stream: U,
+            side: crate::rpc_twoparty_capnp::Side,
+            receive_options: ReaderOptions,
+        ) -> Self
+        where
+            U: AsyncWrite + Unpin + 'static,
+        {
+            VatNetwork {
+                inner: crate::twoparty::io::VatNetwork::new(
+                    Compat::new(input_stream),
+                    Compat::new(output_stream),
+                    side,
+                    receive_options,
+                ),
+            }
+        }
+
+        /// Set the number of bytes in the flow control window for each stream created
+        /// on this connection.
+        pub fn set_window_size(&mut self, window_size: usize) {
+            self.inner.set_window_size(window_size)
         }
     }
 
-    fn drive_until_shutdown(&mut self) -> Promise<(), ::capnp::Error> {
-        Promise::from_future(self.execution_driver.clone())
+    impl<T> crate::VatNetwork<VatId> for VatNetwork<T>
+    where
+        T: AsyncRead + Unpin,
+    {
+        fn connect(&mut self, host_id: VatId) -> Option<Box<dyn crate::Connection<VatId>>> {
+            self.inner.connect(host_id)
+        }
+
+        fn accept(&mut self) -> Promise<Box<dyn crate::Connection<VatId>>, capnp::Error> {
+            self.inner.accept()
+        }
+
+        fn drive_until_shutdown(&mut self) -> Promise<(), capnp::Error> {
+            self.inner.drive_until_shutdown()
+        }
     }
 }
+
+#[cfg(feature = "futures-io")]
+pub use futures_io::VatNetwork;

--- a/capnp-rpc/test/Cargo.toml
+++ b/capnp-rpc/test/Cargo.toml
@@ -19,10 +19,11 @@ path = "../"
 
 [dependencies]
 capnp = { path = "../../capnp" }
+capnp-futures = { path = "../../capnp-futures", default-features = false, features = ["tokio-unix-fd-stream"] }
 futures-channel = { version = "0.3.0" }
 futures-util = { version = "0.3.0" }
 async-byte-channel = {path = "./../../async-byte-channel"}
-tokio = { version = "1.52.3", features = ["macros", "rt"] }
+tokio = { version = "1.52.3", features = ["macros", "rt", "io-util"] }
 
 [lints]
 workspace = true

--- a/capnp-rpc/test/Cargo.toml
+++ b/capnp-rpc/test/Cargo.toml
@@ -19,8 +19,10 @@ path = "../"
 
 [dependencies]
 capnp = { path = "../../capnp" }
-futures = "0.3.0"
+futures-channel = { version = "0.3.0" }
+futures-util = { version = "0.3.0" }
 async-byte-channel = {path = "./../../async-byte-channel"}
+tokio = { version = "1.52.3", features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/capnp-rpc/test/impls.rs
+++ b/capnp-rpc/test/impls.rs
@@ -28,10 +28,11 @@ use crate::test_capnp::{
 use capnp::capability::FromClientHook;
 use capnp::Error;
 
-use futures::channel::oneshot;
-use futures::TryFutureExt;
+use futures_channel::oneshot;
+use futures_util::TryFutureExt as _;
 
 use std::cell::{Cell, RefCell};
+use std::future;
 use std::rc::Rc;
 
 pub struct Bootstrap;
@@ -292,7 +293,7 @@ impl test_pipeline::Server for TestPipeline {
             .init_out_box()
             .set_cap(capnp_rpc::new_client::<test_extends::Client, _>(TestExtends).cast_to());
         results.set_pipeline()?;
-        ::futures::future::pending().await
+        future::pending().await
     }
 }
 
@@ -399,7 +400,7 @@ impl test_more_stuff::Server for TestMoreStuff {
         // Also attach `cap` to the result struct so we can make sure that the results are released.
         results.get().set_cap_copy(cap);
 
-        ::futures::future::pending().await
+        future::pending().await
     }
 
     async fn hold(
@@ -531,7 +532,7 @@ impl test_more_stuff::Server for TestMoreStuff {
             results.push(request.send().promise);
         }
 
-        ::futures::future::try_join_all(results).await?;
+        futures_util::future::try_join_all(results).await?;
         Ok(())
     }
 

--- a/capnp-rpc/test/impls.rs
+++ b/capnp-rpc/test/impls.rs
@@ -33,6 +33,8 @@ use futures_util::TryFutureExt as _;
 
 use std::cell::{Cell, RefCell};
 use std::future;
+#[cfg(unix)]
+use std::os::fd::{AsFd as _, BorrowedFd, OwnedFd};
 use std::rc::Rc;
 
 pub struct Bootstrap;
@@ -568,6 +570,23 @@ impl test_more_stuff::Server for TestMoreStuff {
             .set_cap(capnp_rpc::new_client(TestSelfImpl::new()));
         Ok(())
     }
+
+    #[cfg(unix)]
+    async fn pass_fd(
+        self: Rc<Self>,
+        _params: test_more_stuff::PassFdParams,
+        mut results: test_more_stuff::PassFdResults,
+    ) -> Result<(), Error> {
+        use tokio::io::AsyncWriteExt as _;
+
+        let (mut tx, rx) = tokio::net::unix::pipe::pipe()?;
+        let fd = rx.into_nonblocking_fd()?;
+        let fd_cap: test_interface::Client = capnp_rpc::new_client(TestFd { fd });
+        results.get().set_fd_cap(fd_cap);
+        results.set_pipeline()?;
+        tx.write_all(b"sup").await?;
+        Ok(())
+    }
 }
 
 struct Handle {
@@ -635,6 +654,18 @@ impl test_interface::Server for TestCapDestructor {
         _results: test_interface::BazResults,
     ) -> Result<(), Error> {
         Err(Error::unimplemented("bar is not implemented".to_string()))
+    }
+}
+
+#[cfg(unix)]
+struct TestFd {
+    fd: OwnedFd,
+}
+
+#[cfg(unix)]
+impl test_interface::Server for TestFd {
+    fn get_fd(&self) -> Option<BorrowedFd<'_>> {
+        Some(self.fd.as_fd())
     }
 }
 

--- a/capnp-rpc/test/reconnect_test.rs
+++ b/capnp-rpc/test/reconnect_test.rs
@@ -283,7 +283,7 @@ impl test_capnp::bootstrap::Server for Bootstrap {
 fn auto_reconnect_rpc_call() {
     let (client_writer, server_reader) = async_byte_channel::channel();
     let (server_writer, client_reader) = async_byte_channel::channel();
-    let client_network = Box::new(twoparty::VatNetwork::new(
+    let client_network = Box::new(twoparty::io::VatNetwork::new(
         client_reader,
         client_writer,
         rpc_twoparty_capnp::Side::Client,
@@ -292,7 +292,7 @@ fn auto_reconnect_rpc_call() {
 
     let mut client_rpc_system = RpcSystem::new(client_network, None);
 
-    let server_network = Box::new(twoparty::VatNetwork::new(
+    let server_network = Box::new(twoparty::io::VatNetwork::new(
         server_reader,
         server_writer,
         rpc_twoparty_capnp::Side::Server,

--- a/capnp-rpc/test/reconnect_test.rs
+++ b/capnp-rpc/test/reconnect_test.rs
@@ -8,11 +8,10 @@ use capnp_rpc::{
     auto_reconnect, lazy_auto_reconnect, new_client, new_future_client, rpc_twoparty_capnp,
     twoparty, RpcSystem,
 };
-use futures::channel::oneshot;
-use futures::executor::LocalPool;
-use futures::future::Shared;
-use futures::task::LocalSpawnExt;
-use futures::FutureExt;
+use futures_channel::oneshot;
+use futures_util::future::Shared;
+use futures_util::{FutureExt as _, TryFutureExt};
+use tokio::task;
 
 use crate::spawn;
 use crate::test_capnp::{self, test_interface};
@@ -87,11 +86,11 @@ impl test_interface::Server for TestInterfaceImpl {
     }
 }
 
-fn run_until<F>(pool: &mut LocalPool, fut: F) -> Result<String, Error>
+async fn run<F>(fut: F) -> Result<String, Error>
 where
     F: Future<Output = capnp::Result<Response<test_interface::foo_results::Owned>>>,
 {
-    match pool.run_until(fut) {
+    match fut.await {
         Ok(resp) => Ok(resp.get()?.get_x()?.to_string()?),
         Err(err) => Err(err),
     }
@@ -119,22 +118,21 @@ fn test_promise(
     req.send().promise
 }
 
-fn test(
-    pool: &mut LocalPool,
-    client: &test_interface::Client,
-    i: u32,
-    j: bool,
-) -> Result<String, Error> {
-    let fut = test_promise(client, i, j);
-    run_until(pool, fut)
+async fn test(client: &test_interface::Client, i: u32, j: bool) -> Result<String, Error> {
+    run(test_promise(client, i, j)).await
 }
 
-fn do_autoconnect_test<F>(pool: &mut LocalPool, wrap_client: F) -> capnp::Result<()>
+fn spawn_local_with_handle<F>(fut: F) -> impl Future<Output = F::Output>
+where
+    F: Future + 'static,
+{
+    task::spawn_local(fut).unwrap_or_else(|err| std::panic::resume_unwind(err.into_panic()))
+}
+
+async fn do_autoconnect_test<F>(wrap_client: F) -> capnp::Result<()>
 where
     F: Fn(test_interface::Client) -> test_interface::Client,
 {
-    let spawner = pool.spawner();
-
     let (req3, fulfiller, promise1, promise2, promise4) = {
         let connect_count = Rc::new(RefCell::new(0));
         let current_server = Rc::new(RefCell::new(TestInterfaceImpl::new(0)));
@@ -152,18 +150,18 @@ where
         })?;
         let client = wrap_client(c);
 
-        assert_eq!(test(pool, &client, 123, true).unwrap(), "123 true 0");
+        assert_eq!(test(&client, 123, true).await.unwrap(), "123 true 0");
 
         current_server
             .borrow()
             .set_error(capnp::Error::disconnected("test1 disconnect".into()));
         assert_err!(
-            test(pool, &client, 456, true).unwrap_err(),
+            test(&client, 456, true).await.unwrap_err(),
             Error::disconnected("test1 disconnect".into())
         );
 
-        assert_eq!(test(pool, &client, 789, false).unwrap(), "789 false 1");
-        assert_eq!(test(pool, &client, 21, true).unwrap(), "21 true 1");
+        assert_eq!(test(&client, 789, false).await.unwrap(), "789 false 1");
+        assert_eq!(test(&client, 21, true).await.unwrap(), "21 true 1");
 
         {
             // We cause two disconnect promises to be thrown concurrently. This should only cause the
@@ -171,23 +169,24 @@ where
             let fulfiller = current_server.borrow().block();
             let promise1 = test_promise(&client, 32, false);
             let promise2 = test_promise(&client, 43, true);
-            let promise1 = Promise::from_future(spawner.spawn_local_with_handle(promise1).unwrap());
-            let promise2 = Promise::from_future(spawner.spawn_local_with_handle(promise2).unwrap());
-            pool.run_until_stalled();
+            let promise1 = Promise::from_future(spawn_local_with_handle(promise1));
+            let promise2 = Promise::from_future(spawn_local_with_handle(promise2));
+            // TODO: This isn’t very elegant.
+            task::yield_now().await;
             fulfiller
                 .send(Err(capnp::Error::disconnected("test2 disconnect".into())))
                 .unwrap();
             assert_err!(
-                run_until(pool, promise1).expect_err("disconnect error"),
+                run(promise1).await.expect_err("disconnect error"),
                 capnp::Error::disconnected("test2 disconnect".into())
             );
             assert_err!(
-                run_until(pool, promise2).expect_err("disconnect error"),
+                run(promise2).await.expect_err("disconnect error"),
                 capnp::Error::disconnected("test2 disconnect".into())
             );
         }
 
-        assert_eq!(test(pool, &client, 43, false).unwrap(), "43 false 2");
+        assert_eq!(test(&client, 43, false).await.unwrap(), "43 false 2");
 
         // Start a couple calls that will block at the server end, plus an unsent request.
         let fulfiller = current_server.borrow().block();
@@ -197,9 +196,10 @@ where
         let mut req3 = client.foo_request();
         req3.get().set_i(5656);
         req3.get().set_j(true);
-        let promise1 = Promise::from_future(spawner.spawn_local_with_handle(promise1).unwrap());
-        let promise2 = Promise::from_future(spawner.spawn_local_with_handle(promise2).unwrap());
-        pool.run_until_stalled();
+        let promise1 = Promise::from_future(spawn_local_with_handle(promise1));
+        let promise2 = Promise::from_future(spawn_local_with_handle(promise2));
+        // TODO: This isn’t very elegant.
+        task::yield_now().await;
 
         // Now force a reconnect.
         current_server
@@ -217,14 +217,14 @@ where
 
     // Everything we initiated should still finish.
     assert_err!(
-        run_until(pool, promise4).expect_err("disconnect error"),
+        run(promise4).await.expect_err("disconnect error"),
         capnp::Error::disconnected("test3 disconnect".into())
     );
 
     // Send the request which we created before the disconnect. There are two behaviors we accept
     // as correct here: it may throw the disconnect exception, or it may automatically redirect to
     // the newly-reconnected destination.
-    match run_until(pool, req3.send().promise) {
+    match run(req3.send().promise).await {
         Ok(resp) => {
             assert_eq!(resp, "5656 true 3");
         }
@@ -236,18 +236,16 @@ where
     //KJ_EXPECT(!promise1.poll(ws));
     //KJ_EXPECT(!promise2.poll(ws));
     fulfiller.send(Ok(())).unwrap();
-    assert_eq!(run_until(pool, promise1).unwrap(), "1212 true 2");
-    assert_eq!(run_until(pool, promise2).unwrap(), "3434 false 2");
+    assert_eq!(run(promise1).await.unwrap(), "1212 true 2");
+    assert_eq!(run(promise2).await.unwrap(), "3434 false 2");
 
     Ok(())
 }
 
 /// autoReconnect() direct call (exercises newCall() / RequestHook)
-#[test]
-fn auto_reconnect_direct_call() {
-    let mut pool = LocalPool::new();
-
-    do_autoconnect_test(&mut pool, |c| c).unwrap();
+#[tokio::test(flavor = "local")]
+async fn auto_reconnect_direct_call() {
+    do_autoconnect_test(|c| c).await.unwrap();
 }
 
 #[derive(Clone)]
@@ -279,8 +277,8 @@ impl test_capnp::bootstrap::Server for Bootstrap {
 }
 
 /// autoReconnect() through RPC (exercises call() / CallContextHook)
-#[test]
-fn auto_reconnect_rpc_call() {
+#[tokio::test(flavor = "local")]
+async fn auto_reconnect_rpc_call() {
     let (client_writer, server_reader) = async_byte_channel::channel();
     let (server_writer, client_reader) = async_byte_channel::channel();
     let client_network = Box::new(twoparty::io::VatNetwork::new(
@@ -307,12 +305,10 @@ fn auto_reconnect_rpc_call() {
     let disconnector: capnp_rpc::Disconnector<capnp_rpc::rpc_twoparty_capnp::Side> =
         client_rpc_system.get_disconnector();
 
-    let mut pool = LocalPool::new();
-    let mut spawner = pool.spawner();
-    spawn(&mut spawner, client_rpc_system);
-    spawn(&mut spawner, server_rpc_system);
+    spawn(client_rpc_system);
+    spawn(server_rpc_system);
 
-    do_autoconnect_test(&mut pool, |c| {
+    do_autoconnect_test(|c| {
         b.set_interface(c);
         let req = client.test_interface_request();
         new_future_client(req.send().promise.map(|resp| match resp {
@@ -320,15 +316,14 @@ fn auto_reconnect_rpc_call() {
             Err(err) => Err(err),
         }))
     })
+    .await
     .unwrap();
-    pool.run_until(disconnector).unwrap();
+    disconnector.await.unwrap();
 }
 
 /// lazyAutoReconnect() initializes lazily
-#[test]
-fn lazy_auto_reconnect_test() {
-    let mut pool = LocalPool::new();
-
+#[tokio::test(flavor = "local")]
+async fn lazy_auto_reconnect_test() {
     let connect_count = Rc::new(RefCell::new(0));
     let current_server = Rc::new(RefCell::new(TestInterfaceImpl::new(0)));
 
@@ -347,7 +342,7 @@ fn lazy_auto_reconnect_test() {
     .unwrap();
 
     assert_eq!(*connect_count.borrow(), 1);
-    assert_eq!(test(&mut pool, &client, 123, true).unwrap(), "123 true 0");
+    assert_eq!(test(&client, 123, true).await.unwrap(), "123 true 0");
     assert_eq!(*connect_count.borrow(), 1);
 
     let c_server = current_server.clone();
@@ -364,21 +359,21 @@ fn lazy_auto_reconnect_test() {
     });
 
     assert_eq!(*connect_count.borrow(), 1);
-    assert_eq!(test(&mut pool, &client, 123, true).unwrap(), "123 true 1");
+    assert_eq!(test(&client, 123, true).await.unwrap(), "123 true 1");
     assert_eq!(*connect_count.borrow(), 2);
-    assert_eq!(test(&mut pool, &client, 234, false).unwrap(), "234 false 1");
+    assert_eq!(test(&client, 234, false).await.unwrap(), "234 false 1");
     assert_eq!(*connect_count.borrow(), 2);
 
     current_server
         .borrow()
         .set_error(Error::disconnected("test1 disconnect".into()));
     assert_err!(
-        test(&mut pool, &client, 345, true).unwrap_err(),
+        test(&client, 345, true).await.unwrap_err(),
         Error::disconnected("test1 disconnect".into())
     );
 
     // lazyAutoReconnect is only lazy on the first request, not on reconnects.
     assert_eq!(*connect_count.borrow(), 3);
-    assert_eq!(test(&mut pool, &client, 456, false).unwrap(), "456 false 2");
+    assert_eq!(test(&client, 456, false).await.unwrap(), "456 false 2");
     assert_eq!(*connect_count.borrow(), 3);
 }

--- a/capnp-rpc/test/test.capnp
+++ b/capnp-rpc/test/test.capnp
@@ -195,6 +195,8 @@ interface TestMoreStuff extends(TestCallOrder) {
   # Like getTestStreaming(), but the returned cap's doStreamI() waits before
   # recording its argument, so a following non-streaming call can race ahead
   # of pending streaming calls if the runtime fails to order them.
+
+  passFd @17 () -> (fdCap :TestInterface);
 }
 
 interface TestCapabilityServerSet {

--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -22,12 +22,14 @@
 #![cfg(test)]
 #![allow(clippy::bool_assert_comparison)]
 
+use std::future::Future;
+
 use capnp::capability::{FromClientHook, Promise};
 use capnp::Error;
 use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
 
-use futures::channel::oneshot;
-use futures::{Future, FutureExt, TryFutureExt};
+use futures_channel::oneshot;
+use futures_util::{FutureExt as _, TryFutureExt as _};
 
 capnp::generated_code!(pub mod test_capnp);
 
@@ -35,12 +37,12 @@ pub mod impls;
 pub mod reconnect_test;
 pub mod test_util;
 
-fn canceled_to_error(_e: futures::channel::oneshot::Canceled) -> Error {
+fn canceled_to_error(_e: oneshot::Canceled) -> Error {
     Error::failed("oneshot was canceled".to_string())
 }
 
-#[test]
-fn drop_rpc_system() {
+#[tokio::test(flavor = "local")]
+async fn drop_rpc_system() {
     let (writer, reader) = async_byte_channel::channel();
 
     let network = Box::new(twoparty::io::VatNetwork::new(
@@ -81,67 +83,55 @@ fn disconnector_setup() -> (
     (client_rpc_system, server_rpc_system)
 }
 
-fn spawn<F>(spawner: &mut futures::executor::LocalSpawner, task: F)
+fn spawn<F>(task: F)
 where
     F: Future<Output = Result<(), Error>> + 'static,
 {
-    use futures::task::LocalSpawnExt;
-    spawner
-        .spawn_local(task.map(|r| {
-            if let Err(e) = r {
-                panic!("Error on spawned task: {:?}", e);
-            }
-        }))
-        .unwrap();
+    tokio::task::spawn_local(async {
+        if let Err(e) = task.await {
+            panic!("Error on spawned task: {:?}", e);
+        }
+    });
 }
 
-#[test]
-fn drop_import_client_after_disconnect() {
-    let mut pool = futures::executor::LocalPool::new();
-    let mut spawner = pool.spawner();
+#[tokio::test(flavor = "local")]
+async fn drop_import_client_after_disconnect() {
     let (mut client_rpc_system, server_rpc_system) = disconnector_setup();
 
     let client: test_capnp::bootstrap::Client =
         client_rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
 
-    spawn(&mut spawner, client_rpc_system);
+    spawn(client_rpc_system);
 
     let (tx, rx) = oneshot::channel::<()>();
     let rx = rx.map_err(crate::canceled_to_error);
-    spawn(
-        &mut spawner,
-        futures::future::try_join(rx, server_rpc_system).map(|_| Ok(())),
-    );
+    spawn(futures_util::future::try_join(rx, server_rpc_system).map(|_| Ok(())));
 
-    pool.run_until(async move {
-        client
-            .test_interface_request()
-            .send()
-            .promise
-            .await
-            .unwrap();
-        drop(tx);
+    client
+        .test_interface_request()
+        .send()
+        .promise
+        .await
+        .unwrap();
+    drop(tx);
 
-        match client.test_interface_request().send().promise.await {
-            Err(ref e) if e.kind == ::capnp::ErrorKind::Disconnected => (),
-            Err(e) => panic!("wrong kind of error: {:?}", e),
-            _ => panic!("Should have gotten a 'disconnected' error."),
-        }
+    match client.test_interface_request().send().promise.await {
+        Err(ref e) if e.kind == ::capnp::ErrorKind::Disconnected => (),
+        Err(e) => panic!("wrong kind of error: {:?}", e),
+        _ => panic!("Should have gotten a 'disconnected' error."),
+    }
 
-        // At one point, attempting to call again would cause a panic.
-        match client.test_interface_request().send().promise.await {
-            Err(ref e) if e.kind == ::capnp::ErrorKind::Disconnected => (),
-            _ => panic!("Should have gotten a 'disconnected' error."),
-        }
+    // At one point, attempting to call again would cause a panic.
+    match client.test_interface_request().send().promise.await {
+        Err(ref e) if e.kind == ::capnp::ErrorKind::Disconnected => (),
+        _ => panic!("Should have gotten a 'disconnected' error."),
+    }
 
-        drop(client);
-    });
+    drop(client);
 }
 
-#[test]
-fn disconnector_disconnects() {
-    let mut pool = futures::executor::LocalPool::new();
-    let mut spawner = pool.spawner();
+#[tokio::test(flavor = "local")]
+async fn disconnector_disconnects() {
     let (mut client_rpc_system, server_rpc_system) = disconnector_setup();
 
     let client: test_capnp::bootstrap::Client =
@@ -149,45 +139,39 @@ fn disconnector_disconnects() {
     let disconnector: capnp_rpc::Disconnector<capnp_rpc::rpc_twoparty_capnp::Side> =
         client_rpc_system.get_disconnector();
 
-    spawn(&mut spawner, client_rpc_system);
+    spawn(client_rpc_system);
 
     let (tx, rx) = oneshot::channel::<()>();
 
     //send on tx when server_rpc_system exits
-    spawn(
-        &mut spawner,
-        server_rpc_system.map(|x| {
-            tx.send(()).expect("sending on tx");
-            x
-        }),
-    );
-
-    pool.run_until(async move {
-        //make sure we can make an RPC system call
-        client
-            .test_interface_request()
-            .send()
-            .promise
-            .await
-            .unwrap();
-
-        //disconnect from the server; comment this next line out to see the test fail
-        disconnector.await.unwrap();
-
-        rx.await.expect("rpc system should exit");
-
-        //make sure we can't use client any more (because the server is disconnected)
-        match client.test_interface_request().send().promise.await {
-            Err(ref e) if e.kind == ::capnp::ErrorKind::Disconnected => (),
-            _ => panic!("Should have gotten a 'disconnected' error."),
-        }
+    spawn(async {
+        let x = server_rpc_system.await;
+        tx.send(()).expect("sending on tx");
+        x
     });
+
+    //make sure we can make an RPC system call
+    client
+        .test_interface_request()
+        .send()
+        .promise
+        .await
+        .unwrap();
+
+    //disconnect from the server; comment this next line out to see the test fail
+    disconnector.await.unwrap();
+
+    rx.await.expect("rpc system should exit");
+
+    //make sure we can't use client any more (because the server is disconnected)
+    match client.test_interface_request().send().promise.await {
+        Err(ref e) if e.kind == ::capnp::ErrorKind::Disconnected => (),
+        _ => panic!("Should have gotten a 'disconnected' error."),
+    }
 }
 
-#[test]
-fn disconnector_disconnects_2() {
-    let mut pool = futures::executor::LocalPool::new();
-    let mut spawner = pool.spawner();
+#[tokio::test(flavor = "local")]
+async fn disconnector_disconnects_2() {
     let (mut client_rpc_system, server_rpc_system) = disconnector_setup();
 
     // Grab the disconnector before calling bootstrap().
@@ -198,52 +182,45 @@ fn disconnector_disconnects_2() {
     let client: test_capnp::bootstrap::Client =
         client_rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
 
-    spawn(&mut spawner, client_rpc_system);
+    spawn(client_rpc_system);
 
     let (tx, rx) = oneshot::channel::<()>();
 
     //send on tx when server_rpc_system exits
-    spawn(
-        &mut spawner,
-        server_rpc_system.map(|x| {
-            tx.send(()).expect("sending on tx");
-            x
-        }),
-    );
-
-    pool.run_until(async move {
-        //make sure we can make an RPC system call
-        client
-            .test_interface_request()
-            .send()
-            .promise
-            .await
-            .unwrap();
-
-        //disconnect from the server; comment this next line out to see the test fail
-        disconnector.await.unwrap();
-
-        rx.await.expect("rpc system should exit");
-
-        //make sure we can't use client any more (because the server is disconnected)
-        match client.test_interface_request().send().promise.await {
-            Err(ref e) if e.kind == ::capnp::ErrorKind::Disconnected => (),
-            _ => panic!("Should have gotten a 'disconnected' error."),
-        }
+    spawn(async {
+        let x = server_rpc_system.await;
+        tx.send(()).expect("sending on tx");
+        x
     });
+
+    //make sure we can make an RPC system call
+    client
+        .test_interface_request()
+        .send()
+        .promise
+        .await
+        .unwrap();
+
+    //disconnect from the server; comment this next line out to see the test fail
+    disconnector.await.unwrap();
+
+    rx.await.expect("rpc system should exit");
+
+    //make sure we can't use client any more (because the server is disconnected)
+    match client.test_interface_request().send().promise.await {
+        Err(ref e) if e.kind == ::capnp::ErrorKind::Disconnected => (),
+        _ => panic!("Should have gotten a 'disconnected' error."),
+    }
 }
 
 /// Sets up a test_capnp::bootstrap capability on the remote side of a
-/// two-party RPC connection and provides a local reference to it, along
-/// with a handle that supports spawning of tasks.
-fn rpc_top_level<F, G>(main: F)
+/// two-party RPC connection and provides a local reference to it.
+async fn rpc_top_level<F, G>(main: F)
 where
-    F: FnOnce(futures::executor::LocalSpawner, test_capnp::bootstrap::Client) -> G,
+    F: FnOnce(test_capnp::bootstrap::Client) -> G,
     F: Send + 'static,
     G: Future<Output = Result<(), Error>> + 'static,
 {
-    let mut pool = futures::executor::LocalPool::new();
-    let mut spawner = pool.spawner();
     let (client_writer, server_reader) = async_byte_channel::channel();
     let (server_writer, client_reader) = async_byte_channel::channel();
 
@@ -257,7 +234,10 @@ where
 
         let bootstrap: test_capnp::bootstrap::Client = capnp_rpc::new_client(impls::Bootstrap);
         let rpc_system = RpcSystem::new(network, Some(bootstrap.client));
-        futures::executor::block_on(rpc_system).unwrap();
+        tokio::runtime::LocalRuntime::new()
+            .unwrap()
+            .block_on(rpc_system)
+            .unwrap();
     });
 
     let network = Box::new(twoparty::io::VatNetwork::new(
@@ -272,48 +252,42 @@ where
         rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
 
     let disconnector = rpc_system.get_disconnector();
-    spawn(&mut spawner, rpc_system);
-    pool.run_until(main(spawner, client)).unwrap();
-
-    // Need to explicitly disconnect. Otherwise the spawned task will stick around.
-    // If we were using tokio::task::LocalSet, this would not be necessary, as dropping
-    // the LocalSet would drop all tasks spawned to it.
-    pool.run_until(disconnector).unwrap();
+    tokio::task::spawn_local(rpc_system);
+    main(client).await.unwrap();
+    disconnector.await.unwrap();
     join_handle.join().unwrap();
 }
 
 /// Like rpc_top_level(), but sets up the bootstrap::Client as a local capability,
 /// i.e. not on the other side of an RPC connection.
-fn local_top_level<F, G>(main: F)
+async fn local_top_level<F, G>(main: F)
 where
-    F: FnOnce(futures::executor::LocalSpawner, test_capnp::bootstrap::Client) -> G,
+    F: FnOnce(test_capnp::bootstrap::Client) -> G,
     G: Future<Output = Result<(), Error>> + 'static,
 {
-    let mut pool = futures::executor::LocalPool::new();
-    let spawner = pool.spawner();
     let client: test_capnp::bootstrap::Client = capnp_rpc::new_client(impls::Bootstrap);
-    pool.run_until(main(spawner, client)).unwrap();
+    main(client).await.unwrap();
 }
 
 /// Runs both rpc_top_level() and local_top_level() on the function `main`.
-fn rpc_and_local_top_level<F, G>(main: F)
+async fn rpc_and_local_top_level<F, G>(main: F)
 where
-    F: FnOnce(futures::executor::LocalSpawner, test_capnp::bootstrap::Client) -> G,
+    F: FnOnce(test_capnp::bootstrap::Client) -> G,
     F: Send + 'static + Clone,
     G: Future<Output = Result<(), Error>> + 'static,
 {
-    rpc_top_level(main.clone());
-    local_top_level(main);
+    rpc_top_level(main.clone()).await;
+    local_top_level(main).await;
 }
 
-#[test]
-fn do_nothing() {
-    rpc_top_level(|_spawner, _client| async { Ok(()) });
+#[tokio::test(flavor = "local")]
+async fn do_nothing() {
+    rpc_top_level(|_client| async { Ok(()) }).await;
 }
 
-#[test]
-fn basic_rpc_calls() {
-    rpc_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn basic_rpc_calls() {
+    rpc_top_level(|client| async move {
         let response = client.test_interface_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
 
@@ -345,12 +319,13 @@ fn basic_rpc_calls() {
         promise2.promise.await?;
         promise3.await?;
         Ok(())
-    });
+    })
+    .await;
 }
 
-#[test]
-fn basic_pipelining() {
-    rpc_and_local_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn basic_pipelining() {
+    rpc_and_local_top_level(|client| async move {
         let response = client.test_pipeline_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
 
@@ -396,12 +371,13 @@ fn basic_pipelining() {
         crate::test_util::CheckTestMessage::check_test_message(response2.get()?);
         assert_eq!(chained_call_count.get(), 1);
         Ok(())
-    });
+    })
+    .await;
 }
 
-#[test]
-fn pipelining_return_null() {
-    rpc_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn pipelining_return_null() {
+    rpc_top_level(|client| async move {
         let response = client.test_pipeline_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
 
@@ -423,11 +399,12 @@ fn pipelining_return_null() {
                 "Should have gotten null capability error.".to_string(),
             )),
         }
-    });
+    })
+    .await;
 }
 
-#[test]
-fn null_capability() {
+#[tokio::test(flavor = "local")]
+async fn null_capability() {
     let mut message = ::capnp::message::Builder::new_default();
     let root: crate::test_capnp::test_all_types::Builder = message.get_root().unwrap();
 
@@ -464,24 +441,21 @@ impl Future for WaitNTicks {
     }
 }
 
-#[test]
-fn set_pipeline() {
+#[tokio::test(flavor = "local")]
+async fn set_pipeline() {
     use std::cell::Cell;
     use std::rc::Rc;
-    rpc_and_local_top_level(|mut spawner, client| async move {
+    rpc_and_local_top_level(|client| async move {
         let response = client.test_pipeline_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
         let capnp::capability::RemotePromise { promise, pipeline } =
             client.get_cap_pipeline_only_request().send();
         let promise_completed = Rc::new(Cell::new(false));
         let promise_completed2 = promise_completed.clone();
-        spawn(
-            &mut spawner,
-            promise.map(move |_| {
-                promise_completed2.set(true);
-                Ok(())
-            }),
-        );
+        spawn(promise.map(move |_| {
+            promise_completed2.set(true);
+            Ok(())
+        }));
 
         let mut pipeline_request = pipeline.get_out_box().get_cap().foo_request();
         pipeline_request.get().set_i(321);
@@ -506,12 +480,13 @@ fn set_pipeline() {
         // The original promise never completed.
         assert!(!promise_completed.get());
         Ok(())
-    });
+    })
+    .await;
 }
 
-#[test]
-fn release_simple() {
-    rpc_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn release_simple() {
+    rpc_top_level(|client| async move {
         let response = client.test_more_stuff_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
 
@@ -555,12 +530,13 @@ fn release_simple() {
         }
 
         Ok(())
-    });
+    })
+    .await;
 }
 
 /*
-#[test]
-fn release_on_cancel() {
+#[tokio::test(flavor = "local")]
+async fn release_on_cancel() {
     rpc_top_level(|mut exec, client| {
         let response = exec.run_until(client.test_more_stuff_request().send().promise)?;
         let client = response.get()?.get_cap()?;
@@ -588,13 +564,13 @@ fn release_on_cancel() {
             return Err(Error::failed(format!("handle count: expected 0, but got {}", handle_count)))
         }
         Ok(())
-    });
+    }).await;
 }
 */
 
-#[test]
-fn promise_resolve() {
-    rpc_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn promise_resolve() {
+    rpc_top_level(|client| async move {
         let response = client.test_more_stuff_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
 
@@ -629,30 +605,28 @@ fn promise_resolve() {
             return Err(Error::failed("expected s to equal 'bar'".to_string()));
         }
         Ok(())
-    });
+    })
+    .await;
 }
 
-#[test]
-fn retain_and_release() {
+#[tokio::test(flavor = "local")]
+async fn retain_and_release() {
     use std::cell::Cell;
     use std::rc::Rc;
 
-    rpc_top_level(|mut spawner, client| async move {
+    rpc_top_level(|client| async move {
         let (fulfiller, promise) = oneshot::channel::<()>();
         let destroyed = Rc::new(Cell::new(false));
 
         let (destroyed_done_sender, destroyed_done_receiver) = oneshot::channel::<()>();
 
         let destroyed1 = destroyed.clone();
-        spawn(
-            &mut spawner,
-            promise.map_err(canceled_to_error).map(move |r| {
-                r?;
-                destroyed1.set(true);
-                let _ = destroyed_done_sender.send(());
-                Ok(())
-            }),
-        );
+        spawn(promise.map_err(canceled_to_error).map(move |r| {
+            r?;
+            destroyed1.set(true);
+            let _ = destroyed_done_sender.send(());
+            Ok(())
+        }));
 
         {
             let response = client.test_more_stuff_request().send().promise.await?;
@@ -738,15 +712,16 @@ fn retain_and_release() {
         }
 
         Ok(())
-    });
+    })
+    .await;
 }
 
-#[test]
-fn cancel_releases_params() {
+#[tokio::test(flavor = "local")]
+async fn cancel_releases_params() {
     use std::cell::Cell;
     use std::rc::Rc;
 
-    rpc_top_level(|mut spawner, client| async move {
+    rpc_top_level(|client| async move {
         let response = client.test_more_stuff_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
 
@@ -756,15 +731,12 @@ fn cancel_releases_params() {
         let (destroyed_done_sender, destroyed_done_receiver) = oneshot::channel::<()>();
 
         let destroyed1 = destroyed.clone();
-        spawn(
-            &mut spawner,
-            promise.map_err(canceled_to_error).map(move |r| {
-                r?;
-                destroyed1.set(true);
-                let _ = destroyed_done_sender.send(());
-                Ok(())
-            }),
-        );
+        spawn(promise.map_err(canceled_to_error).map(move |r| {
+            r?;
+            destroyed1.set(true);
+            let _ = destroyed_done_sender.send(());
+            Ok(())
+        }));
 
         {
             let mut request = client.never_return_request();
@@ -800,12 +772,13 @@ fn cancel_releases_params() {
         }
 
         Ok(())
-    });
+    })
+    .await;
 }
 
-#[test]
-fn dont_hold() {
-    rpc_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn dont_hold() {
+    rpc_top_level(|client| async move {
         let response = client.test_more_stuff_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
 
@@ -828,7 +801,8 @@ fn dont_hold() {
                 })
             })
             .await
-    });
+    })
+    .await;
 }
 
 fn get_call_sequence(
@@ -842,9 +816,9 @@ fn get_call_sequence(
     req.send()
 }
 
-#[test]
-fn embargo_success() {
-    rpc_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn embargo_success() {
+    rpc_top_level(|client| async move {
         let response = client.test_more_stuff_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
 
@@ -873,7 +847,7 @@ fn embargo_success() {
         let call4 = get_call_sequence(&pipeline, 4);
         let call5 = get_call_sequence(&pipeline, 5);
 
-        futures::future::try_join_all(vec![
+        futures_util::future::try_join_all(vec![
             call0.promise,
             call1.promise,
             call2.promise,
@@ -890,7 +864,8 @@ fn embargo_success() {
             Ok(())
         })
         .await
-    });
+    })
+    .await;
 }
 
 async fn expect_promise_throws<T>(promise: Promise<T, Error>) -> Result<(), Error> {
@@ -901,9 +876,9 @@ async fn expect_promise_throws<T>(promise: Promise<T, Error>) -> Result<(), Erro
     }
 }
 
-#[test]
-fn embargo_error() {
-    rpc_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn embargo_error() {
+    rpc_top_level(|client| async move {
         let response = client.test_more_stuff_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
 
@@ -943,12 +918,13 @@ fn embargo_error() {
         expect_promise_throws(call4.promise).await?;
         expect_promise_throws(call5.promise).await?;
         Ok(())
-    });
+    })
+    .await;
 }
 
-#[test]
-fn echo_destruction() {
-    rpc_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn echo_destruction() {
+    rpc_top_level(|client| async move {
         let response = client.test_more_stuff_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
 
@@ -977,10 +953,11 @@ fn echo_destruction() {
             })
             .await
     })
+    .await;
 }
 
-#[test]
-fn local_client_call_not_immediate() {
+#[tokio::test(flavor = "local")]
+async fn local_client_call_not_immediate() {
     let server = crate::impls::TestInterface::new();
     let call_count = server.get_call_count();
     assert_eq!(call_count.get(), 0);
@@ -993,12 +970,12 @@ fn local_client_call_not_immediate() {
     // Hm... do we actually care about this?
     assert_eq!(call_count.get(), 0);
 
-    let _ = futures::executor::block_on(remote_promise.promise);
+    let _ = remote_promise.promise.await;
     assert_eq!(call_count.get(), 1);
 }
 
-#[test]
-fn local_client_send_cap() {
+#[tokio::test(flavor = "local")]
+async fn local_client_send_cap() {
     let server1 = crate::impls::TestMoreStuff::new();
     let server2 = crate::impls::TestInterface::new();
     let client1: crate::test_capnp::test_more_stuff::Client = capnp_rpc::new_client(server1);
@@ -1006,28 +983,32 @@ fn local_client_send_cap() {
 
     let mut req = client1.call_foo_request();
     req.get().set_cap(client2);
-    let response = futures::executor::block_on(req.send().promise).unwrap();
+    let response = req.send().promise.await.unwrap();
     assert_eq!(response.get().unwrap().get_s().unwrap(), "bar");
 }
 
-#[test]
-fn local_client_return_cap() {
+#[tokio::test(flavor = "local")]
+async fn local_client_return_cap() {
     let server = crate::impls::Bootstrap;
     let client: crate::test_capnp::bootstrap::Client = capnp_rpc::new_client(server);
-    let response =
-        futures::executor::block_on(client.test_interface_request().send().promise).unwrap();
+    let response = client
+        .test_interface_request()
+        .send()
+        .promise
+        .await
+        .unwrap();
     let client1 = response.get().unwrap().get_cap().unwrap();
 
     let mut request = client1.foo_request();
     request.get().set_i(123);
     request.get().set_j(true);
-    let response1 = futures::executor::block_on(request.send().promise).unwrap();
+    let response1 = request.send().promise.await.unwrap();
     assert_eq!(response1.get().unwrap().get_x().unwrap(), "foo");
 }
 
-#[test]
-fn capability_list() {
-    rpc_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn capability_list() {
+    rpc_top_level(|client| async move {
         let response = client.test_more_stuff_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
 
@@ -1052,10 +1033,11 @@ fn capability_list() {
         assert_eq!(call_count2.get(), 1);
         Ok(())
     })
+    .await;
 }
 
-#[test]
-fn capability_server_set() {
+#[tokio::test(flavor = "local")]
+async fn capability_server_set() {
     use crate::impls;
     use crate::test_capnp::test_interface;
     use capnp_rpc::CapabilityServerSet;
@@ -1079,23 +1061,23 @@ fn capability_server_set() {
     set2.gc();
 
     // Getting the local server using the correct set works.
-    let own_server1_again = futures::executor::block_on(set1.get_local_server(&client1)).unwrap();
+    let own_server1_again = set1.get_local_server(&client1).await.unwrap();
     assert_eq!(
         own_server1_again.get_call_count().as_ptr(),
         own_server1_counter.as_ptr()
     );
 
-    let own_server2_again = futures::executor::block_on(set2.get_local_server(&client2)).unwrap();
+    let own_server2_again = set2.get_local_server(&client2).await.unwrap();
     assert_eq!(
         own_server2_again.get_call_count().as_ptr(),
         own_server2_counter.as_ptr()
     );
 
     // Getting the local server using the wrong set doesn't work.
-    assert!(futures::executor::block_on(set1.get_local_server(&client2)).is_none());
-    assert!(futures::executor::block_on(set2.get_local_server(&client1)).is_none());
-    assert!(futures::executor::block_on(set1.get_local_server(&client_standalone)).is_none());
-    assert!(futures::executor::block_on(set2.get_local_server(&client_standalone)).is_none());
+    assert!(set1.get_local_server(&client2).await.is_none());
+    assert!(set2.get_local_server(&client1).await.is_none());
+    assert!(set1.get_local_server(&client_standalone).await.is_none());
+    assert!(set2.get_local_server(&client_standalone).await.is_none());
 
     // Also works if the client is a promise.
     let (fulfiller, promise) = oneshot::channel();
@@ -1109,23 +1091,22 @@ fn capability_server_set() {
         ::capnp_rpc::new_future_client(error_promise.map_err(canceled_to_error));
 
     assert!(fulfiller.send(client1).is_ok());
-    let own_server1_again2 =
-        futures::executor::block_on(set1.get_local_server(&client_promise)).unwrap();
+    let own_server1_again2 = set1.get_local_server(&client_promise).await.unwrap();
     assert_eq!(
         own_server1_again2.get_call_count().as_ptr(),
         own_server1_counter.as_ptr()
     );
 
     // Wrong set; returns None.
-    assert!(futures::executor::block_on(set2.get_local_server(&client_promise2)).is_none());
+    assert!(set2.get_local_server(&client_promise2).await.is_none());
 
     drop(error_fulfiller);
-    assert!(futures::executor::block_on(set1.get_local_server(&error_promise)).is_none());
+    assert!(set1.get_local_server(&error_promise).await.is_none());
 }
 
-#[test]
-fn capability_server_set_rpc() {
-    rpc_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn capability_server_set_rpc() {
+    rpc_top_level(|client| async move {
         let response1 = client
             .test_capability_server_set_request()
             .send()
@@ -1157,11 +1138,12 @@ fn capability_server_set_rpc() {
 
         Ok(())
     })
+    .await;
 }
 
-#[test]
-fn basic_streaming() {
-    rpc_and_local_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn basic_streaming() {
+    rpc_and_local_top_level(|client| async move {
         let response = client.test_more_stuff_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
         let response = client.get_test_streaming_request().send().promise.await?;
@@ -1179,12 +1161,13 @@ fn basic_streaming() {
         let results = r.get()?;
         assert_eq!(results.get_total_i(), ITERS * EACH);
         Ok(())
-    });
+    })
+    .await;
 }
 
-#[test]
-fn finish_stream_observes_all_streaming_writes() {
-    rpc_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn finish_stream_observes_all_streaming_writes() {
+    rpc_top_level(|client| async move {
         let response = client.test_more_stuff_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
         let response = client
@@ -1202,10 +1185,10 @@ fn finish_stream_observes_all_streaming_writes() {
             req.get().set_i(EACH);
             req.send()
         });
-        let writes = futures::future::try_join_all(writes);
+        let writes = futures_util::future::try_join_all(writes);
         let finish = client.finish_stream_request().send().promise;
 
-        let (_, response) = futures::future::try_join(writes, finish).await?;
+        let (_, response) = futures_util::future::try_join(writes, finish).await?;
         let total = response.get()?.get_total_i();
         assert_eq!(
             total,
@@ -1214,12 +1197,13 @@ fn finish_stream_observes_all_streaming_writes() {
             ITERS * EACH
         );
         Ok(())
-    });
+    })
+    .await;
 }
 
-#[test]
-fn basic_streaming_on_pipeline() {
-    rpc_and_local_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn basic_streaming_on_pipeline() {
+    rpc_and_local_top_level(|client| async move {
         let response = client.test_more_stuff_request().send().pipeline;
         let client = response.get_cap();
         let response = client.get_test_streaming_request().send().pipeline;
@@ -1237,12 +1221,13 @@ fn basic_streaming_on_pipeline() {
         let results = r.get()?;
         assert_eq!(results.get_total_i(), ITERS * EACH);
         Ok(())
-    });
+    })
+    .await;
 }
 
-#[test]
-fn stream_error_gets_reported() {
-    rpc_and_local_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn stream_error_gets_reported() {
+    rpc_and_local_top_level(|client| async move {
         let response = client.test_more_stuff_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
         let response = client.get_test_streaming_request().send().promise.await?;
@@ -1259,12 +1244,13 @@ fn stream_error_gets_reported() {
         };
         assert!(e.to_string().contains("throw requested"));
         Ok(())
-    });
+    })
+    .await;
 }
 
-#[test]
-fn promise_resolve_twice() {
-    rpc_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn promise_resolve_twice() {
+    rpc_top_level(|client| async move {
         let response1 = client.test_promise_resolve_request().send().promise.await?;
         let client1 = response1.get()?.get_cap()?;
 
@@ -1287,12 +1273,13 @@ fn promise_resolve_twice() {
         let x = response2.get()?.get_x()?.to_str()?;
         assert_eq!(x, "foo");
         Ok(())
-    });
+    })
+    .await;
 }
 
-#[test]
-fn get_self() {
-    rpc_and_local_top_level(|_spawner, client| async move {
+#[tokio::test(flavor = "local")]
+async fn get_self() {
+    rpc_and_local_top_level(|client| async move {
         let response = client.test_more_stuff_request().send().promise.await?;
         let client = response.get()?.get_cap()?;
         let response = client.get_test_self_request().send().promise.await?;
@@ -1314,5 +1301,6 @@ fn get_self() {
         assert_eq!(response4.get()?.get_x(), 3);
 
         Ok(())
-    });
+    })
+    .await;
 }

--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -26,6 +26,7 @@ use std::future::Future;
 
 use capnp::capability::{FromClientHook, Promise};
 use capnp::Error;
+use capnp_futures::io::{AsyncFdRead, AsyncFdWrite};
 use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
 
 use futures_channel::oneshot;
@@ -223,11 +224,36 @@ where
 {
     let (client_writer, server_reader) = async_byte_channel::channel();
     let (server_writer, client_reader) = async_byte_channel::channel();
+    rpc_top_level_with_io(
+        server_reader,
+        server_writer,
+        client_reader,
+        client_writer,
+        0,
+        main,
+    )
+    .await
+}
 
+async fn rpc_top_level_with_io<F, G, T, U>(
+    server_reader: T,
+    server_writer: U,
+    client_reader: T,
+    client_writer: U,
+    max_fds_per_message: u8,
+    main: F,
+) where
+    F: FnOnce(test_capnp::bootstrap::Client) -> G,
+    F: Send + 'static,
+    G: Future<Output = Result<(), Error>> + 'static,
+    T: AsyncFdRead + Send + 'static,
+    U: AsyncFdWrite + Send + 'static,
+{
     let join_handle = std::thread::spawn(move || {
-        let network = Box::new(twoparty::io::VatNetwork::new(
+        let network = Box::new(twoparty::io::VatNetwork::new_with_fds(
             server_reader,
             server_writer,
+            max_fds_per_message,
             rpc_twoparty_capnp::Side::Server,
             Default::default(),
         ));
@@ -240,9 +266,10 @@ where
             .unwrap();
     });
 
-    let network = Box::new(twoparty::io::VatNetwork::new(
+    let network = Box::new(twoparty::io::VatNetwork::new_with_fds(
         client_reader,
         client_writer,
+        max_fds_per_message,
         rpc_twoparty_capnp::Side::Client,
         Default::default(),
     ));
@@ -1303,4 +1330,50 @@ async fn get_self() {
         Ok(())
     })
     .await;
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "local")]
+async fn pass_fd() {
+    use capnp_futures::io::tokio::UnixFdStream;
+    use tokio::io::AsyncReadExt as _;
+    use tokio::net::unix::pipe;
+    use tokio::net::UnixStream;
+
+    let main = |client: test_capnp::bootstrap::Client| async move {
+        let response = client
+            .test_more_stuff_request()
+            .send()
+            .pipeline
+            .get_cap()
+            .pass_fd_request()
+            .send();
+        let fd = response
+            .pipeline
+            .get_fd_cap()
+            .client
+            .get_fd()
+            .await?
+            .unwrap()
+            .try_clone_to_owned()?;
+        let mut rx = pipe::Receiver::from_owned_fd(fd)?;
+        let mut buf = Vec::new();
+        rx.read_to_end(&mut buf).await?;
+        assert_eq!(buf, b"sup");
+        Ok(())
+    };
+
+    let (client_writer, server_reader) = UnixStream::pair().unwrap();
+    let (server_writer, client_reader) = UnixStream::pair().unwrap();
+    rpc_top_level_with_io(
+        UnixFdStream::new(server_reader),
+        UnixFdStream::new(server_writer),
+        UnixFdStream::new(client_reader),
+        UnixFdStream::new(client_writer),
+        1,
+        main,
+    )
+    .await;
+
+    local_top_level(main).await;
 }

--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -43,7 +43,7 @@ fn canceled_to_error(_e: futures::channel::oneshot::Canceled) -> Error {
 fn drop_rpc_system() {
     let (writer, reader) = async_byte_channel::channel();
 
-    let network = Box::new(twoparty::VatNetwork::new(
+    let network = Box::new(twoparty::io::VatNetwork::new(
         reader,
         writer,
         rpc_twoparty_capnp::Side::Client,
@@ -59,7 +59,7 @@ fn disconnector_setup() -> (
 ) {
     let (client_writer, server_reader) = async_byte_channel::channel();
     let (server_writer, client_reader) = async_byte_channel::channel();
-    let client_network = Box::new(twoparty::VatNetwork::new(
+    let client_network = Box::new(twoparty::io::VatNetwork::new(
         client_reader,
         client_writer,
         rpc_twoparty_capnp::Side::Client,
@@ -68,7 +68,7 @@ fn disconnector_setup() -> (
 
     let client_rpc_system = RpcSystem::new(client_network, None);
 
-    let server_network = Box::new(twoparty::VatNetwork::new(
+    let server_network = Box::new(twoparty::io::VatNetwork::new(
         server_reader,
         server_writer,
         rpc_twoparty_capnp::Side::Server,
@@ -248,7 +248,7 @@ where
     let (server_writer, client_reader) = async_byte_channel::channel();
 
     let join_handle = std::thread::spawn(move || {
-        let network = Box::new(twoparty::VatNetwork::new(
+        let network = Box::new(twoparty::io::VatNetwork::new(
             server_reader,
             server_writer,
             rpc_twoparty_capnp::Side::Server,
@@ -260,7 +260,7 @@ where
         futures::executor::block_on(rpc_system).unwrap();
     });
 
-    let network = Box::new(twoparty::VatNetwork::new(
+    let network = Box::new(twoparty::io::VatNetwork::new(
         client_reader,
         client_writer,
         rpc_twoparty_capnp::Side::Client,

--- a/capnp/src/capability.rs
+++ b/capnp/src/capability.rs
@@ -36,6 +36,8 @@ use core::task::Poll;
 
 use crate::any_pointer;
 #[cfg(feature = "alloc")]
+use crate::fd::BorrowedFd;
+#[cfg(feature = "alloc")]
 use crate::private::capability::{ClientHook, ParamsHook, RequestHook, ResponseHook, ResultsHook};
 #[cfg(feature = "alloc")]
 use crate::traits::{Owned, Pipelined};
@@ -403,6 +405,25 @@ impl Client {
     pub fn when_resolved(&self) -> Promise<(), Error> {
         self.hook.when_resolved()
     }
+
+    pub async fn get_fd(&self) -> Result<Option<BorrowedFd<'_>>, Error> {
+        let mut hook_ref = &self.hook;
+        let mut hook;
+        loop {
+            // TODO: The C++ implementation chases the promises when calling
+            // `get_fd()`, but we can’t do that for lifetime reasons. This may
+            // be less efficient, although it seems like it should only yield
+            // different results in the presence of dodgy implementations.
+            if let Some(fd) = self.hook.get_fd() {
+                return Ok(Some(fd));
+            }
+            let Some(promise) = hook_ref.when_more_resolved() else {
+                break Ok(None);
+            };
+            hook = promise.await?;
+            hook_ref = &hook;
+        }
+    }
 }
 
 #[cfg(feature = "alloc")]
@@ -468,6 +489,10 @@ pub trait Server {
     ) -> DispatchCallResult;
 
     fn as_ptr(&self) -> usize;
+
+    fn get_fd(&self) -> Option<BorrowedFd<'_>> {
+        None
+    }
 }
 
 /// Trait to track the relationship between generated Server traits and Client structs.

--- a/capnp/src/fd/compat.rs
+++ b/capnp/src/fd/compat.rs
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub enum BorrowedFd<'_> {}
+
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum OwnedFd {}
+
+pub trait AsFd {
+    fn as_fd(&self) -> BorrowedFd<'_>;
+}
+
+impl AsFd for BorrowedFd<'_> {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        match self {}
+    }
+}
+
+impl AsFd for OwnedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        match self {}
+    }
+}

--- a/capnp/src/fd/compat.rs
+++ b/capnp/src/fd/compat.rs
@@ -19,6 +19,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+use crate::private::capability::ClientHook;
+
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy)]
 pub enum BorrowedFd<'_> {}
@@ -40,5 +42,26 @@ impl AsFd for BorrowedFd<'_> {
 impl AsFd for OwnedFd {
     fn as_fd(&self) -> BorrowedFd<'_> {
         match self {}
+    }
+}
+
+#[derive(Default)]
+#[non_exhaustive]
+pub struct FdHooks {}
+
+impl FdHooks {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn try_push(
+        &mut self,
+        hook: Box<dyn ClientHook>,
+    ) -> Result<(u8, &dyn ClientHook), Box<dyn ClientHook>> {
+        Err(hook)
+    }
+
+    pub fn as_fds(&self) -> &[BorrowedFd<'_>] {
+        &[]
     }
 }

--- a/capnp/src/fd/mod.rs
+++ b/capnp/src/fd/mod.rs
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Per <https://github.com/rust-lang/rust/blob/1.96.0/library/std/src/os/mod.rs>.
+#[cfg(not(all(
+    feature = "std",
+    any(
+        unix,
+        target_os = "hermit",
+        target_os = "trusty",
+        target_os = "wasi",
+        target_os = "motor",
+    )
+)))]
+mod compat;
+#[cfg(all(
+    feature = "std",
+    any(
+        unix,
+        target_os = "hermit",
+        target_os = "trusty",
+        target_os = "wasi",
+        target_os = "motor",
+    )
+))]
+mod unix;
+
+#[cfg(not(all(
+    feature = "std",
+    any(
+        unix,
+        target_os = "hermit",
+        target_os = "trusty",
+        target_os = "wasi",
+        target_os = "motor",
+    )
+)))]
+pub use compat::*;
+#[cfg(all(
+    feature = "std",
+    any(
+        unix,
+        target_os = "hermit",
+        target_os = "trusty",
+        target_os = "wasi",
+        target_os = "motor",
+    )
+))]
+pub use unix::*;

--- a/capnp/src/fd/unix.rs
+++ b/capnp/src/fd/unix.rs
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+pub use std::os::fd::{AsFd, BorrowedFd, OwnedFd};

--- a/capnp/src/fd/unix.rs
+++ b/capnp/src/fd/unix.rs
@@ -19,4 +19,52 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+use std::os::fd::{AsRawFd, RawFd};
 pub use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
+
+use crate::private::capability::ClientHook;
+
+#[derive(Default)]
+pub struct FdHooks {
+    hooks: Vec<Box<dyn ClientHook>>,
+    fds: Vec<RawFd>,
+}
+
+impl FdHooks {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn try_push(
+        &mut self,
+        hook: Box<dyn ClientHook>,
+    ) -> Result<(u8, &dyn ClientHook), Box<dyn ClientHook>> {
+        let Ok(index) = self.fds.len().try_into() else {
+            return Err(hook);
+        };
+        if index == u8::MAX {
+            return Err(hook);
+        }
+        let Some(fd) = hook.get_fd() else {
+            return Err(hook);
+        };
+        let fd = fd.as_raw_fd();
+        self.hooks.push(hook);
+        self.fds.push(fd);
+        Ok((index, &*self.hooks[usize::from(index)]))
+    }
+
+    pub fn as_fds(&self) -> &[BorrowedFd<'_>] {
+        let fds: *const [RawFd] = &raw const *self.fds;
+        let fds = fds as *const [BorrowedFd<'_>];
+        // SAFETY: `fds` consists of `RawFd` conversions of `BorrowedFd<'_>`
+        // return values from `<dyn ClientHook + 'static>::get_fd()`.
+        //
+        // The signature of `get_fd()` requires its return value to live as
+        // long as `self`; each corresponding hook is stored in `self.hooks`,
+        // kept alive by our own `self` reference. `BorrowdFd<'_>` is
+        // documented to have the same representation as host file descriptors,
+        // as represented by `RawFd`.
+        unsafe { &*fds }
+    }
+}

--- a/capnp/src/lib.rs
+++ b/capnp/src/lib.rs
@@ -50,6 +50,7 @@ pub mod dynamic_list;
 pub mod dynamic_struct;
 pub mod dynamic_value;
 pub mod enum_list;
+pub mod fd;
 pub mod introspect;
 pub mod io;
 pub mod list_list;

--- a/capnp/src/private/capability.rs
+++ b/capnp/src/private/capability.rs
@@ -23,6 +23,7 @@
 
 use crate::any_pointer;
 use crate::capability::{Params, Promise, RemotePromise, Request, Results};
+use crate::fd::BorrowedFd;
 use crate::MessageSize;
 
 pub trait ResponseHook {
@@ -83,6 +84,12 @@ pub trait ClientHook {
 
     /// Repeatedly calls whenMoreResolved() until it returns nullptr.
     fn when_resolved(&self) -> Promise<(), crate::Error>;
+
+    /// Implements [`crate::capability::Client::get_fd()`]. If this returns `None` but [`when_more_resolved`] returns
+    /// `Some`, then [`crate::capability::Client::get_fd()`] waits for resolution and tries again.
+    fn get_fd(&self) -> Option<BorrowedFd<'_>> {
+        None
+    }
 }
 
 impl Clone for alloc::boxed::Box<dyn ClientHook> {

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 use std::collections;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use capnp::schema_capnp;
@@ -1891,7 +1891,7 @@ fn get_ty_params_of_brand(
     ctx: &GeneratorContext,
     brand: schema_capnp::brand::Reader,
 ) -> ::capnp::Result<String> {
-    let mut acc = HashSet::new();
+    let mut acc = BTreeSet::new();
     get_ty_params_of_brand_helper(ctx, &mut acc, brand)?;
     let mut result = String::new();
     for (scope_id, parameter_index) in acc.into_iter() {
@@ -1906,7 +1906,7 @@ fn get_ty_params_of_brand(
 
 fn get_ty_params_of_type_helper(
     ctx: &GeneratorContext,
-    accumulator: &mut HashSet<(u64, u16)>,
+    accumulator: &mut BTreeSet<(u64, u16)>,
     typ: schema_capnp::type_::Reader,
 ) -> ::capnp::Result<()> {
     use capnp::schema_capnp::type_;
@@ -1954,7 +1954,7 @@ fn get_ty_params_of_type_helper(
 
 fn get_ty_params_of_brand_helper(
     ctx: &GeneratorContext,
-    accumulator: &mut HashSet<(u64, u16)>,
+    accumulator: &mut BTreeSet<(u64, u16)>,
     brand: schema_capnp::brand::Reader,
 ) -> ::capnp::Result<()> {
     for scope in brand.get_scopes()? {

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -2677,6 +2677,14 @@ fn generate_node(
                 method.get_annotations()?;
             }
 
+            // TODO: This will break if an interface defines a method named
+            // `getFd`. I’m not sure if the C++ implementation handles this
+            // either, though.
+            server_interior.push(Line(fmt!(
+                ctx,
+                "fn get_fd(&self) -> Option<{capnp}::fd::BorrowedFd<'_>> {{ None }}"
+            )));
+
             let mut base_dispatch_arms = Vec::new();
 
             let server_base = {
@@ -2915,6 +2923,7 @@ fn generate_node(
 
                     indent(Line(fmt!(ctx, "fn as_ptr(&self) -> usize {{ {capnp}::capability::Rc::as_ptr(&self.server) as usize }}"))),
 
+                    indent(Line(fmt!(ctx, "fn get_fd(&self) -> Option<{capnp}::fd::BorrowedFd<'_>> {{ <_T as Server{}>::get_fd(&self.server) }}", bracketed_params))),
                     line("}")]));
 
             mod_interior.push(


### PR DESCRIPTION
I needed this and it didn’t seem too complicated to implement based on https://github.com/capnproto/capnproto/pull/821; famous last words :)

This is largely based on that PR (and it’s possible I’ve missed fixes postdating it), but with some divergences for Rust’s ownership model and existing differences in the Rust library. In particular, since we need a bespoke IO abstraction to handle FD passing anyway (sadly, all the existing options in the ecosystem are somewhat lacking), I took the opportunity to make the `futures-io` coupling optional and allow more direct use of Tokio.

I’m marking this as a draft for now, because there’s a fair number of unresolved questions and missing pieces, and I’m fairly likely to make changes:

* It’s not entirely clear how to get the best ergonomics here; you usually want an `OwnedFd` on the receiving end, which currently requires an explicit clone, but avoiding that brings up a lot of questions around mutability and what the server‐side interface should be like. A lot of the `RefCell`‐reducing churn here is to make using `BorrowedFd` work, which is nice on the server end but sort of annoying on the client end. The current interface matches the C++ implementation pretty closely, although KJ is a bit more cavalier around FD ownership than Rust is.

* The IO interfaces don’t feel fully baked yet; in particular, I think it may be a more natural fit to the IO patterns to use an ownership‐transferring buffer model, which would also potentially work better with completion‐based interfaces like `io_uring`.

* There ought to be an implementation of buffering that handles FDs, as the C++ version has.

* There are a good few contortions here to try and achieve perfect SemVer compatibility and keep the existing `futures-io`‐based interfaces working by default. If it’s acceptable to make breaking changes, a good portion of this could be simplified.

However, it should be fairly complete and ready for feedback on the basic approach. There’s a fair bit of entangled stuff and some side quests in here; I strongly recommend reading this commit‐by‐commit. Some of it could be split out, and some of it could potentially be dropped or simplified based on the direction this takes, but I’ve been iterating on this locally for long enough and want to get a draft up before it diverges even further :)

Closes: #625