### PR TITLE
rpc: fix panic when re-sending a capability that was imported twice

### DIFF
--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -1428,11 +1428,18 @@ impl<VatId> ConnectionState<VatId> {
             inner = resolved;
         }
         if inner.get_brand() == state.get_brand() {
-            let Some(c) = Client::from_ptr(inner.get_ptr(), state) else {
-                unreachable!()
-            };
-            Ok(c.write_descriptor(descriptor))
-        } else {
+            if let Some(c) = Client::from_ptr(inner.get_ptr(), state) {
+                return Ok(c.write_descriptor(descriptor));
+            }
+            // The hook claims to belong to this connection but the downcast
+            // map has no live entry for it (e.g. a stale entry left by a
+            // since-dropped duplicate wrapper — see the reuse logic in
+            // `import()`). The hook itself still works for calls, so fall
+            // through and export it as if it were foreign: the receiver gets
+            // a functioning capability (at the cost of an extra round-trip)
+            // instead of the event loop panicking.
+        }
+        {
             let ptr = inner.get_ptr();
             let contains_key = state.exports_by_cap.borrow().contains_key(&ptr);
             if contains_key {
@@ -1550,9 +1557,22 @@ impl<VatId> ConnectionState<VatId> {
                 }
             }
         } else {
-            let client: Box<Client<VatId>> = Box::new(import_client.into());
-            import.app_client = Some(client.downgrade());
-            client
+            // Reuse the existing wrapper `Client` if one is still alive,
+            // mirroring the promise branch above. Unconditionally creating a
+            // new wrapper for an already-imported cap overwrites the
+            // `client_downcast_map` entry (keyed by the shared inner
+            // `ImportClient` pointer); when the newer wrapper is dropped
+            // while an older one is still held by the application, the map's
+            // weak reference dies and a later `write_descriptor` of the older
+            // wrapper hits `Client::from_ptr() == None`.
+            match import.app_client.as_ref().and_then(|c| c.upgrade()) {
+                Some(c) => Box::new(c),
+                None => {
+                    let client: Box<Client<VatId>> = Box::new(import_client.into());
+                    import.app_client = Some(client.downgrade());
+                    client
+                }
+            }
         }
     }
 

--- a/capnp-rpc/test/test.rs
+++ b/capnp-rpc/test/test.rs
@@ -1316,3 +1316,34 @@ fn get_self() {
         Ok(())
     });
 }
+
+#[test]
+fn reimport_then_resend_does_not_poison_downcast_map() {
+    // Regression test: receiving a senderHosted descriptor for an import we
+    // already hold used to construct a second wrapper `Client`, overwriting
+    // the client_downcast_map entry keyed by the shared inner ImportClient.
+    // Dropping that duplicate then left a dead weak in the map, and the next
+    // outgoing message carrying the ORIGINAL client panicked in
+    // write_descriptor (`Client::from_ptr` returned None -> unreachable!()).
+    rpc_top_level(|_spawner, client| async move {
+        let response = client.test_more_stuff_request().send().promise.await?;
+        let more_stuff = response.get()?.get_cap()?;
+
+        // Re-import the same server-hosted cap: echoing it back makes the
+        // server return its own capability, so the response carries the same
+        // export id and import() runs again for an id we already hold. The
+        // duplicate wrapper is dropped at the end of this block.
+        {
+            let mut echo = more_stuff.echo_request();
+            echo.get().set_cap(more_stuff.clone().cast_to());
+            let resp = echo.send().promise.await?;
+            let _dup: crate::test_capnp::test_call_order::Client = resp.get()?.get_cap()?;
+        }
+
+        // Sending the original client again must not panic.
+        let mut echo = more_stuff.echo_request();
+        echo.get().set_cap(more_stuff.clone().cast_to());
+        echo.send().promise.await?;
+        Ok(())
+    });
+}


### PR DESCRIPTION
Receiving a `senderHosted` descriptor for an import the vat already holds unconditionally constructs a second wrapper `Client` around the shared inner `ImportClient`. `Client::new` overwrites the `client_downcast_map` entry (keyed by the inner pointer), and `WeakClient::upgrade` requires the per-wrapper `flow_controller` to still be alive — so if the newer wrapper is dropped while the application still holds the older one, the map entry goes dead. The next `write_descriptor` of the older wrapper then hits `Client::from_ptr() == None` and panics via `unreachable!()`, killing the RPC event loop.

We hit this in production: a vat that received the same capability in two messages, dropped the second copy, and later passed the first as a call parameter would reliably panic at `rpc.rs:1432`.

Two changes:
1. `import()`: the non-promise path now reuses the existing live wrapper via `import.app_client` — exactly what the promise path already does — only constructing a new wrapper when none is alive.
2. `write_descriptor()`: if a brand-matching hook has no live downcast-map entry, fall through to the foreign-cap export path instead of panicking. The hook still works for calls, so the receiver gets a functioning capability rather than a dead connection.

The regression test echoes a server-hosted cap back (forcing a re-import of a held id), drops the duplicate, then sends the original again — panics before this change, passes after. All existing tests pass.