### PR TITLE
Expose a public broken-capability constructor

### DIFF
--- a/capnp-rpc/src/lib.rs
+++ b/capnp-rpc/src/lib.rs
@@ -392,6 +392,21 @@ where
     )))
 }
 
+/// Creates a "broken" capability that returns the given error from every operation.
+///
+/// The returned client fails with a clone of `error` on every method call
+/// (via both `call` and `new_call`) and on any pipelined capability obtained
+/// from such a call. It never resolves to a working capability.
+///
+/// This is useful when building a capability membrane or other interposition
+/// layer on top of `ClientHook`: the "deny" path of a membrane needs a
+/// capability that rejects all access with a specific error rather than
+/// forwarding to a real object. This parallels the `newBrokenCap` function
+/// exposed by the C++ implementation of Cap'n Proto.
+pub fn new_broken_cap(error: capnp::Error) -> capnp::capability::Client {
+    capnp::capability::Client::new(broken::new_cap(error))
+}
+
 /// Collection of unwrappable capabilities.
 ///
 /// Allows a server to recognize its own capabilities when passed back to it, and obtain the

--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -1316,3 +1316,32 @@ fn get_self() {
         Ok(())
     });
 }
+
+#[test]
+fn broken_cap_returns_supplied_error() {
+    let error = Error::failed("membrane denied access".to_string());
+
+    futures::executor::block_on(async move {
+        // A broken capability, cast to a concrete interface type.
+        let client = test_capnp::test_interface::Client {
+            client: capnp_rpc::new_broken_cap(error.clone()),
+        };
+
+        // A direct method call fails with the supplied error.
+        match client.foo_request().send().promise.await {
+            Ok(_) => panic!("expected the broken cap to return an error"),
+            Err(e) => assert_eq!(e.extra, error.extra),
+        }
+
+        // Pipelined access through a broken call also fails with the error.
+        let pipeline_client = test_capnp::test_pipeline::Client {
+            client: capnp_rpc::new_broken_cap(error.clone()),
+        };
+        let promise = pipeline_client.get_cap_request().send();
+        let pipelined_cap = promise.pipeline.get_out_box().get_cap();
+        match pipelined_cap.foo_request().send().promise.await {
+            Ok(_) => panic!("expected pipelined access to return an error"),
+            Err(e) => assert_eq!(e.extra, error.extra),
+        }
+    });
+}

--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -1328,10 +1328,8 @@ fn broken_cap_returns_supplied_error() {
         };
 
         // A direct method call fails with the supplied error.
-        match client.foo_request().send().promise.await {
-            Ok(_) => panic!("expected the broken cap to return an error"),
-            Err(e) => assert_eq!(e.extra, error.extra),
-        }
+        let e = client.foo_request().send().promise.await.err().unwrap();
+        assert_eq!(e.extra, error.extra);
 
         // Pipelined access through a broken call also fails with the error.
         let pipeline_client = test_capnp::test_pipeline::Client {
@@ -1339,10 +1337,15 @@ fn broken_cap_returns_supplied_error() {
         };
         let promise = pipeline_client.get_cap_request().send();
         let pipelined_cap = promise.pipeline.get_out_box().get_cap();
-        match pipelined_cap.foo_request().send().promise.await {
-            Ok(_) => panic!("expected pipelined access to return an error"),
-            Err(e) => assert_eq!(e.extra, error.extra),
-        }
+        let e = pipelined_cap
+            .foo_request()
+            .send()
+            .promise
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(e.extra, error.extra);
+    });
 }
 
 #[test]


### PR DESCRIPTION
Building a capability membrane (method-level attenuation à la C++ `membrane.h`) on top of `ClientHook` requires a "broken" client/request/pipeline for the deny path — a cap that returns a given error from every operation. `capnp-rpc` already has exactly this in its `broken` module, but it's `pub(crate)`, so every downstream membrane re-copies ~120 lines of it.

This PR exposes a minimal public constructor and keeps the internals private. C++ capnp exposes `newBrokenCap` publicly for the same reason; membrane-style interposition is impractical downstream without it.

Includes a unit test that the returned client errors on `call`/`new_call` and pipelined access.

Opening as **draft** to gauge interest before polishing.