### PR TITLE
clean up CapTable

### DIFF
--- a/capnp-rpc/src/rpc_capnp.rs
+++ b/capnp-rpc/src/rpc_capnp.rs
@@ -98,7 +98,9 @@ pub mod message {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -330,7 +332,9 @@ pub mod message {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -1208,7 +1212,9 @@ pub mod bootstrap {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -1270,7 +1276,9 @@ pub mod bootstrap {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -1531,7 +1539,9 @@ pub mod call {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -1631,7 +1641,9 @@ pub mod call {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -2104,7 +2116,9 @@ pub mod call {
         impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
                 self.reader
-                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                        cap_table,
+                    ))
             }
         }
 
@@ -2174,7 +2188,9 @@ pub mod call {
         impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
                 self.builder
-                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                        cap_table,
+                    ))
             }
         }
 
@@ -2477,7 +2493,9 @@ pub mod return_ {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -2586,7 +2604,9 @@ pub mod return_ {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -3085,7 +3105,9 @@ pub mod finish {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -3147,7 +3169,9 @@ pub mod finish {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -3428,7 +3452,9 @@ pub mod resolve {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -3514,7 +3540,9 @@ pub mod resolve {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -3850,7 +3878,9 @@ pub mod release {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -3908,7 +3938,9 @@ pub mod release {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -4157,7 +4189,9 @@ pub mod disembargo {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -4222,7 +4256,9 @@ pub mod disembargo {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -4495,7 +4531,9 @@ pub mod disembargo {
         impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
                 self.reader
-                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                        cap_table,
+                    ))
             }
         }
 
@@ -4561,7 +4599,9 @@ pub mod disembargo {
         impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
                 self.builder
-                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                        cap_table,
+                    ))
             }
         }
 
@@ -4873,7 +4913,9 @@ pub mod provide {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -4946,7 +4988,9 @@ pub mod provide {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -5251,7 +5295,9 @@ pub mod accept {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -5317,7 +5363,9 @@ pub mod accept {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -5601,7 +5649,9 @@ pub mod join {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -5674,7 +5724,9 @@ pub mod join {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -5979,7 +6031,9 @@ pub mod message_target {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -6049,7 +6103,9 @@ pub mod message_target {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -6333,7 +6389,9 @@ pub mod payload {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -6406,7 +6464,9 @@ pub mod payload {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -6701,7 +6761,9 @@ pub mod cap_descriptor {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -6795,7 +6857,9 @@ pub mod cap_descriptor {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -7235,7 +7299,9 @@ pub mod promised_answer {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -7304,7 +7370,9 @@ pub mod promised_answer {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -7596,7 +7664,9 @@ pub mod promised_answer {
         impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
                 self.reader
-                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                        cap_table,
+                    ))
             }
         }
 
@@ -7658,7 +7728,9 @@ pub mod promised_answer {
         impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
                 self.builder
-                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                        cap_table,
+                    ))
             }
         }
 
@@ -7921,7 +7993,9 @@ pub mod third_party_cap_descriptor {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -7983,7 +8057,9 @@ pub mod third_party_cap_descriptor {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -8243,7 +8319,9 @@ pub mod exception {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -8330,7 +8408,9 @@ pub mod exception {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 

--- a/capnp-rpc/src/rpc_twoparty_capnp.rs
+++ b/capnp-rpc/src/rpc_twoparty_capnp.rs
@@ -178,7 +178,9 @@ pub mod vat_id {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -234,7 +236,9 @@ pub mod vat_id {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -464,7 +468,9 @@ pub mod provision_id {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -518,7 +524,9 @@ pub mod provision_id {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -743,7 +751,9 @@ pub mod recipient_id {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -793,7 +803,9 @@ pub mod recipient_id {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -991,7 +1003,9 @@ pub mod third_party_cap_id {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -1041,7 +1055,9 @@ pub mod third_party_cap_id {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -1240,7 +1256,9 @@ pub mod join_key_part {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -1302,7 +1320,9 @@ pub mod join_key_part {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -1576,7 +1596,9 @@ pub mod join_result {
     impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
             self.reader
-                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableReader::from_ref(
+                    cap_table,
+                ))
         }
     }
 
@@ -1642,7 +1664,9 @@ pub mod join_result {
     impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
             self.builder
-                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(::capnp::private::layout::CapTableBuilder::from_ref(
+                    cap_table,
+                ))
         }
     }
 

--- a/capnp/src/any_pointer.rs
+++ b/capnp/src/any_pointer.rs
@@ -126,7 +126,7 @@ impl<'a> crate::traits::SetterInput<Owned> for Reader<'a> {
 impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
     fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
         self.reader
-            .imbue(crate::private::layout::CapTableReader::Plain(cap_table));
+            .imbue(crate::private::layout::CapTableReader::from_ref(cap_table));
     }
 }
 
@@ -210,7 +210,7 @@ impl<'a> FromPointerBuilder<'a> for Builder<'a> {
 impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
     fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
         self.builder
-            .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table));
+            .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table));
     }
 }
 

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -2792,20 +2792,15 @@ pub type CapTable = alloc::vec::Vec<Option<alloc::boxed::Box<dyn ClientHook>>>;
 #[cfg(not(feature = "alloc"))]
 pub struct CapTable;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub enum CapTableReader {
+    #[default]
     Dummy,
     Plain(core::ptr::NonNull<CapTable>),
 }
 
 const _: () =
     assert!(core::mem::size_of::<CapTableReader>() == core::mem::size_of::<*const CapTable>());
-
-impl Default for CapTableReader {
-    fn default() -> Self {
-        CapTableReader::Dummy
-    }
-}
 
 impl CapTableReader {
     pub fn from_ref(cap_table: &CapTable) -> Self {
@@ -2829,20 +2824,15 @@ impl CapTableReader {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub enum CapTableBuilder {
+    #[default]
     Dummy,
     Plain(core::ptr::NonNull<CapTable>),
 }
 
 const _: () =
     assert!(core::mem::size_of::<CapTableBuilder>() == core::mem::size_of::<*mut CapTable>());
-
-impl Default for CapTableBuilder {
-    fn default() -> Self {
-        CapTableBuilder::Dummy
-    }
-}
 
 impl CapTableBuilder {
     pub fn into_reader(self) -> CapTableReader {

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -2794,28 +2794,31 @@ pub struct CapTable;
 
 #[derive(Copy, Clone)]
 pub enum CapTableReader {
-    // At one point, we had a `Dummy` variant here, but that ended up
-    // making values of this type take 16 bytes of memory. Now we instead
-    // represent a null CapTableReader with `Plain(ptr::null())`.
-    Plain(*const CapTable),
+    Dummy,
+    Plain(core::ptr::NonNull<CapTable>),
 }
+
+const _: () =
+    assert!(core::mem::size_of::<CapTableReader>() == core::mem::size_of::<*const CapTable>());
 
 impl Default for CapTableReader {
     fn default() -> Self {
-        CapTableReader::Plain(ptr::null())
+        CapTableReader::Dummy
     }
 }
 
-#[cfg(feature = "alloc")]
 impl CapTableReader {
-    pub fn extract_cap(&self, index: usize) -> Option<alloc::boxed::Box<dyn ClientHook>> {
+    pub fn from_ref(cap_table: &CapTable) -> Self {
+        Self::Plain(core::ptr::NonNull::from(cap_table))
+    }
+
+    #[cfg(feature = "alloc")]
+    pub(crate) fn extract_cap(&self, index: usize) -> Option<alloc::boxed::Box<dyn ClientHook>> {
         match *self {
+            Self::Dummy => None,
             Self::Plain(hooks) => {
-                if hooks.is_null() {
-                    return None;
-                }
                 let hooks: &alloc::vec::Vec<Option<alloc::boxed::Box<dyn ClientHook>>> =
-                    unsafe { &*hooks };
+                    unsafe { hooks.as_ref() };
                 if index >= hooks.len() {
                     None
                 } else {
@@ -2828,55 +2831,43 @@ impl CapTableReader {
 
 #[derive(Copy, Clone)]
 pub enum CapTableBuilder {
-    // At one point, we had a `Dummy` variant here, but that ended up
-    // making values of this type take 16 bytes of memory. Now we instead
-    // represent a null CapTableBuilder with `Plain(ptr::null_mut())`.
-    Plain(*mut CapTable),
+    Dummy,
+    Plain(core::ptr::NonNull<CapTable>),
 }
+
+const _: () =
+    assert!(core::mem::size_of::<CapTableBuilder>() == core::mem::size_of::<*mut CapTable>());
 
 impl Default for CapTableBuilder {
     fn default() -> Self {
-        CapTableBuilder::Plain(ptr::null_mut())
+        CapTableBuilder::Dummy
     }
 }
 
 impl CapTableBuilder {
     pub fn into_reader(self) -> CapTableReader {
         match self {
+            Self::Dummy => CapTableReader::Dummy,
             Self::Plain(hooks) => CapTableReader::Plain(hooks),
         }
     }
 
-    #[cfg(feature = "alloc")]
-    pub fn extract_cap(&self, index: usize) -> Option<alloc::boxed::Box<dyn ClientHook>> {
-        match *self {
-            Self::Plain(hooks) => {
-                if hooks.is_null() {
-                    return None;
-                }
-                let hooks: &alloc::vec::Vec<Option<alloc::boxed::Box<dyn ClientHook>>> =
-                    unsafe { &*hooks };
-                if index >= hooks.len() {
-                    None
-                } else {
-                    hooks[index].as_ref().map(|hook| hook.add_ref())
-                }
-            }
-        }
+    pub fn from_ref(cap_table: &mut CapTable) -> Self {
+        Self::Plain(core::ptr::NonNull::from(cap_table))
     }
 
     #[cfg(feature = "alloc")]
-    pub fn inject_cap(&mut self, cap: alloc::boxed::Box<dyn ClientHook>) -> usize {
+    pub(crate) fn inject_cap(&mut self, cap: alloc::boxed::Box<dyn ClientHook>) -> usize {
         match *self {
-            Self::Plain(hooks) => {
-                if hooks.is_null() {
-                    panic!(
-                        "Called inject_cap() on a null capability table. You need \
-                            to call imbue_mut() on this message before adding capabilities."
-                    );
-                }
+            Self::Dummy => {
+                panic!(
+                    "Called inject_cap() on a null capability table. You need \
+                     to call imbue_mut() on this message before adding capabilities."
+                );
+            }
+            Self::Plain(mut hooks) => {
                 let hooks: &mut alloc::vec::Vec<Option<alloc::boxed::Box<dyn ClientHook>>> =
-                    unsafe { &mut *hooks };
+                    unsafe { hooks.as_mut() };
                 hooks.push(Some(cap));
                 hooks.len() - 1
             }
@@ -2886,15 +2877,15 @@ impl CapTableBuilder {
     #[cfg(feature = "alloc")]
     pub fn drop_cap(&mut self, index: usize) {
         match *self {
-            Self::Plain(hooks) => {
-                if hooks.is_null() {
-                    panic!(
-                        "Called drop_cap() on a null capability table. You need \
-                            to call imbue_mut() on this message before adding capabilities."
-                    );
-                }
+            Self::Dummy => {
+                panic!(
+                    "Called drop_cap() on a null capability table. You need \
+                     to call imbue_mut() on this message before adding capabilities."
+                );
+            }
+            Self::Plain(mut hooks) => {
                 let hooks: &mut alloc::vec::Vec<Option<alloc::boxed::Box<dyn ClientHook>>> =
-                    unsafe { &mut *hooks };
+                    unsafe { hooks.as_mut() };
                 if index < hooks.len() {
                     hooks[index] = None;
                 }

--- a/capnp/src/schema_capnp.rs
+++ b/capnp/src/schema_capnp.rs
@@ -95,7 +95,7 @@ pub mod node {
     impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
             self.reader
-                .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
         }
     }
 
@@ -228,7 +228,7 @@ pub mod node {
     impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
             self.builder
-                .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
         }
     }
 
@@ -892,7 +892,7 @@ pub mod node {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -953,7 +953,7 @@ pub mod node {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -1194,7 +1194,7 @@ pub mod node {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -1259,7 +1259,7 @@ pub mod node {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -1524,7 +1524,7 @@ pub mod node {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -1607,7 +1607,7 @@ pub mod node {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -1949,7 +1949,7 @@ pub mod node {
             impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
                 fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                     self.reader
-                        .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                        .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
                 }
             }
 
@@ -2012,7 +2012,7 @@ pub mod node {
             impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
                 fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                     self.builder
-                        .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                        .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
                 }
             }
 
@@ -2262,7 +2262,7 @@ pub mod node {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -2353,7 +2353,7 @@ pub mod node {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -2763,7 +2763,7 @@ pub mod node {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -2827,7 +2827,7 @@ pub mod node {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -3083,7 +3083,7 @@ pub mod node {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -3161,7 +3161,7 @@ pub mod node {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -3474,7 +3474,7 @@ pub mod node {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -3546,7 +3546,7 @@ pub mod node {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -3842,7 +3842,7 @@ pub mod node {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -3951,7 +3951,7 @@ pub mod node {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -4507,7 +4507,7 @@ pub mod field {
     impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
             self.reader
-                .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
         }
     }
 
@@ -4602,7 +4602,7 @@ pub mod field {
     impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
             self.builder
-                .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
         }
     }
 
@@ -5023,7 +5023,7 @@ pub mod field {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -5105,7 +5105,7 @@ pub mod field {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -5454,7 +5454,7 @@ pub mod field {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -5508,7 +5508,7 @@ pub mod field {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -5734,7 +5734,7 @@ pub mod field {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -5792,7 +5792,7 @@ pub mod field {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -6052,7 +6052,7 @@ pub mod enumerant {
     impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
             self.reader
-                .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
         }
     }
 
@@ -6131,7 +6131,7 @@ pub mod enumerant {
     impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
             self.builder
-                .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
         }
     }
 
@@ -6446,7 +6446,7 @@ pub mod superclass {
     impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
             self.reader
-                .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
         }
     }
 
@@ -6511,7 +6511,7 @@ pub mod superclass {
     impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
             self.builder
-                .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
         }
     }
 
@@ -6781,7 +6781,7 @@ pub mod method {
     impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
             self.reader
-                .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
         }
     }
 
@@ -6905,7 +6905,7 @@ pub mod method {
     impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
             self.builder
-                .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
         }
     }
 
@@ -7424,7 +7424,7 @@ pub mod type_ {
     impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
             self.reader
-                .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
         }
     }
 
@@ -7499,7 +7499,7 @@ pub mod type_ {
     impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
             self.builder
-                .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
         }
     }
 
@@ -8123,7 +8123,7 @@ pub mod type_ {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -8184,7 +8184,7 @@ pub mod type_ {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -8435,7 +8435,7 @@ pub mod type_ {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -8500,7 +8500,7 @@ pub mod type_ {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -8772,7 +8772,7 @@ pub mod type_ {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -8837,7 +8837,7 @@ pub mod type_ {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -9110,7 +9110,7 @@ pub mod type_ {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -9175,7 +9175,7 @@ pub mod type_ {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -9450,7 +9450,7 @@ pub mod type_ {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -9509,7 +9509,7 @@ pub mod type_ {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -9795,7 +9795,7 @@ pub mod type_ {
             impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
                 fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                     self.reader
-                        .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                        .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
                 }
             }
 
@@ -9857,7 +9857,7 @@ pub mod type_ {
             impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
                 fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                     self.builder
-                        .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                        .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
                 }
             }
 
@@ -10165,7 +10165,7 @@ pub mod type_ {
             impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
                 fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                     self.reader
-                        .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                        .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
                 }
             }
 
@@ -10225,7 +10225,7 @@ pub mod type_ {
             impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
                 fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                     self.builder
-                        .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                        .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
                 }
             }
 
@@ -10482,7 +10482,7 @@ pub mod type_ {
             impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
                 fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                     self.reader
-                        .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                        .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
                 }
             }
 
@@ -10538,7 +10538,7 @@ pub mod type_ {
             impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
                 fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                     self.builder
-                        .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                        .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
                 }
             }
 
@@ -10771,7 +10771,7 @@ pub mod brand {
     impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
             self.reader
-                .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
         }
     }
 
@@ -10835,7 +10835,7 @@ pub mod brand {
     impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
             self.builder
-                .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
         }
     }
 
@@ -11091,7 +11091,7 @@ pub mod brand {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -11165,7 +11165,7 @@ pub mod brand {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -11490,7 +11490,7 @@ pub mod brand {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -11560,7 +11560,7 @@ pub mod brand {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -11849,7 +11849,7 @@ pub mod value {
     impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
             self.reader
-                .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
         }
     }
 
@@ -11975,7 +11975,7 @@ pub mod value {
     impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
             self.builder
-                .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
         }
     }
 
@@ -12707,7 +12707,7 @@ pub mod annotation {
     impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
             self.reader
-                .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
         }
     }
 
@@ -12783,7 +12783,7 @@ pub mod annotation {
     impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
             self.builder
-                .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
         }
     }
 
@@ -13230,7 +13230,7 @@ pub mod capnp_version {
     impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
             self.reader
-                .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
         }
     }
 
@@ -13292,7 +13292,7 @@ pub mod capnp_version {
     impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
             self.builder
-                .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
         }
     }
 
@@ -13562,7 +13562,7 @@ pub mod code_generator_request {
     impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
         fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
             self.reader
-                .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
         }
     }
 
@@ -13672,7 +13672,7 @@ pub mod code_generator_request {
     impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
         fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
             self.builder
-                .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
         }
     }
 
@@ -14093,7 +14093,7 @@ pub mod code_generator_request {
         impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
             fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                 self.reader
-                    .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
             }
         }
 
@@ -14176,7 +14176,7 @@ pub mod code_generator_request {
         impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
             fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                 self.builder
-                    .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                    .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
             }
         }
 
@@ -14520,7 +14520,7 @@ pub mod code_generator_request {
             impl<'a> crate::traits::Imbue<'a> for Reader<'a> {
                 fn imbue(&mut self, cap_table: &'a crate::private::layout::CapTable) {
                     self.reader
-                        .imbue(crate::private::layout::CapTableReader::Plain(cap_table))
+                        .imbue(crate::private::layout::CapTableReader::from_ref(cap_table))
                 }
             }
 
@@ -14587,7 +14587,7 @@ pub mod code_generator_request {
             impl<'a> crate::traits::ImbueMut<'a> for Builder<'a> {
                 fn imbue_mut(&mut self, cap_table: &'a mut crate::private::layout::CapTable) {
                     self.builder
-                        .imbue(crate::private::layout::CapTableBuilder::Plain(cap_table))
+                        .imbue(crate::private::layout::CapTableBuilder::from_ref(cap_table))
                 }
             }
 

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -2294,7 +2294,7 @@ fn generate_node(
                     params.params, params.where_clause)),
                 indent(vec![
                     Line(fmt!(ctx,"fn imbue(&mut self, cap_table: &'a {capnp}::private::layout::CapTable) {{")),
-                    indent(Line(fmt!(ctx,"self.reader.imbue({capnp}::private::layout::CapTableReader::Plain(cap_table))"))),
+                    indent(Line(fmt!(ctx,"self.reader.imbue({capnp}::private::layout::CapTableReader::from_ref(cap_table))"))),
                     line("}")
                 ]),
                 line("}"),
@@ -2360,7 +2360,7 @@ fn generate_node(
                              params.params, params.where_clause)),
                 indent(vec![
                         Line(fmt!(ctx,"fn imbue_mut(&mut self, cap_table: &'a mut {capnp}::private::layout::CapTable) {{")),
-                        indent(Line(fmt!(ctx,"self.builder.imbue({capnp}::private::layout::CapTableBuilder::Plain(cap_table))"))),
+                        indent(Line(fmt!(ctx,"self.builder.imbue({capnp}::private::layout::CapTableBuilder::from_ref(cap_table))"))),
                         line("}")]),
                 line("}"),
                 BlankLine,


### PR DESCRIPTION
I saw this comment:
```
    // At one point, we had a `Dummy` variant here, but that ended up
    // making values of this type take 16 bytes of memory. Now we instead
    // represent a null CapTableReader with `Plain(ptr::null())`.
```
and realized that the `Dummy` variant works as intended if we use `NonNull` in the `Plain` variant.