### PR TITLE
Use GeneratedCodeArena to avoid the need for unsafe{} in RawEnumSchema construction.

### DIFF
--- a/capnp-rpc/src/rpc_capnp.rs
+++ b/capnp-rpc/src/rpc_capnp.rs
@@ -8559,10 +8559,10 @@ pub mod exception {
 
     impl ::capnp::introspect::Introspect for Type {
         fn introspect() -> ::capnp::introspect::Type {
-            ::capnp::introspect::TypeVariant::Enum(::capnp::introspect::RawEnumSchema {
-                encoded_node: &type_::ENCODED_NODE,
-                annotation_types: type_::get_annotation_types,
-            })
+            ::capnp::introspect::TypeVariant::Enum(::capnp::introspect::RawEnumSchema::new(
+                &type_::ARENA,
+                type_::get_annotation_types,
+            ))
             .into()
         }
     }
@@ -8570,11 +8570,8 @@ pub mod exception {
         fn from(e: Type) -> Self {
             ::capnp::dynamic_value::Enum::new(
                 e.into(),
-                ::capnp::introspect::RawEnumSchema {
-                    encoded_node: &type_::ENCODED_NODE,
-                    annotation_types: type_::get_annotation_types,
-                }
-                .into(),
+                ::capnp::introspect::RawEnumSchema::new(&type_::ARENA, type_::get_annotation_types)
+                    .into(),
             )
             .into()
         }
@@ -8648,5 +8645,7 @@ pub mod exception {
         ) -> ::capnp::introspect::Type {
             ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
+        pub(crate) static ARENA: ::capnp::private::arena::GeneratedCodeArena =
+            ::capnp::private::arena::GeneratedCodeArena::new(&ENCODED_NODE);
     }
 }

--- a/capnp-rpc/src/rpc_twoparty_capnp.rs
+++ b/capnp-rpc/src/rpc_twoparty_capnp.rs
@@ -13,10 +13,10 @@ pub enum Side {
 
 impl ::capnp::introspect::Introspect for Side {
     fn introspect() -> ::capnp::introspect::Type {
-        ::capnp::introspect::TypeVariant::Enum(::capnp::introspect::RawEnumSchema {
-            encoded_node: &side::ENCODED_NODE,
-            annotation_types: side::get_annotation_types,
-        })
+        ::capnp::introspect::TypeVariant::Enum(::capnp::introspect::RawEnumSchema::new(
+            &side::ARENA,
+            side::get_annotation_types,
+        ))
         .into()
     }
 }
@@ -24,11 +24,8 @@ impl ::core::convert::From<Side> for ::capnp::dynamic_value::Reader<'_> {
     fn from(e: Side) -> Self {
         ::capnp::dynamic_value::Enum::new(
             e.into(),
-            ::capnp::introspect::RawEnumSchema {
-                encoded_node: &side::ENCODED_NODE,
-                annotation_types: side::get_annotation_types,
-            }
-            .into(),
+            ::capnp::introspect::RawEnumSchema::new(&side::ARENA, side::get_annotation_types)
+                .into(),
         )
         .into()
     }
@@ -88,6 +85,8 @@ mod side {
     ) -> ::capnp::introspect::Type {
         ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
     }
+    pub(crate) static ARENA: ::capnp::private::arena::GeneratedCodeArena =
+        ::capnp::private::arena::GeneratedCodeArena::new(&ENCODED_NODE);
 }
 
 pub mod vat_id {

--- a/capnp/src/introspect.rs
+++ b/capnp/src/introspect.rs
@@ -312,16 +312,16 @@ impl From<StructSchema> for RawBrandedStructSchema {
 #[derive(Clone, Copy)]
 pub struct RawEnumSchema {
     /// The Node (as defined in schema.capnp), as a single segment message.
-    pub encoded_node: &'static [crate::Word],
+    pub(crate) arena: &'static crate::private::arena::GeneratedCodeArena,
 
     /// Map from (maybe enumerant index, annotation index) to the Type
     /// of the value held by that annotation.
-    pub annotation_types: fn(Option<u16>, u32) -> Type,
+    pub(crate) annotation_types: fn(Option<u16>, u32) -> Type,
 }
 
 impl core::cmp::PartialEq for RawEnumSchema {
     fn eq(&self, other: &Self) -> bool {
-        ::core::ptr::eq(self.encoded_node, other.encoded_node)
+        ::core::ptr::eq(self.arena, other.arena)
     }
 }
 
@@ -329,7 +329,20 @@ impl core::cmp::Eq for RawEnumSchema {}
 
 impl core::fmt::Debug for RawEnumSchema {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error> {
-        write!(f, "RawEnumSchema({:?})", self.encoded_node as *const _)
+        write!(f, "RawEnumSchema({:?})", self.arena as *const _)
+    }
+}
+
+impl RawEnumSchema {
+    /// Constructs a new `RawEnumSchema`.
+    pub const fn new(
+        arena: &'static crate::private::arena::GeneratedCodeArena,
+        annotation_types: fn(Option<u16>, u32) -> Type,
+    ) -> Self {
+        Self {
+            arena,
+            annotation_types,
+        }
     }
 }
 

--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -256,9 +256,9 @@ pub struct EnumSchema {
 
 impl EnumSchema {
     pub fn new(raw: RawEnumSchema) -> Self {
-        let proto = crate::any_pointer::Reader::new(unsafe {
-            layout::PointerReader::get_root_unchecked(raw.encoded_node.as_ptr() as *const u8)
-        })
+        let proto = crate::any_pointer::Reader::new(
+            layout::PointerReader::get_root_from_arena(raw.arena).unwrap(),
+        )
         .get_as()
         .unwrap();
         Self { raw, proto }

--- a/capnp/src/schema_capnp.rs
+++ b/capnp/src/schema_capnp.rs
@@ -12934,10 +12934,10 @@ pub enum ElementSize {
 
 impl crate::introspect::Introspect for ElementSize {
     fn introspect() -> crate::introspect::Type {
-        crate::introspect::TypeVariant::Enum(crate::introspect::RawEnumSchema {
-            encoded_node: &element_size::ENCODED_NODE,
-            annotation_types: element_size::get_annotation_types,
-        })
+        crate::introspect::TypeVariant::Enum(crate::introspect::RawEnumSchema::new(
+            &element_size::ARENA,
+            element_size::get_annotation_types,
+        ))
         .into()
     }
 }
@@ -12945,10 +12945,10 @@ impl ::core::convert::From<ElementSize> for crate::dynamic_value::Reader<'_> {
     fn from(e: ElementSize) -> Self {
         crate::dynamic_value::Enum::new(
             e.into(),
-            crate::introspect::RawEnumSchema {
-                encoded_node: &element_size::ENCODED_NODE,
-                annotation_types: element_size::get_annotation_types,
-            }
+            crate::introspect::RawEnumSchema::new(
+                &element_size::ARENA,
+                element_size::get_annotation_types,
+            )
             .into(),
         )
         .into()
@@ -13044,6 +13044,8 @@ mod element_size {
     ) -> crate::introspect::Type {
         crate::introspect::panic_invalid_annotation_indices(child_index, index)
     }
+    pub(crate) static ARENA: crate::private::arena::GeneratedCodeArena =
+        crate::private::arena::GeneratedCodeArena::new(&ENCODED_NODE);
 }
 
 pub mod capnp_version {

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -2480,14 +2480,14 @@ fn generate_node(
                     "impl {capnp}::introspect::Introspect for {last_name} {{"
                 )),
                 indent(Line(fmt!(ctx,
-                    "fn introspect() -> {capnp}::introspect::Type {{ {capnp}::introspect::TypeVariant::Enum({capnp}::introspect::RawEnumSchema {{ encoded_node: &{0}::ENCODED_NODE, annotation_types: {0}::get_annotation_types }}).into() }}", name_as_mod))),
+                    "fn introspect() -> {capnp}::introspect::Type {{ {capnp}::introspect::TypeVariant::Enum({capnp}::introspect::RawEnumSchema::new(&{0}::ARENA, {0}::get_annotation_types)).into() }}", name_as_mod))),
                 Line("}".into()),
             ]));
 
             output.push(Branch(vec![
                 Line(fmt!(ctx,"impl ::core::convert::From<{last_name}> for {capnp}::dynamic_value::Reader<'_> {{")),
                 indent(Line(fmt!(ctx,
-                    "fn from(e: {last_name}) -> Self {{ {capnp}::dynamic_value::Enum::new(e.into(), {capnp}::introspect::RawEnumSchema {{ encoded_node: &{0}::ENCODED_NODE, annotation_types: {0}::get_annotation_types }}.into()).into() }}", name_as_mod ))),
+                    "fn from(e: {last_name}) -> Self {{ {capnp}::dynamic_value::Enum::new(e.into(), {capnp}::introspect::RawEnumSchema::new(&{0}::ARENA, {0}::get_annotation_types).into()).into() }}", name_as_mod ))),
                 Line("}".into())
             ]));
 
@@ -2540,6 +2540,7 @@ fn generate_node(
                         crate::pointer_constants::WordArrayDeclarationOptions { pub_crate: true },
                     )?,
                     generate_get_annotation_types(ctx, *node_reader)?,
+                    Line(fmt!(ctx, "pub(crate) static ARENA: {capnp}::private::arena::GeneratedCodeArena = {capnp}::private::arena::GeneratedCodeArena::new(&ENCODED_NODE);")),
                 ]),
                 Line("}".into()),
             ]));


### PR DESCRIPTION
Fixes #667.