### PR TITLE
cleanups enabled by schema Eq/Hash support

### DIFF
--- a/capnp/CHANGELOG.md
+++ b/capnp/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.27.0
+- Add `PartialEq`, `Eq`, and `Hash` impls for `EnumSchema` and `Enumerant`, and
+  derive them for `TypeVariant`, matching the new impls on `StructSchema` and `Field`.
+- Add `Debug` impls for `StructSchema`, `Field`, `EnumSchema`, and `Enumerant`.
+- Make the dynamic API's field-membership assertions use full branded schema
+  equality. A `Field` from a differently-branded instantiation of the same
+  generic struct is now rejected instead of silently accepted.
+
 ## v0.26.2
 - Avoid possible panic in `BufferSegments::new()`.
 - Avoid possible desyncing in `read_message_no_alloc()`.

--- a/capnp/src/dynamic_list.rs
+++ b/capnp/src/dynamic_list.rs
@@ -326,7 +326,7 @@ impl<'a> Builder<'a> {
                 Ok(())
             }
             (TypeVariant::Struct(ss), dynamic_value::Reader::Struct(s)) => {
-                assert!(core::ptr::eq(ss.generic, s.get_schema().raw.generic));
+                assert_eq!(ss, s.get_schema().raw);
                 self.builder
                     .reborrow()
                     .get_struct_element(index)

--- a/capnp/src/dynamic_struct.rs
+++ b/capnp/src/dynamic_struct.rs
@@ -49,10 +49,7 @@ impl<'a> Reader<'a> {
     }
 
     pub fn get(self, field: Field) -> Result<dynamic_value::Reader<'a>> {
-        assert!(core::ptr::eq(
-            self.schema.raw.generic,
-            field.parent.raw.generic
-        ));
+        assert_eq!(self.schema, field.parent);
         let ty = field.get_type();
         match field.get_proto().which()? {
             field::Slot(slot) => {
@@ -201,10 +198,7 @@ impl<'a> Reader<'a> {
     /// is active in the union and is not a null pointer. On non-union fields,
     /// returns `true` if the field is not a null pointer.
     pub fn has(&self, field: Field) -> Result<bool> {
-        assert!(core::ptr::eq(
-            self.schema.raw.generic,
-            field.parent.raw.generic
-        ));
+        assert_eq!(self.schema, field.parent);
         let proto = field.get_proto();
         if has_discriminant_value(proto) {
             let node::Struct(st) = self.schema.get_proto().which()? else {
@@ -293,10 +287,7 @@ impl<'a> Builder<'a> {
     }
 
     pub fn get(self, field: Field) -> Result<dynamic_value::Builder<'a>> {
-        assert!(core::ptr::eq(
-            self.schema.raw.generic,
-            field.parent.raw.generic
-        ));
+        assert_eq!(self.schema, field.parent);
         let ty = field.get_type();
         match field.get_proto().which()? {
             field::Slot(slot) => {
@@ -453,10 +444,7 @@ impl<'a> Builder<'a> {
     }
 
     pub fn set(&mut self, field: Field, value: dynamic_value::Reader<'_>) -> Result<()> {
-        assert!(core::ptr::eq(
-            self.schema.raw.generic,
-            field.parent.raw.generic
-        ));
+        assert_eq!(self.schema, field.parent);
         self.set_in_union(field)?;
         let ty = field.get_type();
         match field.get_proto().which()? {
@@ -596,10 +584,7 @@ impl<'a> Builder<'a> {
     }
 
     pub fn init(mut self, field: Field) -> Result<dynamic_value::Builder<'a>> {
-        assert!(core::ptr::eq(
-            self.schema.raw.generic,
-            field.parent.raw.generic
-        ));
+        assert_eq!(self.schema, field.parent);
         self.set_in_union(field)?;
         let ty = field.get_type();
         match field.get_proto().which()? {
@@ -640,10 +625,7 @@ impl<'a> Builder<'a> {
     }
 
     pub fn initn(mut self, field: Field, size: u32) -> Result<dynamic_value::Builder<'a>> {
-        assert!(core::ptr::eq(
-            self.schema.raw.generic,
-            field.parent.raw.generic
-        ));
+        assert_eq!(self.schema, field.parent);
         self.set_in_union(field)?;
         let ty = field.get_type();
         match field.get_proto().which()? {
@@ -696,10 +678,7 @@ impl<'a> Builder<'a> {
     /// Clears a field, setting it to its default value. For pointer fields,
     /// this makes the field null.
     pub fn clear(&mut self, field: Field) -> Result<()> {
-        assert!(core::ptr::eq(
-            self.schema.raw.generic,
-            field.parent.raw.generic
-        ));
+        assert_eq!(self.schema, field.parent);
         self.set_in_union(field)?;
         let ty = field.get_type();
         match field.get_proto().which()? {

--- a/capnp/src/introspect.rs
+++ b/capnp/src/introspect.rs
@@ -148,7 +148,7 @@ impl Type {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 /// A `Type` unfolded one level. Suitable for pattern matching. Can be trivially
 /// converted to `Type` via the `From`/`Into` traits.
 pub enum TypeVariant {

--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -138,6 +138,17 @@ impl ::core::hash::Hash for StructSchema {
     }
 }
 
+impl ::core::fmt::Debug for StructSchema {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        // Two schemas with the same display name are unequal if their brandings
+        // differ, so also include the type id.
+        match self.proto.get_display_name().map(|n| n.to_str()) {
+            Ok(Ok(name)) => write!(f, "StructSchema({name}, {:?})", self.raw.type_id),
+            _ => write!(f, "StructSchema({:?})", self.raw),
+        }
+    }
+}
+
 /// A field of a struct, with generics applied.
 #[derive(Clone, Copy)]
 pub struct Field {
@@ -179,6 +190,15 @@ impl ::core::hash::Hash for Field {
     fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
         self.parent.hash(state);
         self.index.hash(state);
+    }
+}
+
+impl ::core::fmt::Debug for Field {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        match self.proto.get_name().map(|n| n.to_str()) {
+            Ok(Ok(name)) => write!(f, "Field({name}, {:?})", self.parent),
+            _ => write!(f, "Field(index {}, {:?})", self.index, self.parent),
+        }
     }
 }
 
@@ -321,6 +341,29 @@ impl From<RawEnumSchema> for EnumSchema {
     }
 }
 
+impl ::core::cmp::PartialEq for EnumSchema {
+    fn eq(&self, other: &Self) -> bool {
+        self.raw == other.raw
+    }
+}
+
+impl ::core::cmp::Eq for EnumSchema {}
+
+impl ::core::hash::Hash for EnumSchema {
+    fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
+        self.raw.hash(state);
+    }
+}
+
+impl ::core::fmt::Debug for EnumSchema {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        match self.proto.get_display_name().map(|n| n.to_str()) {
+            Ok(Ok(name)) => write!(f, "EnumSchema({name})"),
+            _ => write!(f, "EnumSchema({:?})", self.raw),
+        }
+    }
+}
+
 /// An enumerant, with generics applied. (Generics may affect types of annotations.)
 #[derive(Clone, Copy)]
 pub struct Enumerant {
@@ -348,6 +391,28 @@ impl Enumerant {
             child_index: Some(self.ordinal),
             get_annotation_type: self.parent.raw.annotation_types,
         })
+    }
+}
+
+impl ::core::cmp::PartialEq for Enumerant {
+    fn eq(&self, other: &Self) -> bool {
+        self.parent == other.parent && self.ordinal == other.ordinal
+    }
+}
+impl ::core::cmp::Eq for Enumerant {}
+impl ::core::hash::Hash for Enumerant {
+    fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
+        self.parent.hash(state);
+        self.ordinal.hash(state);
+    }
+}
+
+impl ::core::fmt::Debug for Enumerant {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        match self.proto.get_name().map(|n| n.to_str()) {
+            Ok(Ok(name)) => write!(f, "Enumerant({name}, {:?})", self.parent),
+            _ => write!(f, "Enumerant(ordinal {}, {:?})", self.ordinal, self.parent),
+        }
     }
 }
 
@@ -515,12 +580,15 @@ mod tests {
         let display_name = struct_schema.get_field_by_name("displayName").unwrap();
         let id = struct_schema.get_field_by_name("id").unwrap();
 
-        assert!(display_name == display_name);
-        assert!(display_name == struct_schema.get_field_by_name("displayName").unwrap());
-        assert!(id == id);
-        assert!(id == struct_schema.get_field_by_name("id").unwrap());
+        assert_eq!(display_name, display_name);
+        assert_eq!(
+            display_name,
+            struct_schema.get_field_by_name("displayName").unwrap()
+        );
+        assert_eq!(id, id);
+        assert_eq!(id, struct_schema.get_field_by_name("id").unwrap());
 
-        assert!(display_name != id);
+        assert_ne!(display_name, id);
     }
 
     #[cfg(feature = "std")]
@@ -572,8 +640,59 @@ mod tests {
             crate::schema::StructSchema::new(schema)
         };
 
-        assert!(node_schema == node_schema);
-        assert!(cgr_schema == cgr_schema);
-        assert!(node_schema != cgr_schema);
+        assert_eq!(node_schema, node_schema);
+        assert_eq!(cgr_schema, cgr_schema);
+        assert_ne!(node_schema, cgr_schema);
+    }
+
+    #[test]
+    fn enum_schemas_can_be_compared() {
+        let crate::introspect::TypeVariant::Enum(raw) =
+            crate::schema_capnp::ElementSize::introspect().which()
+        else {
+            panic!("Expected an enum schema");
+        };
+        let schema = crate::schema::EnumSchema::new(raw);
+
+        assert_eq!(schema, crate::schema::EnumSchema::new(raw));
+
+        let enumerants = schema.get_enumerants().unwrap();
+        assert_eq!(enumerants.get(0), enumerants.get(0));
+        assert_ne!(enumerants.get(0), enumerants.get(1));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn enumerants_can_be_hashed() {
+        let crate::introspect::TypeVariant::Enum(raw) =
+            crate::schema_capnp::ElementSize::introspect().which()
+        else {
+            panic!("Expected an enum schema");
+        };
+        let schema = crate::schema::EnumSchema::new(raw);
+        let enumerants = schema.get_enumerants().unwrap();
+
+        let mut map = std::collections::HashMap::new();
+        map.insert(enumerants.get(0), 0);
+        map.insert(enumerants.get(1), 1);
+
+        assert_eq!(map.get(&enumerants.get(0)), Some(&0));
+        assert_eq!(map.get(&enumerants.get(1)), Some(&1));
+    }
+
+    #[test]
+    fn type_variants_can_be_compared() {
+        use crate::introspect::TypeVariant;
+
+        assert_eq!(u32::introspect().which(), TypeVariant::UInt32);
+        assert_ne!(u32::introspect().which(), TypeVariant::Int32);
+        assert_eq!(
+            crate::schema_capnp::node::Owned::introspect().which(),
+            crate::schema_capnp::node::Owned::introspect().which()
+        );
+        assert_ne!(
+            crate::schema_capnp::node::Owned::introspect().which(),
+            crate::schema_capnp::code_generator_request::Owned::introspect().which()
+        );
     }
 }

--- a/capnpc/test/dynamic.rs
+++ b/capnpc/test/dynamic.rs
@@ -526,5 +526,60 @@ fn introspect_equals() {
         test_all_types::Owned::introspect()
     );
 
-    assert!(test_all_types::Owned::introspect() != test_defaults::Owned::introspect())
+    assert_ne!(
+        test_all_types::Owned::introspect(),
+        test_defaults::Owned::introspect()
+    )
+}
+
+#[test]
+#[should_panic(expected = "left == right")]
+fn field_from_wrong_schema_panics() {
+    use capnp::introspect::{Introspect, TypeVariant};
+
+    let mut builder = message::Builder::new_default();
+    builder.init_root::<test_all_types::Builder<'_>>();
+    let reader = builder
+        .get_root_as_reader::<test_all_types::Reader<'_>>()
+        .unwrap();
+    let dynamic: dynamic_value::Reader<'_> = reader.into();
+    let dynamic: dynamic_struct::Reader<'_> = dynamic.downcast();
+
+    // `test_defaults` has a field of the same name at the same index, but it
+    // belongs to a different schema.
+    let TypeVariant::Struct(raw) = test_defaults::Owned::introspect().which() else {
+        panic!("Expected a struct schema");
+    };
+    let wrong_schema = capnp::schema::StructSchema::new(raw);
+    let field = wrong_schema.get_field_by_name("boolField").unwrap();
+
+    let _ = dynamic.get(field);
+}
+
+#[test]
+#[should_panic(expected = "left == right")]
+fn field_from_differently_branded_schema_panics() {
+    use crate::test_capnp::test_generics;
+    use capnp::introspect::{Introspect, TypeVariant};
+    use capnp::{data, text};
+
+    let mut builder = message::Builder::new_default();
+    builder.init_root::<test_generics::Builder<'_, text::Owned, data::Owned>>();
+    let reader = builder
+        .get_root_as_reader::<test_generics::Reader<'_, text::Owned, data::Owned>>()
+        .unwrap();
+    let dynamic: dynamic_value::Reader<'_> = reader.into();
+    let dynamic: dynamic_struct::Reader<'_> = dynamic.downcast();
+
+    // Same generic struct, but with different type parameters. A field from
+    // this schema would report the wrong types for our reader.
+    let TypeVariant::Struct(raw) =
+        test_generics::Owned::<data::Owned, text::Owned>::introspect().which()
+    else {
+        panic!("Expected a struct schema");
+    };
+    let differently_branded = capnp::schema::StructSchema::new(raw);
+    let field = differently_branded.get_field_by_name("foo").unwrap();
+
+    let _ = dynamic.get(field);
 }

--- a/capnpc/test/test.rs
+++ b/capnpc/test/test.rs
@@ -2362,12 +2362,12 @@ mod tests {
             capnp::schema::StructSchema::new(schema)
         };
 
-        assert!(schema_t_t != schema_d_d);
+        assert_ne!(schema_t_t, schema_d_d);
 
         let foo_t_t = schema_t_t.get_field_by_name("foo")?;
         let foo_d_d = schema_d_d.get_field_by_name("foo")?;
 
-        assert!(foo_t_t != foo_d_d);
+        assert_ne!(foo_t_t, foo_d_d);
 
         Ok(())
     }


### PR DESCRIPTION
- Replace the ptr::eq(generic, generic) field-membership assertions in dynamic_struct and dynamic_list with the new TypeId-based equality.
- Derive Debug, PartialEq, Eq, Hash for TypeVariant, now that all of its payload types support them.
- Add PartialEq, Eq, Hash for EnumSchema and Enumerant, mirroring StructSchema and Field.
- Add Debug impls for StructSchema, Field, EnumSchema, and Enumerant, so the above assertions can use assert_eq! and produce useful messages.
- Convert assert!(a == b) to assert_eq! in tests where missing Debug impls previously prevented it.